### PR TITLE
Add Zig binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ not depend on libzmq, libsodium, or a C compiler.
   - [Python](bindings/pyomq/)
   - [Ruby](bindings/ruby/) and pure Ruby [OMQ.rb](https://github.com/zeromq/omq.rb)
   - [TypeScript](https://github.com/paddor/omq.ts) for browsers (ZWS transport only)
+  - [Zig](bindings/zig/)
 
 ## Performance
 
@@ -157,6 +158,7 @@ Five Cargo workspace crates plus language bindings.
 | [`OMQ.node`](bindings/node/) | Node.js 24.11 binding (NAPI over omq-tokio, native addon) | NAPI/native addon boundary |
 | [`OMQ.lua`](bindings/lua/) | Lua 5.4 binding (mlua native module over omq-libzmq) | mlua/native ABI boundary |
 | [`OMQ.beam`](bindings/beam/) | Erlang binding plus Elixir and Gleam wrappers (Rustler NIF over omq-tokio) | BEAM NIF boundary |
+| [`OMQ.zig`](bindings/zig/) | Zig 0.16 binding (thin wrapper over omq-libzmq) | C ABI boundary |
 
 ## Testing
 

--- a/bindings/zig/.gitignore
+++ b/bindings/zig/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/bindings/zig/DEVELOPMENT.md
+++ b/bindings/zig/DEVELOPMENT.md
@@ -1,0 +1,129 @@
+# OMQ.zig Development
+
+Run commands from repository root unless shown otherwise.
+
+## Prerequisites
+
+- Zig 0.16.
+- Rust toolchain with Cargo.
+- `python3` for benchmark chart generation.
+- `git` and network access when running comparison benchmarks.
+
+## Normal Test Pass
+
+Build native C ABI first:
+
+```sh
+cargo build --release -p omq-libzmq
+```
+
+Run Zig tests:
+
+```sh
+(cd bindings/zig && zig build test)
+```
+
+Run one filtered test group:
+
+```sh
+(cd bindings/zig && zig build test -Dtest-filter=pub)
+```
+
+Override native paths when building outside this repository layout:
+
+```sh
+zig build test \
+  -Domq-include-dir=/path/to/include \
+  -Domq-lib-dir=/path/to/lib
+```
+
+## API Docs
+
+Generate Zig API docs:
+
+```sh
+(cd bindings/zig && zig build docs)
+```
+
+Output:
+
+```text
+bindings/zig/zig-out/docs/
+```
+
+## Benchmarks
+
+Run perf work on an otherwise quiet machine. Do not run benchmark or profiler
+jobs in parallel.
+
+The benchmark script is adapted from `bindings/pyomq/scripts/update_perf.py`.
+It uses the same append-only JSONL model and SVG chart generator shape.
+
+Implementations:
+
+- `omq.zig`: this binding, backed by `omq-libzmq`.
+- `zzmq`: `https://github.com/nine-lives-later/zzmq`.
+- `zimq`: `https://github.com/uyha/zimq`, pinned to tag `zig-0.16`.
+
+Rows append to:
+
+```text
+~/.cache/omq.zig/bindings.jsonl
+```
+
+Quick local run:
+
+```sh
+bindings/zig/scripts/update_perf.py --quick
+```
+
+Full default run:
+
+```sh
+bindings/zig/scripts/update_perf.py
+```
+
+Defaults are 3 measured rounds per implementation and size. Throughput uses
+2.5 second windows. Latency uses 1.5 second windows and only measures sizes up
+to 4 KiB. Each round uses a 0.5 second warmup window. The median round is kept.
+`--quick` uses one 0.5 second measured round and 0.1 second warmup.
+
+Useful flags:
+
+- `--impl omq.zig`
+- `--impl zzmq`
+- `--impl zimq`
+- `--sizes 16,128,1k,8k,32k`
+- `--rounds N`
+- `--target-runtime SECONDS`
+- `--warmup-duration SECONDS`
+- `--latency-duration SECONDS`
+- `--latency-warmup-duration SECONDS`
+- `--chart-only`
+- `--no-save`
+- `--no-chart`
+- `--no-build`
+
+Chart output:
+
+```text
+bindings/zig/doc/charts/bindings.svg
+```
+
+Regenerate only the SVG from cached rows:
+
+```sh
+bindings/zig/scripts/update_perf.py --chart-only
+```
+
+Hardware subtitle comes from repository-root `.chart_hw`:
+
+```text
+prefix=Ryzen 9 9950X
+postfix=16 cores, turbo off, performance governor
+```
+
+`.chart_hw` is local-only and gitignored.
+
+The machine is noisy. Treat current rows as provisional and rerun on an idle
+system before publishing performance claims.

--- a/bindings/zig/DEVELOPMENT.md
+++ b/bindings/zig/DEVELOPMENT.md
@@ -29,6 +29,16 @@ Run one filtered test group:
 (cd bindings/zig && zig build test -Dtest-filter=pub)
 ```
 
+Run soak tests. Default script duration is one hour:
+
+```sh
+bindings/zig/scripts/soak.sh
+bindings/zig/scripts/soak.sh 10m
+```
+
+Soak tests sample RSS and `/proc/self/fd` counts and fail on resource growth.
+They are not part of `zig build test`.
+
 Override native paths when building outside this repository layout:
 
 ```sh

--- a/bindings/zig/DEVELOPMENT.md
+++ b/bindings/zig/DEVELOPMENT.md
@@ -37,7 +37,10 @@ bindings/zig/scripts/soak.sh 10m
 ```
 
 Soak tests sample RSS and `/proc/self/fd` counts and fail on resource growth.
-They are not part of `zig build test`.
+They are not part of `zig build test`. The script runs all soak scenarios in
+parallel by default, like pyomq, and each scenario gets the full requested
+duration. Set `OMQ_ZIG_SOAK_JOBS=1` to run them serially. Set
+`OMQ_ZIG_SOAK_TIMEOUT_EXTRA_SECS` to tune shutdown/build slack.
 
 Override native paths when building outside this repository layout:
 

--- a/bindings/zig/README.md
+++ b/bindings/zig/README.md
@@ -1,0 +1,85 @@
+# OMQ.zig
+
+Zig 0.16 binding for OMQ backed by `omq-libzmq`.
+
+The binding wraps the libzmq-compatible C ABI from `omq-libzmq/include/zmq.h`.
+That ABI is the right base for Zig: `@cImport` can consume it directly, Zig
+callers keep explicit allocator ownership, and the surface stays close to
+pyomq/libzmq names.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/main/bindings/zig/doc/charts/bindings.svg" alt="OMQ.zig binding performance" width="850">
+</p>
+
+## Install
+
+Build `omq-libzmq`, then import the package from `bindings/zig`:
+
+```sh
+cargo build --release -p omq-libzmq
+cd bindings/zig
+zig build test
+```
+
+## API Shape
+
+- `Context.init()` creates a context with one IO thread.
+- `Context.initWithIoThreads(n)` selects IO threads.
+- `Context.socket(omq.PUSH)` creates a socket.
+- `Socket.bind(allocator, endpoint)` binds and returns the resolved endpoint.
+- `Socket.connect(allocator, endpoint)` connects.
+- `Socket.send(data, flags)` sends one frame.
+- `Socket.sendMultipart(parts, flags)` sends all frames atomically.
+- `Socket.sendFrame(allocator, frame, flags)` sends data plus routing id/group
+  metadata.
+- `Socket.recvAlloc(allocator, flags)` receives one frame. Caller frees it.
+- `Socket.recvFrameAlloc(allocator, flags)` receives data plus `more`,
+  `routing_id`, and `group` metadata.
+- `Socket.recvMultipartAlloc(allocator, flags)` receives all frames into a
+  `Message`. Caller calls `Message.deinit()`.
+- `Socket.recvMultipartFramesAlloc(allocator, flags)` receives all frames with
+  metadata into a `FrameMessage`. Caller calls `FrameMessage.deinit()`.
+- `Socket.subscribe(prefix)` and `Socket.unsubscribe(prefix)` manage SUB
+  filters.
+- `Socket.join(allocator, group)` and `Socket.leave(allocator, group)` manage
+  DISH groups.
+- `Socket.sendGroup(allocator, group, data, flags)` sends RADIO messages.
+- `Socket.setInt`, `Socket.getInt`, `Socket.setBytes`, and typed helpers cover
+  pyomq/libzmq options plus OMQ extensions: on-mute policy, compression knobs,
+  arena threshold, PLAIN/CURVE security, identity, timeouts, HWM, and routing.
+- `omq.poll()` wraps `zmq_poll`.
+- `Poller` gives register/modify/unregister and returns active events.
+- `Socket.monitor()` returns a PAIR monitor socket wrapper with parsed events.
+- `Context.shareKey()` and `Context.fromShareKey()` mirror pyomq shadow-context
+  use cases for OMQ shared contexts.
+- `omq.proxy()` and `omq.proxySteerable()` wrap native proxy helpers.
+- `omq.curveKeypair()` and `omq.curvePublic()` expose CURVE key helpers.
+
+Example:
+
+```zig
+const std = @import("std");
+const omq = @import("omq");
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const endpoint = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(endpoint);
+    try push.connect(allocator, endpoint);
+
+    _ = try push.send("hello", 0);
+    const msg = try pull.recvAlloc(allocator, 0);
+    defer allocator.free(msg);
+}
+```
+
+See [`DEVELOPMENT.md`](DEVELOPMENT.md) for test, docs, and benchmark commands.

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -69,6 +69,7 @@ pub fn build(b: *std.Build) void {
             },
             .link_libc = true,
         }),
+        .filters = test_filters,
     });
     const run_soak_tests = b.addRunArtifact(soak_tests);
     if (b.args) |args| {

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -41,6 +41,42 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_tests.step);
 
+    const parity_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/parity.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "omq", .module = omq },
+            },
+            .link_libc = true,
+        }),
+        .filters = test_filters,
+    });
+    const run_parity_tests = b.addRunArtifact(parity_tests);
+    if (b.args) |args| {
+        run_parity_tests.addArgs(args);
+    }
+    test_step.dependOn(&run_parity_tests.step);
+
+    const soak_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/soak.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+            .imports = &.{
+                .{ .name = "omq", .module = omq },
+            },
+            .link_libc = true,
+        }),
+    });
+    const run_soak_tests = b.addRunArtifact(soak_tests);
+    if (b.args) |args| {
+        run_soak_tests.addArgs(args);
+    }
+    const soak_step = b.step("soak", "Run long-running soak tests");
+    soak_step.dependOn(&run_soak_tests.step);
+
     const docs_module = b.createModule(.{
         .root_source_file = b.path("src/omq.zig"),
         .target = target,

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const omq_include_dir =
+        b.option([]const u8, "omq-include-dir", "Path containing zmq.h") orelse
+        "../../omq-libzmq/include";
+    const omq_lib_dir =
+        b.option([]const u8, "omq-lib-dir", "Path containing libomq_zmq") orelse
+        "../../target/release";
+    const test_filter = b.option([]const u8, "test-filter", "Only build matching tests");
+    const test_filters: []const []const u8 = if (test_filter) |filter| &.{filter} else &.{};
+
+    const omq = b.addModule("omq", .{
+        .root_source_file = b.path("src/omq.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    configureOmqModule(b, omq, omq_include_dir, omq_lib_dir);
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/basic.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "omq", .module = omq },
+            },
+            .link_libc = true,
+        }),
+        .filters = test_filters,
+    });
+
+    const run_tests = b.addRunArtifact(tests);
+    if (b.args) |args| {
+        run_tests.addArgs(args);
+    }
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_tests.step);
+
+    const docs_module = b.createModule(.{
+        .root_source_file = b.path("src/omq.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    configureOmqModule(b, docs_module, omq_include_dir, omq_lib_dir);
+
+    const docs_object = b.addObject(.{
+        .name = "omq-docs",
+        .root_module = docs_module,
+    });
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = docs_object.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+    const docs_step = b.step("docs", "Generate API documentation");
+    docs_step.dependOn(&install_docs.step);
+
+    const bench = b.addExecutable(.{
+        .name = "omq-zig-bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("scripts/bench/omq_bench.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "omq", .module = omq },
+            },
+            .link_libc = true,
+        }),
+    });
+    b.installArtifact(bench);
+}
+
+fn configureOmqModule(
+    b: *std.Build,
+    mod: *std.Build.Module,
+    include_dir: []const u8,
+    lib_dir: []const u8,
+) void {
+    const include_path = hostOrBuildPath(b, include_dir);
+    const lib_path = hostOrBuildPath(b, lib_dir);
+    mod.addIncludePath(include_path);
+    mod.addLibraryPath(lib_path);
+    mod.addRPath(lib_path);
+    mod.linkSystemLibrary("omq_zmq", .{
+        .use_pkg_config = .no,
+        .search_strategy = .paths_first,
+    });
+}
+
+fn hostOrBuildPath(b: *std.Build, path: []const u8) std.Build.LazyPath {
+    if (std.fs.path.isAbsolute(path)) {
+        return .{ .cwd_relative = path };
+    }
+    return b.path(path);
+}

--- a/bindings/zig/build.zig.zon
+++ b/bindings/zig/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .omq,
+    .version = "0.1.0",
+    .fingerprint = 0x4b9b014f2d9af2a2, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "tests",
+        "scripts",
+        "README.md",
+        "DEVELOPMENT.md",
+        "doc",
+    },
+}

--- a/bindings/zig/doc/architecture.md
+++ b/bindings/zig/doc/architecture.md
@@ -1,0 +1,33 @@
+# OMQ.zig Architecture
+
+OMQ.zig is a Zig 0.16 package over the `omq-libzmq` C ABI. It imports
+`omq-libzmq/include/zmq.h` with `@cImport` and links `libomq_zmq`.
+
+The binding has no native shim. Public Zig types are thin owners around C
+handles:
+
+- `Context` owns `zmq_ctx_t`.
+- `Socket` owns `zmq_socket`.
+- `Frame`, `Message`, and `FrameMessage` own received or copied frame data.
+- `Poller` stores Zig-side registrations and calls `zmq_poll`.
+- `Monitor` is a PAIR socket wrapper around `zmq_socket_monitor`.
+
+All transport, reconnect, routing, ZMTP, compression, security, and queue
+behavior lives below the ABI in `omq-libzmq`, `omq-tokio`, and `omq-proto`.
+Zig callers only enqueue sends, receive complete messages, set options, and
+manage explicit ownership.
+
+Returned byte slices are allocator-owned. `recvAlloc`, `recvFrameAlloc`,
+`recvMultipartAlloc`, `getBytesAlloc`, and `getStringAlloc` allocate with the
+caller-provided allocator. Matching `deinit` methods release aggregate types.
+
+String inputs that cross the ABI are duplicated as sentinel-terminated temporary
+buffers. Raw byte options and message payloads pass pointer plus length.
+
+Errors are mapped from thread-local `zmq_errno()` into a Zig error set. Unknown
+errno values collapse to `error.Unknown`; `lastErrno()` remains available for
+direct ABI diagnostics.
+
+Context sharing uses OMQ extension keys. `Context.shareKey()` exports the
+process-local context key and `Context.fromShareKey()` imports another handle
+to the same native context, preserving shared `inproc://` namespaces.

--- a/bindings/zig/doc/charts/bindings.svg
+++ b/bindings/zig/doc/charts/bindings.svg
@@ -2,16 +2,18 @@
   <rect width="850" height="824" fill="#000000"/>
   <text x="425.0" y="44" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
   <text x="425.0" y="58" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
-  <line x1="60" y1="377.0" x2="395" y2="377.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="377.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
-  <line x1="60" y1="310.0" x2="395" y2="310.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="310.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">8M</text>
-  <line x1="60" y1="243.0" x2="395" y2="243.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="243.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">12M</text>
-  <line x1="60" y1="176.0" x2="395" y2="176.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">16M</text>
+  <line x1="60" y1="388.2" x2="395" y2="388.2" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="388.2" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2M</text>
+  <line x1="60" y1="332.3" x2="395" y2="332.3" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="332.3" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <line x1="60" y1="276.5" x2="395" y2="276.5" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="276.5" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">6M</text>
+  <line x1="60" y1="220.7" x2="395" y2="220.7" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="220.7" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">8M</text>
+  <line x1="60" y1="164.8" x2="395" y2="164.8" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="164.8" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">10M</text>
   <line x1="60" y1="109.0" x2="395" y2="109.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="109.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20M</text>
+  <text x="52" y="109.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">12M</text>
   <line x1="60.0" y1="109" x2="60.0" y2="444" stroke="#374151" stroke-width="1"/>
   <line x1="115.8" y1="109" x2="115.8" y2="444" stroke="#374151" stroke-width="1"/>
   <line x1="171.7" y1="109" x2="171.7" y2="444" stroke="#374151" stroke-width="1"/>
@@ -49,9 +51,9 @@
   <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
   <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
-  <polyline points="60.0,294.0 115.8,273.3 171.7,366.1 227.5,416.8 283.3,418.5 339.2,414.4 395.0,421.0" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,344.7 115.8,338.8 171.7,373.7 227.5,408.8 283.3,412.0 339.2,420.5 395.0,429.7" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,344.1 115.8,343.1 171.7,376.8 227.5,410.4 283.3,412.9 339.2,420.3 395.0,429.9" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,193.9 115.8,159.6 171.7,314.1 227.5,398.6 283.3,401.5 339.2,394.7 395.0,405.6" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,278.6 115.8,268.7 171.7,326.9 227.5,385.3 283.3,390.7 339.2,404.8 395.0,420.1" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,277.6 115.8,275.8 171.7,332.0 227.5,388.0 283.3,392.2 339.2,404.5 395.0,420.6" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="455.0,411.3 502.9,368.3 550.7,326.1 598.6,263.6 646.4,214.2 694.3,167.5 742.1,160.1 790.0,141.8" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="455.0" cy="411.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
   <circle cx="502.9" cy="368.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
@@ -95,27 +97,19 @@
   <text x="742.1" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
   <text x="790.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
   <text x="425.0" y="476" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate - solid = bandwidth</text>
-  <text x="425.0" y="532" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: TCP loopback, p50 us (lower is better)</text>
-  <line x1="60" y1="729.0" x2="790" y2="729.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="729.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 us</text>
-  <line x1="60" y1="709.0" x2="790" y2="709.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="709.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 us</text>
-  <line x1="60" y1="689.0" x2="790" y2="689.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="689.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 us</text>
-  <line x1="60" y1="669.0" x2="790" y2="669.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="669.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 us</text>
+  <text x="425.0" y="532" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: TCP loopback, p50 μs (lower is better)</text>
+  <line x1="60" y1="715.7" x2="790" y2="715.7" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="715.7" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 μs</text>
+  <line x1="60" y1="682.3" x2="790" y2="682.3" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="682.3" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 μs</text>
   <line x1="60" y1="649.0" x2="790" y2="649.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="649.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 us</text>
-  <line x1="60" y1="629.0" x2="790" y2="629.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="629.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 us</text>
-  <line x1="60" y1="609.0" x2="790" y2="609.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="609.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 us</text>
-  <line x1="60" y1="589.0" x2="790" y2="589.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="589.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 us</text>
-  <line x1="60" y1="569.0" x2="790" y2="569.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="569.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 us</text>
+  <text x="52" y="649.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 μs</text>
+  <line x1="60" y1="615.7" x2="790" y2="615.7" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="615.7" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 μs</text>
+  <line x1="60" y1="582.3" x2="790" y2="582.3" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="582.3" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 μs</text>
   <line x1="60" y1="549.0" x2="790" y2="549.0" stroke="#374151" stroke-width="1"/>
-  <text x="52" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 us</text>
+  <text x="52" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 μs</text>
   <line x1="60.0" y1="549" x2="60.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="151.2" y1="549" x2="151.2" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="242.5" y1="549" x2="242.5" y2="749" stroke="#374151" stroke-width="1"/>
@@ -127,36 +121,36 @@
   <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="60.0,669.9 151.2,672.2 242.5,668.8 333.8,669.5 425.0,668.7 516.2,669.9 607.5,669.8 698.8,664.5 790.0,658.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="669.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="672.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="668.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="669.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="668.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="669.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="669.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="664.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="658.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,645.4 151.2,647.2 242.5,643.4 333.8,643.8 425.0,642.6 516.2,642.7 607.5,642.4 698.8,640.5 790.0,640.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="645.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="647.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="643.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="643.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="642.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="642.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="642.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="640.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="640.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,661.2 151.2,663.1 242.5,661.3 333.8,661.3 425.0,660.8 516.2,660.3 607.5,660.5 698.8,659.2 790.0,656.4" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="661.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="663.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="661.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="661.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="660.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="660.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="660.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="659.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="656.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,617.1 151.2,621.0 242.5,615.3 333.8,616.5 425.0,615.1 516.2,617.2 607.5,617.0 698.8,608.2 790.0,597.3" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="617.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="621.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="615.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="616.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="615.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="617.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="617.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="608.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="597.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,576.3 151.2,579.4 242.5,573.0 333.8,573.7 425.0,571.6 516.2,571.8 607.5,571.3 698.8,568.1 790.0,567.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="576.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="579.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="573.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="573.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="571.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="571.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="571.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="568.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="567.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,602.7 151.2,605.8 242.5,602.9 333.8,602.8 425.0,601.9 516.2,601.2 607.5,601.5 698.8,599.3 790.0,594.6" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="602.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="605.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="602.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="602.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="601.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="601.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="601.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="599.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="594.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/zig/doc/charts/bindings.svg
+++ b/bindings/zig/doc/charts/bindings.svg
@@ -49,36 +49,36 @@
   <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
   <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
-  <polyline points="60.0,275.8 115.8,276.1 171.7,366.3 227.5,416.4 283.3,418.9 339.2,415.6 395.0,420.8" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,339.8 115.8,338.1 171.7,372.2 227.5,409.3 283.3,412.4 339.2,420.4 395.0,429.7" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,344.4 115.8,342.2 171.7,376.0 227.5,410.2 283.3,412.9 339.2,420.7 395.0,429.9" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="455.0,411.9 502.9,371.3 550.7,325.3 598.6,277.1 646.4,233.5 694.3,162.1 742.1,158.7 790.0,133.1" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="411.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="371.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="325.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="277.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="233.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="162.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="158.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="133.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="455.0,403.6 502.9,383.5 550.7,370.5 598.6,358.2 646.4,353.6 694.3,347.6 742.1,349.0 790.0,284.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="403.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="383.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="370.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="358.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="353.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="347.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="349.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="284.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="455.0,404.3 502.9,384.2 550.7,371.9 598.6,362.0 646.4,352.3 694.3,347.1 742.1,344.1 790.0,279.5" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="404.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="384.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="371.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="362.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="352.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="347.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="344.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="279.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,294.0 115.8,273.3 171.7,366.1 227.5,416.8 283.3,418.5 339.2,414.4 395.0,421.0" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,344.7 115.8,338.8 171.7,373.7 227.5,408.8 283.3,412.0 339.2,420.5 395.0,429.7" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,344.1 115.8,343.1 171.7,376.8 227.5,410.4 283.3,412.9 339.2,420.3 395.0,429.9" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="455.0,411.3 502.9,368.3 550.7,326.1 598.6,263.6 646.4,214.2 694.3,167.5 742.1,160.1 790.0,141.8" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="411.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="368.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="326.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="263.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="214.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="167.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="160.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="141.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,403.1 502.9,383.8 550.7,370.6 598.6,358.6 646.4,352.7 694.3,346.9 742.1,349.1 790.0,282.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="403.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="383.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="370.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="358.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="352.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="346.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="349.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="282.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,404.2 502.9,383.4 550.7,372.0 598.6,358.7 646.4,353.2 694.3,334.4 742.1,345.0 790.0,279.1" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="404.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="383.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="372.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="358.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="353.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="334.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="345.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="279.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="115.8" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="171.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
@@ -127,36 +127,36 @@
   <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="60.0,653.0 151.2,654.5 242.5,653.4 333.8,658.3 425.0,657.6 516.2,656.5 607.5,652.1 698.8,654.3 790.0,644.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="653.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="654.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="653.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="658.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="657.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="656.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="652.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="654.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="644.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,627.8 151.2,629.2 242.5,626.9 333.8,629.5 425.0,626.7 516.2,631.2 607.5,628.5 698.8,625.2 790.0,623.9" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="627.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="629.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="626.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="629.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="626.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="631.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="628.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="625.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="623.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,651.4 151.2,652.4 242.5,650.5 333.8,652.0 425.0,649.3 516.2,652.4 607.5,650.0 698.8,650.1 790.0,648.0" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="651.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="652.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="650.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="652.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="649.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="652.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="650.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="650.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="648.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,669.9 151.2,672.2 242.5,668.8 333.8,669.5 425.0,668.7 516.2,669.9 607.5,669.8 698.8,664.5 790.0,658.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="669.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="672.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="668.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="669.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="668.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="669.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="669.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="664.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="658.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,645.4 151.2,647.2 242.5,643.4 333.8,643.8 425.0,642.6 516.2,642.7 607.5,642.4 698.8,640.5 790.0,640.1" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="645.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="647.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="643.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="643.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="642.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="642.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="642.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="640.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="640.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,661.2 151.2,663.1 242.5,661.3 333.8,661.3 425.0,660.8 516.2,660.3 607.5,660.5 698.8,659.2 790.0,656.4" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="661.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="663.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="661.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="661.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="660.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="660.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="660.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="659.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="656.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/zig/doc/charts/bindings.svg
+++ b/bindings/zig/doc/charts/bindings.svg
@@ -1,0 +1,179 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 824" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="850" height="824" fill="#000000"/>
+  <text x="425.0" y="44" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>
+  <text x="425.0" y="58" text-anchor="middle" fill="#9ca3af" font-size="10">Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off</text>
+  <line x1="60" y1="377.0" x2="395" y2="377.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="377.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4M</text>
+  <line x1="60" y1="310.0" x2="395" y2="310.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="310.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">8M</text>
+  <line x1="60" y1="243.0" x2="395" y2="243.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="243.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">12M</text>
+  <line x1="60" y1="176.0" x2="395" y2="176.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="176.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">16M</text>
+  <line x1="60" y1="109.0" x2="395" y2="109.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="109.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20M</text>
+  <line x1="60.0" y1="109" x2="60.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="115.8" y1="109" x2="115.8" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="171.7" y1="109" x2="171.7" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="227.5" y1="109" x2="227.5" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="283.3" y1="109" x2="283.3" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="339.2" y1="109" x2="339.2" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="395.0" y1="109" x2="395.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="60" y1="109" x2="60" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="60" y1="444" x2="395" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="455" y1="402.1" x2="790" y2="402.1" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="402.1" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">0.5 GB/s</text>
+  <line x1="455" y1="360.2" x2="790" y2="360.2" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="360.2" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1 GB/s</text>
+  <line x1="455" y1="318.4" x2="790" y2="318.4" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="318.4" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">1.5 GB/s</text>
+  <line x1="455" y1="276.5" x2="790" y2="276.5" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="276.5" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2 GB/s</text>
+  <line x1="455" y1="234.6" x2="790" y2="234.6" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="234.6" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">2.5 GB/s</text>
+  <line x1="455" y1="192.8" x2="790" y2="192.8" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="192.8" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3 GB/s</text>
+  <line x1="455" y1="150.9" x2="790" y2="150.9" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="150.9" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">3.5 GB/s</text>
+  <line x1="455" y1="109.0" x2="790" y2="109.0" stroke="#374151" stroke-width="1"/>
+  <text x="798" y="109.0" text-anchor="start" dominant-baseline="middle" fill="#e5e7eb" font-size="10">4 GB/s</text>
+  <line x1="455.0" y1="109" x2="455.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="502.9" y1="109" x2="502.9" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="550.7" y1="109" x2="550.7" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="598.6" y1="109" x2="598.6" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="646.4" y1="109" x2="646.4" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="694.3" y1="109" x2="694.3" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="742.1" y1="109" x2="742.1" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="790.0" y1="109" x2="790.0" y2="444" stroke="#374151" stroke-width="1"/>
+  <line x1="790" y1="109" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
+  <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
+  <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
+  <polyline points="60.0,275.8 115.8,276.1 171.7,366.3 227.5,416.4 283.3,418.9 339.2,415.6 395.0,420.8" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,339.8 115.8,338.1 171.7,372.2 227.5,409.3 283.3,412.4 339.2,420.4 395.0,429.7" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,344.4 115.8,342.2 171.7,376.0 227.5,410.2 283.3,412.9 339.2,420.7 395.0,429.9" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="455.0,411.9 502.9,371.3 550.7,325.3 598.6,277.1 646.4,233.5 694.3,162.1 742.1,158.7 790.0,133.1" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="411.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="371.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="325.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="277.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="233.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="162.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="158.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="133.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,403.6 502.9,383.5 550.7,370.5 598.6,358.2 646.4,353.6 694.3,347.6 742.1,349.0 790.0,284.0" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="403.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="383.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="370.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="358.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="353.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="347.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="349.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="284.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,404.3 502.9,384.2 550.7,371.9 598.6,362.0 646.4,352.3 694.3,347.1 742.1,344.1 790.0,279.5" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="404.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="384.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="371.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="362.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="352.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="347.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="344.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="279.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="60.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="115.8" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="171.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="227.5" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="283.3" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="339.2" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="395.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="455.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="502.9" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="550.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="598.6" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="646.4" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <text x="694.3" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">8 KiB</text>
+  <text x="742.1" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 KiB</text>
+  <text x="790.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 KiB</text>
+  <text x="425.0" y="476" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate - solid = bandwidth</text>
+  <text x="425.0" y="532" text-anchor="middle" fill="#f9fafb" font-size="13" font-weight="700">REQ/REP latency: TCP loopback, p50 us (lower is better)</text>
+  <line x1="60" y1="729.0" x2="790" y2="729.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="729.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">20 us</text>
+  <line x1="60" y1="709.0" x2="790" y2="709.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="709.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">40 us</text>
+  <line x1="60" y1="689.0" x2="790" y2="689.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="689.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">60 us</text>
+  <line x1="60" y1="669.0" x2="790" y2="669.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="669.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">80 us</text>
+  <line x1="60" y1="649.0" x2="790" y2="649.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="649.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">100 us</text>
+  <line x1="60" y1="629.0" x2="790" y2="629.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="629.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">120 us</text>
+  <line x1="60" y1="609.0" x2="790" y2="609.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="609.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">140 us</text>
+  <line x1="60" y1="589.0" x2="790" y2="589.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="589.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">160 us</text>
+  <line x1="60" y1="569.0" x2="790" y2="569.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="569.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">180 us</text>
+  <line x1="60" y1="549.0" x2="790" y2="549.0" stroke="#374151" stroke-width="1"/>
+  <text x="52" y="549.0" text-anchor="end" dominant-baseline="middle" fill="#e5e7eb" font-size="10">200 us</text>
+  <line x1="60.0" y1="549" x2="60.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="151.2" y1="549" x2="151.2" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="242.5" y1="549" x2="242.5" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="333.8" y1="549" x2="333.8" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="425.0" y1="549" x2="425.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="516.2" y1="549" x2="516.2" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="607.5" y1="549" x2="607.5" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="698.8" y1="549" x2="698.8" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
+  <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
+  <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
+  <polyline points="60.0,653.0 151.2,654.5 242.5,653.4 333.8,658.3 425.0,657.6 516.2,656.5 607.5,652.1 698.8,654.3 790.0,644.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="653.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="654.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="653.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="658.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="657.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="656.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="652.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="654.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="644.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,627.8 151.2,629.2 242.5,626.9 333.8,629.5 425.0,626.7 516.2,631.2 607.5,628.5 698.8,625.2 790.0,623.9" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="627.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="629.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="626.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="629.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="626.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="631.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="628.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="625.2" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="623.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,651.4 151.2,652.4 242.5,650.5 333.8,652.0 425.0,649.3 516.2,652.4 607.5,650.0 698.8,650.1 790.0,648.0" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="651.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="652.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="650.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="652.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="649.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="652.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="650.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="650.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="648.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
+  <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
+  <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
+  <text x="333.8" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">128 B</text>
+  <text x="425.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">256 B</text>
+  <text x="516.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">512 B</text>
+  <text x="607.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">1 KiB</text>
+  <text x="698.8" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">2 KiB</text>
+  <text x="790.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">4 KiB</text>
+  <line x1="245" y1="789" x2="259" y2="789" stroke="#ef4444" stroke-width="2.5"/>
+  <circle cx="252" cy="789" r="2.5" fill="#ef4444"/>
+  <text x="265" y="793" fill="#e5e7eb" font-size="11" font-weight="500">omq.zig</text>
+  <line x1="365" y1="789" x2="379" y2="789" stroke="#60a5fa" stroke-width="2.5"/>
+  <circle cx="372" cy="789" r="2.5" fill="#60a5fa"/>
+  <text x="385" y="793" fill="#e5e7eb" font-size="11" font-weight="500">zzmq</text>
+  <line x1="485" y1="789" x2="499" y2="789" stroke="#a855f7" stroke-width="2.5"/>
+  <circle cx="492" cy="789" r="2.5" fill="#a855f7"/>
+  <text x="505" y="793" fill="#e5e7eb" font-size="11" font-weight="500">zimq</text>
+  <text x="425.0" y="807" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = msg/s (left) - solid = throughput (right)</text>
+</svg>

--- a/bindings/zig/doc/charts/bindings.svg
+++ b/bindings/zig/doc/charts/bindings.svg
@@ -51,36 +51,36 @@
   <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
   <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
-  <polyline points="60.0,193.9 115.8,159.6 171.7,314.1 227.5,398.6 283.3,401.5 339.2,394.7 395.0,405.6" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,278.6 115.8,268.7 171.7,326.9 227.5,385.3 283.3,390.7 339.2,404.8 395.0,420.1" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,277.6 115.8,275.8 171.7,332.0 227.5,388.0 283.3,392.2 339.2,404.5 395.0,420.6" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="455.0,411.3 502.9,368.3 550.7,326.1 598.6,263.6 646.4,214.2 694.3,167.5 742.1,160.1 790.0,141.8" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="411.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="368.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="326.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="263.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="214.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="167.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="160.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="141.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="455.0,403.1 502.9,383.8 550.7,370.6 598.6,358.6 646.4,352.7 694.3,346.9 742.1,349.1 790.0,282.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="403.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="383.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="370.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,165.7 115.8,164.6 171.7,313.3 227.5,398.3 283.3,401.6 339.2,396.7 395.0,404.7" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,272.2 115.8,270.6 171.7,322.7 227.5,386.1 283.3,390.2 339.2,403.7 395.0,420.4" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,271.9 115.8,275.0 171.7,329.6 227.5,387.0 283.3,391.7 339.2,403.9 395.0,420.7" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="455.0,411.4 502.9,371.3 550.7,323.3 598.6,266.7 646.4,208.6 694.3,156.2 742.1,152.5 790.0,139.6" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="411.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="371.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="323.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="266.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="208.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="156.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="152.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="139.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,402.7 502.9,382.0 550.7,371.6 598.6,358.6 646.4,351.3 694.3,345.0 742.1,346.7 790.0,282.6" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="402.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="382.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="371.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="598.6" cy="358.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="352.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="346.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="349.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="351.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="345.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="346.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="790.0" cy="282.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="455.0,404.2 502.9,383.4 550.7,372.0 598.6,358.7 646.4,353.2 694.3,334.4 742.1,345.0 790.0,279.1" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="404.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="383.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="372.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="358.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="353.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="334.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="345.0" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="279.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,403.8 502.9,382.4 550.7,372.3 598.6,359.6 646.4,352.7 694.3,345.2 742.1,341.1 790.0,295.1" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="403.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="382.4" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="372.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="359.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="352.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="345.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="341.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="295.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="115.8" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="171.7" y="458" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>
@@ -121,36 +121,36 @@
   <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="60.0,617.1 151.2,621.0 242.5,615.3 333.8,616.5 425.0,615.1 516.2,617.2 607.5,617.0 698.8,608.2 790.0,597.3" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="617.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="621.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="615.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="616.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="615.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="617.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="617.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="608.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="597.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,576.3 151.2,579.4 242.5,573.0 333.8,573.7 425.0,571.6 516.2,571.8 607.5,571.3 698.8,568.1 790.0,567.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="576.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="579.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="573.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="573.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="571.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="571.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="571.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="568.1" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="567.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,602.7 151.2,605.8 242.5,602.9 333.8,602.8 425.0,601.9 516.2,601.2 607.5,601.5 698.8,599.3 790.0,594.6" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="602.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="605.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="602.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="602.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="601.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="601.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="601.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="599.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="594.6" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,636.5 151.2,636.9 242.5,638.1 333.8,635.4 425.0,637.5 516.2,635.7 607.5,634.1 698.8,630.6 790.0,621.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="636.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="636.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="638.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="635.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="637.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="635.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="634.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="630.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="621.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,569.5 151.2,563.0 242.5,561.8 333.8,564.9 425.0,566.7 516.2,565.7 607.5,565.4 698.8,563.3 790.0,557.7" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="569.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="563.0" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="561.8" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="564.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="566.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="565.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="565.4" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="563.3" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="557.7" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,590.8 151.2,588.8 242.5,586.3 333.8,584.2 425.0,583.7 516.2,583.1 607.5,581.9 698.8,581.1 790.0,579.5" fill="none" stroke="#a855f7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="590.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="588.8" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="586.3" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="584.2" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="583.7" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="583.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="581.9" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="581.1" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="579.5" r="3" fill="#a855f7" stroke="#000000" stroke-width="1"/>
   <text x="60.0" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">16 B</text>
   <text x="151.2" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">32 B</text>
   <text x="242.5" y="763" text-anchor="middle" fill="#e5e7eb" font-size="8.5">64 B</text>

--- a/bindings/zig/scripts/bench/omq_bench.zig
+++ b/bindings/zig/scripts/bench/omq_bench.zig
@@ -28,6 +28,11 @@ pub fn main(init: std.process.Init) !void {
         try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
         return;
     }
+    if (std.mem.eql(u8, args[1], "latency-rep")) {
+        if (args.len != 3) return usage(init);
+        try runLatencyRep(init, allocator, try parseUsize(args[2]));
+        return;
+    }
     return usage(init);
 }
 
@@ -57,7 +62,7 @@ fn runThroughputTcp(init: std.process.Init, allocator: std.mem.Allocator, size: 
 
     var count: u64 = 0;
     var start_ns: ?i128 = null;
-    var recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    const recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
     defer allocator.free(recv_buffer);
     while (true) {
         const received = try pull.recvInto(recv_buffer, 0);
@@ -111,7 +116,7 @@ fn runThroughputPull(init: std.process.Init, allocator: std.mem.Allocator, endpo
 
     var count: u64 = 0;
     var start_ns: ?i128 = null;
-    var recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    const recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
     defer allocator.free(recv_buffer);
     while (true) {
         const received = try pull.recvInto(recv_buffer, 0);
@@ -141,14 +146,11 @@ fn runLatency(
 
     var ctx = try omq.Context.init();
     defer ctx.deinit();
-
-    var echo: Echoer = .{ .ctx = &ctx, .endpoint = endpoint, .allocator = allocator };
-    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
-    sleepMillis(50);
-
     var req = try ctx.socket(omq.REQ);
     defer req.deinit();
+    try req.setLinger(0);
     try req.connect(allocator, endpoint);
+    sleepMillis(50);
 
     try pingLoop(&req, allocator, payload, secondsToNanos(warmup_s), null);
 
@@ -156,14 +158,38 @@ fn runLatency(
     defer samples.deinit();
     try pingLoop(&req, allocator, payload, secondsToNanos(duration_s), &samples);
 
-    _ = try req.send(stop, 0);
-    const final = try req.recvAlloc(allocator, 0);
-    allocator.free(final);
-    thread.join();
-
     std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
     const p50 = percentile(samples.items, 50);
     try printFloat(init, p50);
+
+    _ = try req.send(stop, 0);
+    std.process.exit(0);
+}
+
+fn runLatencyRep(init: std.process.Init, allocator: std.mem.Allocator, size: usize) !void {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+    try rep.setLinger(0);
+    try rep.setReceiveTimeout(1000);
+
+    const endpoint = try rep.bind(allocator, "tcp://127.0.0.1:0");
+    defer allocator.free(endpoint);
+    try printLine(init, endpoint);
+
+    var recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    defer allocator.free(recv_buffer);
+    while (true) {
+        const received = rep.recvInto(recv_buffer, 0) catch |err| switch (err) {
+            error.Again => break,
+            else => return err,
+        };
+        const msg = recv_buffer[0..received];
+        _ = try rep.send(msg, 0);
+        if (std.mem.eql(u8, msg, stop)) break;
+    }
     std.process.exit(0);
 }
 
@@ -179,30 +205,6 @@ fn sendLoop(sender: *Sender) !void {
         _ = try sender.socket.send(sender.payload, 0);
     }
     _ = try sender.socket.send(stop, 0);
-}
-
-const Echoer = struct {
-    ctx: *omq.Context,
-    endpoint: []const u8,
-    allocator: std.mem.Allocator,
-};
-
-fn echoLoop(echoer: *Echoer) !void {
-    var socket = try echoer.ctx.socket(omq.REP);
-    defer socket.deinit();
-    const bound = try socket.bind(echoer.allocator, echoer.endpoint);
-    defer echoer.allocator.free(bound);
-
-    var recv_buffer = try echoer.allocator.alloc(u8, 1024 * 1024);
-    defer echoer.allocator.free(recv_buffer);
-    while (true) {
-        const received = try socket.recvInto(recv_buffer, 0);
-        const msg = recv_buffer[0..received];
-        _ = try socket.send(msg, 0);
-        if (std.mem.eql(u8, msg, stop)) {
-            break;
-        }
-    }
 }
 
 fn pingLoop(
@@ -285,7 +287,7 @@ fn usage(init: std.process.Init) !void {
     var buffer: [256]u8 = undefined;
     var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
     const stderr = &stderr_writer.interface;
-    try stderr.print("usage: omq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.print("usage: omq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT | latency-rep SIZE\n", .{});
     try stderr.flush();
     return error.InvalidArgs;
 }

--- a/bindings/zig/scripts/bench/omq_bench.zig
+++ b/bindings/zig/scripts/bench/omq_bench.zig
@@ -139,12 +139,13 @@ fn runLatency(
     defer allocator.free(payload);
     @memset(payload, 'x');
 
-    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var echo: Echoer = .{ .ctx = &ctx, .endpoint = endpoint, .allocator = allocator };
     const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
     sleepMillis(50);
 
-    var ctx = try omq.Context.init();
-    defer ctx.deinit();
     var req = try ctx.socket(omq.REQ);
     defer req.deinit();
     try req.connect(allocator, endpoint);
@@ -181,14 +182,13 @@ fn sendLoop(sender: *Sender) !void {
 }
 
 const Echoer = struct {
+    ctx: *omq.Context,
     endpoint: []const u8,
     allocator: std.mem.Allocator,
 };
 
 fn echoLoop(echoer: *Echoer) !void {
-    var ctx = try omq.Context.init();
-    defer ctx.deinit();
-    var socket = try ctx.socket(omq.REP);
+    var socket = try echoer.ctx.socket(omq.REP);
     defer socket.deinit();
     const bound = try socket.bind(echoer.allocator, echoer.endpoint);
     defer echoer.allocator.free(bound);

--- a/bindings/zig/scripts/bench/omq_bench.zig
+++ b/bindings/zig/scripts/bench/omq_bench.zig
@@ -1,0 +1,291 @@
+const std = @import("std");
+const omq = @import("omq");
+
+const stop = "__OMQ_ZIG_BENCH_STOP__";
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = std.heap.page_allocator;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 2) return usage(init);
+
+    if (std.mem.eql(u8, args[1], "throughput")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputTcp(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-push")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPush(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-pull")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPull(init, allocator, args[2], try parseUsize(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "latency")) {
+        if (args.len != 6) return usage(init);
+        try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
+        return;
+    }
+    return usage(init);
+}
+
+fn runThroughputTcp(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:0");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var sender: Sender = .{
+        .socket = &push,
+        .payload = payload,
+        .duration_ns = secondsToNanos(duration_s),
+    };
+    const thread = try std.Thread.spawn(.{}, sendLoop, .{&sender});
+
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    var recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    defer allocator.free(recv_buffer);
+    while (true) {
+        const received = try pull.recvInto(recv_buffer, 0);
+        const msg = recv_buffer[0..received];
+        if (std.mem.eql(u8, msg, stop)) break;
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+    }
+    const end_ns = nowNs();
+    thread.join();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runThroughputPush(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+    try push.setLinger(0);
+
+    const endpoint = try push.bind(allocator, "tcp://127.0.0.1:0");
+    defer allocator.free(endpoint);
+    try printLine(init, endpoint);
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    const start = nowNs();
+    const duration_ns = secondsToNanos(duration_s);
+    while (nowNs() - start < duration_ns) {
+        _ = try push.send(payload, 0);
+    }
+    _ = try push.send(stop, 0);
+    waitForRelease();
+    std.process.exit(0);
+}
+
+fn runThroughputPull(init: std.process.Init, allocator: std.mem.Allocator, endpoint: []const u8, size: usize) !void {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    try pull.setLinger(0);
+    try pull.connect(allocator, endpoint);
+
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    var recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    defer allocator.free(recv_buffer);
+    while (true) {
+        const received = try pull.recvInto(recv_buffer, 0);
+        const msg = recv_buffer[0..received];
+        if (std.mem.eql(u8, msg, stop)) break;
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+    }
+    const end_ns = nowNs();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runLatency(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    size: usize,
+    warmup_s: f64,
+    duration_s: f64,
+    endpoint: []const u8,
+) !void {
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
+    sleepMillis(50);
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+    try req.connect(allocator, endpoint);
+
+    try pingLoop(&req, allocator, payload, secondsToNanos(warmup_s), null);
+
+    var samples: std.array_list.Managed(f64) = .init(allocator);
+    defer samples.deinit();
+    try pingLoop(&req, allocator, payload, secondsToNanos(duration_s), &samples);
+
+    _ = try req.send(stop, 0);
+    const final = try req.recvAlloc(allocator, 0);
+    allocator.free(final);
+    thread.join();
+
+    std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
+    const p50 = percentile(samples.items, 50);
+    try printFloat(init, p50);
+    std.process.exit(0);
+}
+
+const Sender = struct {
+    socket: *omq.Socket,
+    payload: []const u8,
+    duration_ns: u64,
+};
+
+fn sendLoop(sender: *Sender) !void {
+    const start = nowNs();
+    while (nowNs() - start < sender.duration_ns) {
+        _ = try sender.socket.send(sender.payload, 0);
+    }
+    _ = try sender.socket.send(stop, 0);
+}
+
+const Echoer = struct {
+    endpoint: []const u8,
+    allocator: std.mem.Allocator,
+};
+
+fn echoLoop(echoer: *Echoer) !void {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+    var socket = try ctx.socket(omq.REP);
+    defer socket.deinit();
+    const bound = try socket.bind(echoer.allocator, echoer.endpoint);
+    defer echoer.allocator.free(bound);
+
+    var recv_buffer = try echoer.allocator.alloc(u8, 1024 * 1024);
+    defer echoer.allocator.free(recv_buffer);
+    while (true) {
+        const received = try socket.recvInto(recv_buffer, 0);
+        const msg = recv_buffer[0..received];
+        _ = try socket.send(msg, 0);
+        if (std.mem.eql(u8, msg, stop)) {
+            break;
+        }
+    }
+}
+
+fn pingLoop(
+    req: *omq.Socket,
+    allocator: std.mem.Allocator,
+    payload: []const u8,
+    duration_ns: u64,
+    samples: ?*std.array_list.Managed(f64),
+) !void {
+    const recv_buffer = try allocator.alloc(u8, @max(payload.len, stop.len));
+    defer allocator.free(recv_buffer);
+    const start = nowNs();
+    while (nowNs() - start < duration_ns) {
+        const t0 = nowNs();
+        _ = try req.send(payload, 0);
+        _ = try req.recvInto(recv_buffer, 0);
+        if (samples) |out| {
+            try out.append(elapsedSeconds(t0, nowNs()) * 1_000_000.0);
+        }
+    }
+}
+
+fn parseUsize(raw: []const u8) !usize {
+    return std.fmt.parseInt(usize, raw, 10);
+}
+
+fn parseSeconds(raw: []const u8) !f64 {
+    return std.fmt.parseFloat(f64, raw);
+}
+
+fn secondsToNanos(seconds: f64) u64 {
+    return @intFromFloat(seconds * std.time.ns_per_s);
+}
+
+fn elapsedSeconds(start_ns: i128, end_ns: i128) f64 {
+    return @as(f64, @floatFromInt(end_ns - start_ns)) / @as(f64, @floatFromInt(std.time.ns_per_s));
+}
+
+fn nowNs() i128 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+}
+
+fn waitForRelease() void {
+    var buffer: [1]u8 = undefined;
+    _ = std.posix.read(0, &buffer) catch 0;
+}
+
+fn percentile(sorted: []const f64, pct: usize) f64 {
+    if (sorted.len == 0) return 0.0;
+    return sorted[sorted.len * pct / 100];
+}
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn printFloat(init: std.process.Init, value: f64) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{d:.6}\n", .{value});
+    try stdout.flush();
+}
+
+fn printLine(init: std.process.Init, value: []const u8) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{s}\n", .{value});
+    try stdout.flush();
+}
+
+fn usage(init: std.process.Init) !void {
+    var buffer: [256]u8 = undefined;
+    var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
+    const stderr = &stderr_writer.interface;
+    try stderr.print("usage: omq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.flush();
+    return error.InvalidArgs;
+}

--- a/bindings/zig/scripts/bench/zimq_bench.zig
+++ b/bindings/zig/scripts/bench/zimq_bench.zig
@@ -1,0 +1,310 @@
+const std = @import("std");
+const zimq = @import("zimq");
+
+const stop = "__OMQ_ZIG_BENCH_STOP__";
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = std.heap.page_allocator;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 2) return usage(init);
+
+    if (std.mem.eql(u8, args[1], "throughput")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputTcp(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-push")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPush(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-pull")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPull(init, allocator, args[2], try parseUsize(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "latency")) {
+        if (args.len != 6) return usage(init);
+        try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
+        return;
+    }
+    return usage(init);
+}
+
+fn runThroughputTcp(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+
+    const pull: *zimq.Socket = try .init(ctx, .pull);
+    defer pull.deinit();
+    const push: *zimq.Socket = try .init(ctx, .push);
+    defer push.deinit();
+
+    try pull.bind("tcp://127.0.0.1:0");
+    const endpoint = try lastEndpoint(allocator, pull);
+    defer allocator.free(endpoint);
+    try push.connect(endpoint);
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var sender: Sender = .{
+        .socket = push,
+        .payload = payload,
+        .duration_ns = secondsToNanos(duration_s),
+    };
+    const thread = try std.Thread.spawn(.{}, sendLoop, .{&sender});
+
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    while (true) {
+        var msg: zimq.Message = .empty();
+        _ = try pull.recvMsg(&msg, .{});
+        const data = msg.slice();
+        if (std.mem.eql(u8, data, stop)) {
+            msg.deinit();
+            break;
+        }
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+        msg.deinit();
+    }
+    const end_ns = nowNs();
+    thread.join();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runThroughputPush(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+
+    const push: *zimq.Socket = try .init(ctx, .push);
+    defer push.deinit();
+    try push.set(.linger, 0);
+    try push.bind("tcp://127.0.0.1:0");
+    const endpoint = try lastEndpoint(allocator, push);
+    defer allocator.free(endpoint);
+    try printLine(init, endpoint);
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    const start = nowNs();
+    const duration_ns = secondsToNanos(duration_s);
+    while (nowNs() - start < duration_ns) {
+        try push.sendSlice(payload, .{});
+    }
+    try push.sendSlice(stop, .{});
+    waitForRelease();
+    std.process.exit(0);
+}
+
+fn runThroughputPull(init: std.process.Init, allocator: std.mem.Allocator, endpoint: []const u8, size: usize) !void {
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+
+    const pull: *zimq.Socket = try .init(ctx, .pull);
+    defer pull.deinit();
+    try pull.set(.linger, 0);
+    const endpoint_z = try allocator.dupeZ(u8, endpoint);
+    defer allocator.free(endpoint_z);
+    try pull.connect(endpoint_z);
+
+    _ = size;
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    while (true) {
+        var msg: zimq.Message = .empty();
+        _ = try pull.recvMsg(&msg, .{});
+        const data = msg.slice();
+        if (std.mem.eql(u8, data, stop)) {
+            msg.deinit();
+            break;
+        }
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+        msg.deinit();
+    }
+    const end_ns = nowNs();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runLatency(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    size: usize,
+    warmup_s: f64,
+    duration_s: f64,
+    endpoint: []const u8,
+) !void {
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
+    sleepMillis(50);
+
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+    const req: *zimq.Socket = try .init(ctx, .req);
+    defer req.deinit();
+    const endpoint_z = try allocator.dupeZ(u8, endpoint);
+    defer allocator.free(endpoint_z);
+    try req.connect(endpoint_z);
+
+    try pingLoop(req, payload, secondsToNanos(warmup_s), null);
+
+    var samples: std.array_list.Managed(f64) = .init(allocator);
+    defer samples.deinit();
+    try pingLoop(req, payload, secondsToNanos(duration_s), &samples);
+
+    try req.sendSlice(stop, .{});
+    var final: zimq.Message = .empty();
+    _ = try req.recvMsg(&final, .{});
+    final.deinit();
+    thread.join();
+
+    std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
+    try printFloat(init, percentile(samples.items, 50));
+    std.process.exit(0);
+}
+
+const Sender = struct {
+    socket: *zimq.Socket,
+    payload: []const u8,
+    duration_ns: u64,
+};
+
+fn sendLoop(sender: *Sender) !void {
+    const start = nowNs();
+    while (nowNs() - start < sender.duration_ns) {
+        try sender.socket.sendSlice(sender.payload, .{});
+    }
+    try sender.socket.sendSlice(stop, .{});
+}
+
+const Echoer = struct {
+    endpoint: []const u8,
+    allocator: std.mem.Allocator,
+};
+
+fn echoLoop(echoer: *Echoer) !void {
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+    const socket: *zimq.Socket = try .init(ctx, .rep);
+    defer socket.deinit();
+    const endpoint_z = try echoer.allocator.dupeZ(u8, echoer.endpoint);
+    defer echoer.allocator.free(endpoint_z);
+    try socket.bind(endpoint_z);
+
+    while (true) {
+        var msg: zimq.Message = .empty();
+        _ = try socket.recvMsg(&msg, .{});
+        const data = msg.slice();
+        try socket.sendSlice(data, .{});
+        const done = std.mem.eql(u8, data, stop);
+        msg.deinit();
+        if (done) break;
+    }
+}
+
+fn pingLoop(
+    req: *zimq.Socket,
+    payload: []const u8,
+    duration_ns: u64,
+    samples: ?*std.array_list.Managed(f64),
+) !void {
+    const start = nowNs();
+    while (nowNs() - start < duration_ns) {
+        const t0 = nowNs();
+        try req.sendSlice(payload, .{});
+        var msg: zimq.Message = .empty();
+        _ = try req.recvMsg(&msg, .{});
+        msg.deinit();
+        if (samples) |out| {
+            try out.append(elapsedSeconds(t0, nowNs()) * 1_000_000.0);
+        }
+    }
+}
+
+fn parseUsize(raw: []const u8) !usize {
+    return std.fmt.parseInt(usize, raw, 10);
+}
+
+fn parseSeconds(raw: []const u8) !f64 {
+    return std.fmt.parseFloat(f64, raw);
+}
+
+fn secondsToNanos(seconds: f64) u64 {
+    return @intFromFloat(seconds * std.time.ns_per_s);
+}
+
+fn elapsedSeconds(start_ns: i128, end_ns: i128) f64 {
+    return @as(f64, @floatFromInt(end_ns - start_ns)) / @as(f64, @floatFromInt(std.time.ns_per_s));
+}
+
+fn nowNs() i128 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+}
+
+fn waitForRelease() void {
+    var buffer: [1]u8 = undefined;
+    _ = std.posix.read(0, &buffer) catch 0;
+}
+
+fn lastEndpoint(allocator: std.mem.Allocator, socket: *zimq.Socket) ![:0]u8 {
+    var buffer: [512:0]u8 = undefined;
+    var endpoint: [:0]u8 = buffer[0..];
+    try socket.get(.last_endpoint, &endpoint);
+    const end = std.mem.indexOfScalar(u8, endpoint, 0) orelse endpoint.len;
+    return allocator.dupeZ(u8, endpoint[0..end]);
+}
+
+fn percentile(sorted: []const f64, pct: usize) f64 {
+    if (sorted.len == 0) return 0.0;
+    return sorted[sorted.len * pct / 100];
+}
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn printFloat(init: std.process.Init, value: f64) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{d:.6}\n", .{value});
+    try stdout.flush();
+}
+
+fn printLine(init: std.process.Init, value: []const u8) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{s}\n", .{value});
+    try stdout.flush();
+}
+
+fn usage(init: std.process.Init) !void {
+    var buffer: [256]u8 = undefined;
+    var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
+    const stderr = &stderr_writer.interface;
+    try stderr.print("usage: zimq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.flush();
+    return error.InvalidArgs;
+}

--- a/bindings/zig/scripts/bench/zimq_bench.zig
+++ b/bindings/zig/scripts/bench/zimq_bench.zig
@@ -149,12 +149,13 @@ fn runLatency(
     defer allocator.free(payload);
     @memset(payload, 'x');
 
-    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+
+    var echo: Echoer = .{ .ctx = ctx, .endpoint = endpoint, .allocator = allocator };
     const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
     sleepMillis(50);
 
-    const ctx: *zimq.Context = try .init();
-    defer ctx.deinit();
     const req: *zimq.Socket = try .init(ctx, .req);
     defer req.deinit();
     const endpoint_z = try allocator.dupeZ(u8, endpoint);
@@ -193,14 +194,13 @@ fn sendLoop(sender: *Sender) !void {
 }
 
 const Echoer = struct {
+    ctx: *zimq.Context,
     endpoint: []const u8,
     allocator: std.mem.Allocator,
 };
 
 fn echoLoop(echoer: *Echoer) !void {
-    const ctx: *zimq.Context = try .init();
-    defer ctx.deinit();
-    const socket: *zimq.Socket = try .init(ctx, .rep);
+    const socket: *zimq.Socket = try .init(echoer.ctx, .rep);
     defer socket.deinit();
     const endpoint_z = try echoer.allocator.dupeZ(u8, echoer.endpoint);
     defer echoer.allocator.free(endpoint_z);

--- a/bindings/zig/scripts/bench/zimq_bench.zig
+++ b/bindings/zig/scripts/bench/zimq_bench.zig
@@ -28,6 +28,11 @@ pub fn main(init: std.process.Init) !void {
         try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
         return;
     }
+    if (std.mem.eql(u8, args[1], "latency-rep")) {
+        if (args.len != 3) return usage(init);
+        try runLatencyRep(init, allocator, try parseUsize(args[2]));
+        return;
+    }
     return usage(init);
 }
 
@@ -151,31 +156,52 @@ fn runLatency(
 
     const ctx: *zimq.Context = try .init();
     defer ctx.deinit();
-
-    var echo: Echoer = .{ .ctx = ctx, .endpoint = endpoint, .allocator = allocator };
-    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
-    sleepMillis(50);
-
     const req: *zimq.Socket = try .init(ctx, .req);
     defer req.deinit();
+    try req.set(.linger, 0);
     const endpoint_z = try allocator.dupeZ(u8, endpoint);
     defer allocator.free(endpoint_z);
     try req.connect(endpoint_z);
+    sleepMillis(50);
 
-    try pingLoop(req, payload, secondsToNanos(warmup_s), null);
+    try pingLoop(req, allocator, payload, secondsToNanos(warmup_s), null);
 
     var samples: std.array_list.Managed(f64) = .init(allocator);
     defer samples.deinit();
-    try pingLoop(req, payload, secondsToNanos(duration_s), &samples);
-
-    try req.sendSlice(stop, .{});
-    var final: zimq.Message = .empty();
-    _ = try req.recvMsg(&final, .{});
-    final.deinit();
-    thread.join();
+    try pingLoop(req, allocator, payload, secondsToNanos(duration_s), &samples);
 
     std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
     try printFloat(init, percentile(samples.items, 50));
+
+    try req.sendSlice(stop, .{});
+    std.process.exit(0);
+}
+
+fn runLatencyRep(init: std.process.Init, allocator: std.mem.Allocator, size: usize) !void {
+    const ctx: *zimq.Context = try .init();
+    defer ctx.deinit();
+
+    const rep: *zimq.Socket = try .init(ctx, .rep);
+    defer rep.deinit();
+    try rep.set(.linger, 0);
+    try rep.set(.rcvtimeo, 1000);
+    try rep.bind("tcp://127.0.0.1:0");
+    const endpoint = try lastEndpoint(allocator, rep);
+    defer allocator.free(endpoint);
+    try printLine(init, endpoint);
+
+    const recv_buffer = try allocator.alloc(u8, @max(size, stop.len));
+    defer allocator.free(recv_buffer);
+    while (true) {
+        const received = rep.recv(recv_buffer, .{}) catch |err| switch (err) {
+            error.WouldBlock => break,
+            else => return err,
+        };
+        const data = recv_buffer[0..received];
+        try rep.sendSlice(data, .{});
+        const done = std.mem.eql(u8, data, stop);
+        if (done) break;
+    }
     std.process.exit(0);
 }
 
@@ -193,43 +219,20 @@ fn sendLoop(sender: *Sender) !void {
     try sender.socket.sendSlice(stop, .{});
 }
 
-const Echoer = struct {
-    ctx: *zimq.Context,
-    endpoint: []const u8,
-    allocator: std.mem.Allocator,
-};
-
-fn echoLoop(echoer: *Echoer) !void {
-    const socket: *zimq.Socket = try .init(echoer.ctx, .rep);
-    defer socket.deinit();
-    const endpoint_z = try echoer.allocator.dupeZ(u8, echoer.endpoint);
-    defer echoer.allocator.free(endpoint_z);
-    try socket.bind(endpoint_z);
-
-    while (true) {
-        var msg: zimq.Message = .empty();
-        _ = try socket.recvMsg(&msg, .{});
-        const data = msg.slice();
-        try socket.sendSlice(data, .{});
-        const done = std.mem.eql(u8, data, stop);
-        msg.deinit();
-        if (done) break;
-    }
-}
-
 fn pingLoop(
     req: *zimq.Socket,
+    allocator: std.mem.Allocator,
     payload: []const u8,
     duration_ns: u64,
     samples: ?*std.array_list.Managed(f64),
 ) !void {
+    const recv_buffer = try allocator.alloc(u8, @max(payload.len, stop.len));
+    defer allocator.free(recv_buffer);
     const start = nowNs();
     while (nowNs() - start < duration_ns) {
         const t0 = nowNs();
         try req.sendSlice(payload, .{});
-        var msg: zimq.Message = .empty();
-        _ = try req.recvMsg(&msg, .{});
-        msg.deinit();
+        _ = try req.recv(recv_buffer, .{});
         if (samples) |out| {
             try out.append(elapsedSeconds(t0, nowNs()) * 1_000_000.0);
         }
@@ -304,7 +307,7 @@ fn usage(init: std.process.Init) !void {
     var buffer: [256]u8 = undefined;
     var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
     const stderr = &stderr_writer.interface;
-    try stderr.print("usage: zimq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.print("usage: zimq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT | latency-rep SIZE\n", .{});
     try stderr.flush();
     return error.InvalidArgs;
 }

--- a/bindings/zig/scripts/bench/zzmq_bench.zig
+++ b/bindings/zig/scripts/bench/zzmq_bench.zig
@@ -144,12 +144,13 @@ fn runLatency(
     defer allocator.free(payload);
     @memset(payload, 'x');
 
-    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+
+    var echo: Echoer = .{ .ctx = &ctx, .endpoint = endpoint, .allocator = allocator };
     const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
     sleepMillis(50);
 
-    var ctx = try zzmq.ZContext.init(allocator);
-    defer ctx.deinit();
     const req = try zzmq.ZSocket.init(zzmq.ZSocketType.Req, &ctx);
     defer req.deinit();
     try req.connect(endpoint);
@@ -185,14 +186,13 @@ fn sendLoop(sender: *Sender) !void {
 }
 
 const Echoer = struct {
+    ctx: *zzmq.ZContext,
     endpoint: []const u8,
     allocator: std.mem.Allocator,
 };
 
 fn echoLoop(echoer: *Echoer) !void {
-    var ctx = try zzmq.ZContext.init(echoer.allocator);
-    defer ctx.deinit();
-    const socket = try zzmq.ZSocket.init(zzmq.ZSocketType.Rep, &ctx);
+    const socket = try zzmq.ZSocket.init(zzmq.ZSocketType.Rep, echoer.ctx);
     defer socket.deinit();
     try socket.bind(echoer.endpoint);
 

--- a/bindings/zig/scripts/bench/zzmq_bench.zig
+++ b/bindings/zig/scripts/bench/zzmq_bench.zig
@@ -1,0 +1,297 @@
+const std = @import("std");
+const zzmq = @import("zzmq");
+const c = @cImport({
+    @cInclude("zmq.h");
+});
+
+const stop = "__OMQ_ZIG_BENCH_STOP__";
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = std.heap.page_allocator;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 2) return usage(init);
+
+    if (std.mem.eql(u8, args[1], "throughput")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputTcp(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-push")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPush(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "throughput-pull")) {
+        if (args.len != 4) return usage(init);
+        try runThroughputPull(init, allocator, args[2], try parseUsize(args[3]));
+        return;
+    }
+    if (std.mem.eql(u8, args[1], "latency")) {
+        if (args.len != 6) return usage(init);
+        try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
+        return;
+    }
+    return usage(init);
+}
+
+fn runThroughputTcp(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+
+    const pull = try zzmq.ZSocket.init(zzmq.ZSocketType.Pull, &ctx);
+    defer pull.deinit();
+    const push = try zzmq.ZSocket.init(zzmq.ZSocketType.Push, &ctx);
+    defer push.deinit();
+
+    try pull.bind("tcp://127.0.0.1:0");
+    try push.connect(try pull.endpoint());
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var sender: Sender = .{
+        .socket = push,
+        .payload = payload,
+        .duration_ns = secondsToNanos(duration_s),
+    };
+    const thread = try std.Thread.spawn(.{}, sendLoop, .{&sender});
+
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    while (true) {
+        var msg = try pull.receive(.{});
+        const data = try msg.data();
+        if (std.mem.eql(u8, data, stop)) {
+            msg.deinit();
+            break;
+        }
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+        msg.deinit();
+    }
+    const end_ns = nowNs();
+    thread.join();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runThroughputPush(init: std.process.Init, allocator: std.mem.Allocator, size: usize, duration_s: f64) !void {
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+
+    const push = try zzmq.ZSocket.init(zzmq.ZSocketType.Push, &ctx);
+    defer push.deinit();
+    try push.setSocketOption(.{ .LingerTimeout = 0 });
+    try push.bind("tcp://127.0.0.1:0");
+    try printLine(init, try push.endpoint());
+
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    const start = nowNs();
+    const duration_ns = secondsToNanos(duration_s);
+    while (nowNs() - start < duration_ns) {
+        try sendSlice(push, payload);
+    }
+    try sendSlice(push, stop);
+    waitForRelease();
+    std.process.exit(0);
+}
+
+fn runThroughputPull(init: std.process.Init, allocator: std.mem.Allocator, endpoint: []const u8, size: usize) !void {
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+
+    const pull = try zzmq.ZSocket.init(zzmq.ZSocketType.Pull, &ctx);
+    defer pull.deinit();
+    try pull.setSocketOption(.{ .LingerTimeout = 0 });
+    try pull.connect(endpoint);
+
+    _ = size;
+    var count: u64 = 0;
+    var start_ns: ?i128 = null;
+    while (true) {
+        var msg = try pull.receive(.{});
+        const data = try msg.data();
+        if (std.mem.eql(u8, data, stop)) {
+            msg.deinit();
+            break;
+        }
+        if (start_ns == null) start_ns = nowNs();
+        count += 1;
+        msg.deinit();
+    }
+    const end_ns = nowNs();
+
+    const elapsed = elapsedSeconds(start_ns orelse end_ns, end_ns);
+    try printFloat(init, @as(f64, @floatFromInt(count)) / elapsed);
+    std.process.exit(0);
+}
+
+fn runLatency(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    size: usize,
+    warmup_s: f64,
+    duration_s: f64,
+    endpoint: []const u8,
+) !void {
+    const payload = try allocator.alloc(u8, size);
+    defer allocator.free(payload);
+    @memset(payload, 'x');
+
+    var echo: Echoer = .{ .endpoint = endpoint, .allocator = allocator };
+    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
+    sleepMillis(50);
+
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+    const req = try zzmq.ZSocket.init(zzmq.ZSocketType.Req, &ctx);
+    defer req.deinit();
+    try req.connect(endpoint);
+
+    try pingLoop(req, payload, secondsToNanos(warmup_s), null);
+
+    var samples: std.array_list.Managed(f64) = .init(allocator);
+    defer samples.deinit();
+    try pingLoop(req, payload, secondsToNanos(duration_s), &samples);
+
+    try sendSlice(req, stop);
+    var final = try req.receive(.{});
+    final.deinit();
+    thread.join();
+
+    std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
+    try printFloat(init, percentile(samples.items, 50));
+    std.process.exit(0);
+}
+
+const Sender = struct {
+    socket: *zzmq.ZSocket,
+    payload: []const u8,
+    duration_ns: u64,
+};
+
+fn sendLoop(sender: *Sender) !void {
+    const start = nowNs();
+    while (nowNs() - start < sender.duration_ns) {
+        try sendSlice(sender.socket, sender.payload);
+    }
+    try sendSlice(sender.socket, stop);
+}
+
+const Echoer = struct {
+    endpoint: []const u8,
+    allocator: std.mem.Allocator,
+};
+
+fn echoLoop(echoer: *Echoer) !void {
+    var ctx = try zzmq.ZContext.init(echoer.allocator);
+    defer ctx.deinit();
+    const socket = try zzmq.ZSocket.init(zzmq.ZSocketType.Rep, &ctx);
+    defer socket.deinit();
+    try socket.bind(echoer.endpoint);
+
+    while (true) {
+        var msg = try socket.receive(.{});
+        const data = try msg.data();
+        const copy = try echoer.allocator.dupe(u8, data);
+        const done = std.mem.eql(u8, data, stop);
+        msg.deinit();
+        defer echoer.allocator.free(copy);
+        try sendSlice(socket, copy);
+        if (done) break;
+    }
+}
+
+fn pingLoop(
+    req: *zzmq.ZSocket,
+    payload: []const u8,
+    duration_ns: u64,
+    samples: ?*std.array_list.Managed(f64),
+) !void {
+    const start = nowNs();
+    while (nowNs() - start < duration_ns) {
+        const t0 = nowNs();
+        try sendSlice(req, payload);
+        var msg = try req.receive(.{});
+        msg.deinit();
+        if (samples) |out| {
+            try out.append(elapsedSeconds(t0, nowNs()) * 1_000_000.0);
+        }
+    }
+}
+
+fn sendSlice(socket: *zzmq.ZSocket, payload: []const u8) !void {
+    const sent = c.zmq_send(socket.socket_, payload.ptr, payload.len, 0);
+    if (sent == -1) return error.SendFailed;
+}
+
+fn parseUsize(raw: []const u8) !usize {
+    return std.fmt.parseInt(usize, raw, 10);
+}
+
+fn parseSeconds(raw: []const u8) !f64 {
+    return std.fmt.parseFloat(f64, raw);
+}
+
+fn secondsToNanos(seconds: f64) u64 {
+    return @intFromFloat(seconds * std.time.ns_per_s);
+}
+
+fn elapsedSeconds(start_ns: i128, end_ns: i128) f64 {
+    return @as(f64, @floatFromInt(end_ns - start_ns)) / @as(f64, @floatFromInt(std.time.ns_per_s));
+}
+
+fn nowNs() i128 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+}
+
+fn waitForRelease() void {
+    var buffer: [1]u8 = undefined;
+    _ = std.posix.read(0, &buffer) catch 0;
+}
+
+fn percentile(sorted: []const f64, pct: usize) f64 {
+    if (sorted.len == 0) return 0.0;
+    return sorted[sorted.len * pct / 100];
+}
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn printFloat(init: std.process.Init, value: f64) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{d:.6}\n", .{value});
+    try stdout.flush();
+}
+
+fn printLine(init: std.process.Init, value: []const u8) !void {
+    var buffer: [256]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.print("{s}\n", .{value});
+    try stdout.flush();
+}
+
+fn usage(init: std.process.Init) !void {
+    var buffer: [256]u8 = undefined;
+    var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
+    const stderr = &stderr_writer.interface;
+    try stderr.print("usage: zzmq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.flush();
+    return error.InvalidArgs;
+}

--- a/bindings/zig/scripts/bench/zzmq_bench.zig
+++ b/bindings/zig/scripts/bench/zzmq_bench.zig
@@ -31,6 +31,11 @@ pub fn main(init: std.process.Init) !void {
         try runLatency(init, allocator, try parseUsize(args[2]), try parseSeconds(args[3]), try parseSeconds(args[4]), args[5]);
         return;
     }
+    if (std.mem.eql(u8, args[1], "latency-rep")) {
+        if (args.len != 3) return usage(init);
+        try runLatencyRep(init, allocator, try parseUsize(args[2]));
+        return;
+    }
     return usage(init);
 }
 
@@ -146,14 +151,11 @@ fn runLatency(
 
     var ctx = try zzmq.ZContext.init(allocator);
     defer ctx.deinit();
-
-    var echo: Echoer = .{ .ctx = &ctx, .endpoint = endpoint, .allocator = allocator };
-    const thread = try std.Thread.spawn(.{}, echoLoop, .{&echo});
-    sleepMillis(50);
-
     const req = try zzmq.ZSocket.init(zzmq.ZSocketType.Req, &ctx);
     defer req.deinit();
+    try req.setSocketOption(.{ .LingerTimeout = 0 });
     try req.connect(endpoint);
+    sleepMillis(50);
 
     try pingLoop(req, payload, secondsToNanos(warmup_s), null);
 
@@ -161,13 +163,38 @@ fn runLatency(
     defer samples.deinit();
     try pingLoop(req, payload, secondsToNanos(duration_s), &samples);
 
-    try sendSlice(req, stop);
-    var final = try req.receive(.{});
-    final.deinit();
-    thread.join();
-
     std.mem.sort(f64, samples.items, {}, comptime std.sort.asc(f64));
     try printFloat(init, percentile(samples.items, 50));
+
+    try sendSlice(req, stop);
+    std.process.exit(0);
+}
+
+fn runLatencyRep(init: std.process.Init, allocator: std.mem.Allocator, size: usize) !void {
+    var ctx = try zzmq.ZContext.init(allocator);
+    defer ctx.deinit();
+
+    const rep = try zzmq.ZSocket.init(zzmq.ZSocketType.Rep, &ctx);
+    defer rep.deinit();
+    try rep.setSocketOption(.{ .LingerTimeout = 0 });
+    try rep.setSocketOption(.{ .ReceiveTimeout = 1000 });
+    try rep.bind("tcp://127.0.0.1:0");
+    try printLine(init, try rep.endpoint());
+
+    _ = size;
+    while (true) {
+        var msg = rep.receive(.{}) catch |err| switch (err) {
+            error.NonBlockingQueueEmpty => break,
+            else => return err,
+        };
+        const data = try msg.data();
+        const copy = try allocator.dupe(u8, data);
+        const done = std.mem.eql(u8, data, stop);
+        msg.deinit();
+        defer allocator.free(copy);
+        try sendSlice(rep, copy);
+        if (done) break;
+    }
     std.process.exit(0);
 }
 
@@ -183,29 +210,6 @@ fn sendLoop(sender: *Sender) !void {
         try sendSlice(sender.socket, sender.payload);
     }
     try sendSlice(sender.socket, stop);
-}
-
-const Echoer = struct {
-    ctx: *zzmq.ZContext,
-    endpoint: []const u8,
-    allocator: std.mem.Allocator,
-};
-
-fn echoLoop(echoer: *Echoer) !void {
-    const socket = try zzmq.ZSocket.init(zzmq.ZSocketType.Rep, echoer.ctx);
-    defer socket.deinit();
-    try socket.bind(echoer.endpoint);
-
-    while (true) {
-        var msg = try socket.receive(.{});
-        const data = try msg.data();
-        const copy = try echoer.allocator.dupe(u8, data);
-        const done = std.mem.eql(u8, data, stop);
-        msg.deinit();
-        defer echoer.allocator.free(copy);
-        try sendSlice(socket, copy);
-        if (done) break;
-    }
 }
 
 fn pingLoop(
@@ -291,7 +295,7 @@ fn usage(init: std.process.Init) !void {
     var buffer: [256]u8 = undefined;
     var stderr_writer = std.Io.File.stderr().writer(init.io, &buffer);
     const stderr = &stderr_writer.interface;
-    try stderr.print("usage: zzmq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT\n", .{});
+    try stderr.print("usage: zzmq_bench throughput SIZE SECONDS | throughput-push SIZE SECONDS | throughput-pull ENDPOINT SIZE | latency SIZE WARMUP_SECONDS SECONDS ENDPOINT | latency-rep SIZE\n", .{});
     try stderr.flush();
     return error.InvalidArgs;
 }

--- a/bindings/zig/scripts/soak.sh
+++ b/bindings/zig/scripts/soak.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+duration="${1:-${OMQ_ZIG_SOAK_DURATION:-1h}}"
+
+if [[ ! "$duration" =~ ^([1-9][0-9]*)([smhd]?)$ ]]; then
+  printf 'error: duration must be a positive integer followed by s, m, h, or d\n' >&2
+  exit 2
+fi
+
+value="${BASH_REMATCH[1]}"
+case "${BASH_REMATCH[2]:-s}" in
+  s) multiplier=1 ;;
+  m) multiplier=60 ;;
+  h) multiplier=3600 ;;
+  d) multiplier=86400 ;;
+esac
+seconds=$((10#$value * multiplier))
+
+if [[ "${SOAK_SKIP_BUILD:-0}" != "1" ]]; then
+  cargo build --release -p omq-libzmq
+fi
+
+export LD_LIBRARY_PATH="${repo_root}/target/release:${LD_LIBRARY_PATH:-}"
+
+OMQ_ZIG_SOAK_DURATION_SECS="$seconds" \
+  timeout "$((seconds + 120))s" \
+  zig build --build-file "${repo_root}/bindings/zig/build.zig" soak

--- a/bindings/zig/scripts/soak.sh
+++ b/bindings/zig/scripts/soak.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 duration="${1:-${OMQ_ZIG_SOAK_DURATION:-1h}}"
+jobs="${OMQ_ZIG_SOAK_JOBS:-}"
+timeout_extra="${OMQ_ZIG_SOAK_TIMEOUT_EXTRA_SECS:-300}"
 
 if [[ ! "$duration" =~ ^([1-9][0-9]*)([smhd]?)$ ]]; then
   printf 'error: duration must be a positive integer followed by s, m, h, or d\n' >&2
@@ -17,6 +19,22 @@ case "${BASH_REMATCH[2]:-s}" in
   d) multiplier=86400 ;;
 esac
 seconds=$((10#$value * multiplier))
+if [[ ! "$timeout_extra" =~ ^[0-9]+$ ]]; then
+  printf 'error: OMQ_ZIG_SOAK_TIMEOUT_EXTRA_SECS must be a non-negative integer\n' >&2
+  exit 2
+fi
+
+tests=(
+  "context churn tracks resources"
+  "req rep cycles track resources"
+  "push pull sustained tracks resources"
+  "pair bidirectional tracks resources"
+  "multipart push pull tracks resources"
+  "pub sub sustained tracks resources"
+  "large messages track resources"
+  "reconnect storm tracks resources"
+  "peer churn tracks resources"
+)
 
 if [[ "${SOAK_SKIP_BUILD:-0}" != "1" ]]; then
   cargo build --release -p omq-libzmq
@@ -24,6 +42,67 @@ fi
 
 export LD_LIBRARY_PATH="${repo_root}/target/release:${LD_LIBRARY_PATH:-}"
 
-OMQ_ZIG_SOAK_DURATION_SECS="$seconds" \
-  timeout "$((seconds + 120))s" \
-  zig build --build-file "${repo_root}/bindings/zig/build.zig" soak
+if [[ -z "$jobs" ]]; then
+  jobs="${#tests[@]}"
+fi
+if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'error: OMQ_ZIG_SOAK_JOBS must be a positive integer\n' >&2
+  exit 2
+fi
+if (( jobs > ${#tests[@]} )); then
+  jobs="${#tests[@]}"
+fi
+
+cd "${repo_root}"
+
+pids=()
+cleanup() {
+  for pid in "${pids[@]:-}"; do
+    pkill -TERM -P "$pid" 2>/dev/null || true
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  sleep 0.2
+  for pid in "${pids[@]:-}"; do
+    pkill -KILL -P "$pid" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+}
+trap 'cleanup; exit 130' INT TERM
+
+printf '== OMQ.zig soak: %ss, jobs=%s ==\n' "$seconds" "$jobs"
+
+active=0
+failed=0
+for test_name in "${tests[@]}"; do
+  label="${test_name// /-}"
+  bash -c '
+    set -o pipefail
+    label="$1"
+    seconds="$2"
+    repo_root="$3"
+    test_name="$4"
+    timeout_extra="$5"
+    OMQ_ZIG_SOAK_DURATION_SECS="$seconds" \
+      timeout "$((seconds + timeout_extra))s" \
+      zig build --build-file "${repo_root}/bindings/zig/build.zig" \
+        soak -Dtest-filter="$test_name" \
+      2>&1 | sed -u "s/^/[${label}] /"
+  ' bash "$label" "$seconds" "$repo_root" "$test_name" "$timeout_extra" &
+  pids+=("$!")
+  active=$((active + 1))
+  if (( active >= jobs )); then
+    if ! wait -n; then
+      failed=1
+    fi
+    active=$((active - 1))
+  fi
+done
+
+while (( active > 0 )); do
+  if ! wait -n; then
+    failed=1
+  fi
+  active=$((active - 1))
+done
+
+exit "$failed"

--- a/bindings/zig/scripts/update_perf.py
+++ b/bindings/zig/scripts/update_perf.py
@@ -1,0 +1,848 @@
+#!/usr/bin/env python3
+"""Measure Zig ZeroMQ binding throughput and latency.
+
+Adapted from bindings/pyomq/scripts/update_perf.py. Full runs append to
+~/.cache/omq.zig/bindings.jsonl and generate doc/charts/bindings.svg.
+"""
+
+import argparse
+import json
+import math
+import os
+import select
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+QUICK_SIZES = [16, 128, 1024, 4096, 32768]
+LATENCY_MAX_SIZE = 4096
+SIZES = DEFAULT_SIZES.copy()
+TARGET_RUNTIME_S = 2.5
+THROUGHPUT_WARMUP_S = 0.5
+N_ROUNDS = 3
+LATENCY_WARMUP_S = 0.5
+LATENCY_RUNTIME_S = 1.5
+SUBPROCESS_TIMEOUT_S = 45.0
+
+SCRIPT_DIR = os.path.dirname(__file__)
+BINDING_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
+REPO_ROOT = os.path.abspath(os.path.join(BINDING_DIR, "..", ".."))
+CHART_DIR = os.path.join(BINDING_DIR, "doc", "charts")
+CACHE_DIR = os.path.join(
+    os.environ.get("OMQ_ZIG_CACHE_DIR")
+    or os.path.join(os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "omq.zig")
+)
+JSONL_FILE = os.path.join(CACHE_DIR, "bindings.jsonl")
+SRC_DIR = os.path.join(CACHE_DIR, "src")
+BIN_DIR = os.path.join(CACHE_DIR, "bin")
+
+IMPLS = {
+    "omq.zig": {
+        "repo": None,
+        "bench": os.path.join(BINDING_DIR, "zig-out", "bin", "omq-zig-bench"),
+    },
+    "zzmq": {
+        "repo": "https://github.com/nine-lives-later/zzmq",
+        "bench": os.path.join(BIN_DIR, "zzmq-bench"),
+    },
+    "zimq": {
+        "repo": "https://github.com/uyha/zimq",
+        "tag": "zig-0.16",
+        "bench": os.path.join(BIN_DIR, "zimq-bench"),
+    },
+}
+
+
+def parse_sizes(value):
+    sizes = []
+    for raw in value.split(","):
+        raw = raw.strip().lower()
+        if not raw:
+            continue
+        multiplier = 1
+        if raw.endswith("kib"):
+            multiplier = 1024
+            raw = raw[:-3]
+        elif raw.endswith("kb"):
+            multiplier = 1000
+            raw = raw[:-2]
+        elif raw.endswith("k"):
+            multiplier = 1024
+            raw = raw[:-1]
+        size = int(raw.strip()) * multiplier
+        if size <= 0:
+            raise argparse.ArgumentTypeError("sizes must be positive")
+        sizes.append(size)
+    if not sizes:
+        raise argparse.ArgumentTypeError("at least one size is required")
+    return sizes
+
+
+def configure_benchmark(args):
+    global SIZES
+    global TARGET_RUNTIME_S
+    global THROUGHPUT_WARMUP_S
+    global N_ROUNDS
+    global LATENCY_WARMUP_S
+    global LATENCY_RUNTIME_S
+    global SUBPROCESS_TIMEOUT_S
+
+    if args.quick:
+        SIZES = QUICK_SIZES.copy()
+        TARGET_RUNTIME_S = 0.5
+        THROUGHPUT_WARMUP_S = 0.1
+        N_ROUNDS = 1
+        LATENCY_WARMUP_S = 0.1
+        LATENCY_RUNTIME_S = 0.5
+        SUBPROCESS_TIMEOUT_S = 20.0
+
+    if args.sizes is not None:
+        SIZES = args.sizes
+    if args.rounds is not None:
+        N_ROUNDS = args.rounds
+    if args.target_runtime is not None:
+        TARGET_RUNTIME_S = args.target_runtime
+        if args.latency_duration is None:
+            LATENCY_RUNTIME_S = min(TARGET_RUNTIME_S, LATENCY_RUNTIME_S)
+    if args.warmup_duration is not None:
+        THROUGHPUT_WARMUP_S = args.warmup_duration
+        if args.latency_warmup_duration is None:
+            LATENCY_WARMUP_S = THROUGHPUT_WARMUP_S
+    if args.latency_warmup_duration is not None:
+        LATENCY_WARMUP_S = args.latency_warmup_duration
+    if args.latency_duration is not None:
+        LATENCY_RUNTIME_S = args.latency_duration
+    if args.timeout is not None:
+        SUBPROCESS_TIMEOUT_S = args.timeout
+
+    if N_ROUNDS < 1:
+        raise argparse.ArgumentTypeError("--rounds must be at least 1")
+    if TARGET_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--target-runtime must be positive")
+    if THROUGHPUT_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--warmup-duration cannot be negative")
+    if LATENCY_WARMUP_S < 0:
+        raise argparse.ArgumentTypeError("--latency-warmup-duration cannot be negative")
+    if LATENCY_RUNTIME_S <= 0:
+        raise argparse.ArgumentTypeError("--latency-duration must be positive")
+
+
+def run(cmd, *, cwd=None, timeout=None):
+    r = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed:\n{r.stdout}{r.stderr}")
+    if "warning:" in r.stdout.lower() or "warning:" in r.stderr.lower():
+        raise RuntimeError(f"{' '.join(cmd)} printed warning:\n{r.stdout}{r.stderr}")
+    return r
+
+
+def ensure_clone(name):
+    repo = IMPLS[name]["repo"]
+    dest = os.path.join(SRC_DIR, name)
+    if not os.path.isdir(os.path.join(dest, ".git")):
+        os.makedirs(SRC_DIR, exist_ok=True)
+        run(["git", "-c", "init.templateDir=", "clone", "--depth", "1", repo, dest], timeout=60)
+    if "tag" in IMPLS[name]:
+        run(["git", "fetch", "--depth", "1", "origin", "tag", IMPLS[name]["tag"]], cwd=dest)
+        run(["git", "checkout", f"tags/{IMPLS[name]['tag']}"], cwd=dest)
+    return dest
+
+
+def build_omq():
+    run(["cargo", "build", "--release", "-p", "omq-libzmq"], cwd=REPO_ROOT, timeout=180)
+    run(["zig", "build", "-Doptimize=ReleaseFast"], cwd=BINDING_DIR, timeout=120)
+
+
+def build_zzmq():
+    src = ensure_clone("zzmq")
+    work = tempfile.mkdtemp(prefix="omq-zig-zzmq-")
+    shutil.copytree(src, os.path.join(work, "zzmq"), symlinks=True)
+    patched = os.path.join(work, "zzmq", "src", "classes", "zmessage.zig")
+    with open(patched) as f:
+        content = f.read()
+    content = content.replace("callconv(.C)", "callconv(.c)")
+    with open(patched, "w") as f:
+        f.write(content)
+    out = IMPLS["zzmq"]["bench"]
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    run(
+        [
+            "zig",
+            "build-exe",
+            "-O",
+            "ReleaseFast",
+            "--dep",
+            "zzmq",
+            f"-Mroot={os.path.join(BINDING_DIR, 'scripts', 'bench', 'zzmq_bench.zig')}",
+            f"-Mzzmq={os.path.join(work, 'zzmq', 'src', 'zzmq.zig')}",
+            "-lc",
+            "-lzmq",
+            f"-femit-bin={out}",
+        ],
+        timeout=120,
+    )
+
+
+def build_zimq():
+    src = ensure_clone("zimq")
+    work = tempfile.mkdtemp(prefix="omq-zig-zimq-build-")
+    deps_dir = os.path.join(work, "deps")
+    os.makedirs(deps_dir, exist_ok=True)
+    os.symlink(src, os.path.join(deps_dir, "zimq"))
+    build_zig = f"""
+const std = @import("std");
+pub fn build(b: *std.Build) void {{
+    const target = b.standardTargetOptions(.{{}});
+    const optimize = b.standardOptimizeOption(.{{}});
+    const zimq_dep = b.dependency("zimq", .{{
+        .target = target,
+        .optimize = optimize,
+        .curve = false,
+    }});
+    const exe = b.addExecutable(.{{
+        .name = "zimq-bench",
+        .root_module = b.createModule(.{{
+            .root_source_file = .{{ .cwd_relative = "{os.path.join(BINDING_DIR, 'scripts', 'bench', 'zimq_bench.zig')}" }},
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{{ .{{ .name = "zimq", .module = zimq_dep.module("zimq") }} }},
+        }}),
+    }});
+    b.installArtifact(exe);
+}}
+"""
+    build_zon = f""".{{
+    .name = .zimq_bench,
+    .version = "0.0.0",
+    .fingerprint = 0xaef28a37f715d243,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{{
+        .zimq = .{{ .path = "deps/zimq" }},
+    }},
+    .paths = .{{ "build.zig" }},
+}}
+"""
+    with open(os.path.join(work, "build.zig"), "w") as f:
+        f.write(build_zig)
+    with open(os.path.join(work, "build.zig.zon"), "w") as f:
+        f.write(build_zon)
+    run(["zig", "build", "-Doptimize=ReleaseFast", "--prefix", CACHE_DIR], cwd=work, timeout=240)
+
+
+def build_impls(impls):
+    for impl in impls:
+        print(f"building {impl}...")
+        if impl == "omq.zig":
+            build_omq()
+        elif impl == "zzmq":
+            build_zzmq()
+        elif impl == "zimq":
+            build_zimq()
+
+
+def load_jsonl():
+    rows = []
+    try:
+        with open(JSONL_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return rows
+
+
+def append_jsonl(rows):
+    os.makedirs(os.path.dirname(JSONL_FILE), exist_ok=True)
+    with open(JSONL_FILE, "a") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def latency_sizes_from(sizes):
+    return [size for size in sizes if size <= LATENCY_MAX_SIZE]
+
+
+def median(values, key=lambda value: value):
+    ordered = sorted(values, key=key)
+    return ordered[len(ordered) // 2]
+
+
+def fmt_rate(rate):
+    if rate >= 1_000_000:
+        return f"{rate / 1_000_000:.2f} M/s"
+    return f"{rate / 1_000:.0f} k/s"
+
+
+def fmt_size(size):
+    if size >= 1024:
+        return f"{size // 1024} KiB"
+    return f"{size} B"
+
+
+def run_bench(exe, args, timeout):
+    r = run([exe, *args], timeout=timeout)
+    return float(r.stdout.strip())
+
+
+def free_tcp_endpoint():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    finally:
+        sock.close()
+    return f"tcp://127.0.0.1:{port}"
+
+
+def _fail_process(proc):
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def run_throughput_tcp(exe, size, duration):
+    push_proc = subprocess.Popen(
+        [exe, "throughput-push", str(size), str(duration)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+    assert push_proc.stdout is not None
+    assert push_proc.stderr is not None
+    assert push_proc.stdin is not None
+    try:
+        ready, _, _ = select.select([push_proc.stdout], [], [], SUBPROCESS_TIMEOUT_S)
+        if not ready:
+            _fail_process(push_proc)
+            raise RuntimeError(f"{exe} throughput-push {size}B timed out before endpoint")
+        endpoint = push_proc.stdout.readline().strip()
+        if not endpoint:
+            _, stderr = push_proc.communicate(timeout=5)
+            raise RuntimeError(f"{exe} throughput-push {size}B failed:\n{stderr}")
+
+        pull = run(
+            [exe, "throughput-pull", endpoint, str(size)],
+            timeout=SUBPROCESS_TIMEOUT_S,
+        )
+        return float(pull.stdout.strip())
+    finally:
+        try:
+            push_proc.stdin.write("\n")
+            push_proc.stdin.flush()
+        except OSError:
+            pass
+        try:
+            stdout, stderr = push_proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            _fail_process(push_proc)
+            raise RuntimeError(f"{exe} throughput-push {size}B did not exit")
+        if push_proc.returncode != 0:
+            raise RuntimeError(f"{exe} throughput-push {size}B failed:\n{stdout}{stderr}")
+        if "warning:" in stdout.lower() or "warning:" in stderr.lower():
+            raise RuntimeError(f"{exe} throughput-push {size}B printed warning:\n{stdout}{stderr}")
+
+
+def run_throughput(impl):
+    results = []
+    exe = IMPLS[impl]["bench"]
+    for size in SIZES:
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+        runs = []
+        for _ in range(N_ROUNDS):
+            if THROUGHPUT_WARMUP_S > 0:
+                run_throughput_tcp(exe, size, THROUGHPUT_WARMUP_S)
+            runs.append(run_throughput_tcp(exe, size, TARGET_RUNTIME_S))
+        rate = median(runs)
+        results.append(rate)
+        print(f" {fmt_rate(rate):>10}")
+    return results
+
+
+def run_latency(impl):
+    results = []
+    exe = IMPLS[impl]["bench"]
+    for size in latency_sizes_from(SIZES):
+        label = fmt_size(size)
+        sys.stdout.write(f"  {label:>7} ...")
+        sys.stdout.flush()
+        runs = [
+            run_bench(
+                exe,
+                [
+                    "latency",
+                    str(size),
+                    str(LATENCY_WARMUP_S),
+                    str(LATENCY_RUNTIME_S),
+                    free_tcp_endpoint(),
+                ],
+                SUBPROCESS_TIMEOUT_S,
+            )
+            for _ in range(N_ROUNDS)
+        ]
+        p50 = median(runs)
+        results.append(p50)
+        print(f" p50 {p50:.1f} us")
+    return results
+
+
+def save_results(run_id, impl, throughput, latency):
+    rows = []
+    for i, size in enumerate(SIZES):
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "throughput",
+                "mode": "sync",
+                "transport": "tcp",
+                "msg_size": size,
+                "msgs_s": throughput[i],
+            }
+        )
+    for i, size in enumerate(latency_sizes_from(SIZES)):
+        rows.append(
+            {
+                "run_id": run_id,
+                "impl": impl,
+                "kind": "latency",
+                "mode": "sync",
+                "transport": "tcp",
+                "msg_size": size,
+                "p50_us": latency[i],
+            }
+        )
+    append_jsonl(rows)
+    print(f"  appended {len(rows)} rows to {JSONL_FILE}")
+
+
+def chart_data_from_jsonl():
+    rows = load_jsonl()
+    latest = {}
+    for r in rows:
+        key = (r.get("impl"), r.get("kind"), r.get("mode"), r.get("transport"), r.get("msg_size"))
+        prev = latest.get(key)
+        if prev is None or r.get("run_id", "") >= prev.get("run_id", ""):
+            latest[key] = r
+
+    def get_tp(impl, size):
+        r = latest.get((impl, "throughput", "sync", "tcp", size))
+        return r["msgs_s"] if r else 0.0
+
+    def get_lat(impl, size):
+        r = latest.get((impl, "latency", "sync", "tcp", size))
+        return r["p50_us"] if r else 0.0
+
+    latency_sizes = latency_sizes_from(SIZES)
+    return {
+        "throughput": {impl: [get_tp(impl, size) for size in SIZES] for impl in IMPLS},
+        "latency": {impl: [get_lat(impl, size) for size in latency_sizes] for impl in IMPLS},
+    }
+
+
+# SVG chart generation. Layout copied from bindings/pyomq/scripts/update_perf.py;
+# only series names, title text, and input data keys differ.
+
+C_OMQ = "#ef4444"
+C_ZZMQ = "#60a5fa"
+C_ZIMQ = "#a855f7"
+CHART_SERIES = [
+    ("omq.zig", C_OMQ),
+    ("zzmq", C_ZZMQ),
+    ("zimq", C_ZIMQ),
+]
+
+
+def _fmt_y_rate(val):
+    if val >= 1_000_000:
+        return f"{val / 1_000_000:g}M"
+    if val >= 1_000:
+        return f"{val / 1_000:g}k"
+    return f"{val:g}"
+
+
+def _fmt_y_us(val):
+    if val >= 1000:
+        return f"{val / 1000:g} ms"
+    return f"{val:g} us"
+
+
+def _read_chart_hw():
+    config = {}
+    path = os.path.join(REPO_ROOT, ".chart_hw")
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, sep, value = line.partition("=")
+                if sep:
+                    config[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return config
+
+
+def _detect_hardware():
+    hw_conf = _read_chart_hw()
+    prefix = os.environ.get("OMQ_HW_PREFIX") or hw_conf.get("prefix")
+    postfix = os.environ.get("OMQ_HW_POSTFIX") or hw_conf.get("postfix")
+    if prefix and postfix:
+        return f"{prefix}, {postfix}"
+    if prefix:
+        return prefix
+    if postfix:
+        return postfix
+    return None
+
+
+def _nice_ceil(v):
+    if v <= 0:
+        return 1
+    exp = math.floor(math.log10(v))
+    base = 10**exp
+    for m in [1, 2, 5, 10]:
+        candidate = m * base
+        if candidate >= v:
+            return candidate
+    return 10 * base
+
+
+def gen_combined_chart(data, path):
+    latency_sizes = latency_sizes_from(SIZES)
+    lat_n = len(latency_sizes)
+    hw_label = _detect_hardware()
+    hw_offset = 14 if hw_label else 0
+    svg_w = 850
+    svg_h = 810 + hw_offset
+    x_left, x_right = 60, 790
+    plot_w = x_right - x_left
+    top_left, top_mid, top_right = 60, 395, 790
+    top_right_left = 455
+
+    t1_top = 95 + hw_offset
+    t1_bot = 430 + hw_offset
+    t1_h = t1_bot - t1_top
+    t2_top = t1_bot + 105
+    t2_bot = t2_top + 200
+    t2_h = t2_bot - t2_top
+
+    small_sizes = [s for s in SIZES if s <= 1024]
+    large_sizes = [s for s in SIZES if s >= 256]
+    small_indices = [SIZES.index(s) for s in small_sizes]
+    large_indices = [SIZES.index(s) for s in large_sizes]
+    small_xs = [
+        top_left + i * (top_mid - top_left) / max(len(small_sizes) - 1, 1)
+        for i in range(len(small_sizes))
+    ]
+    large_xs = [
+        top_right_left + i * (top_right - top_right_left) / max(len(large_sizes) - 1, 1)
+        for i in range(len(large_sizes))
+    ]
+    lat_xs = [x_left + i * plot_w / max(lat_n - 1, 1) for i in range(lat_n)]
+    mid_x = (x_left + x_right) / 2
+
+    tp_series = [(label, color, data["throughput"][label]) for label, color in CHART_SERIES]
+    msg_max = _nice_ceil(
+        max(
+            [vals[i] for _, _, vals in tp_series for i in small_indices],
+            default=1,
+        )
+    )
+    gbs_values = [
+        vals[i] * SIZES[i] / 1_000_000_000
+        for _, _, vals in tp_series
+        for i in large_indices
+    ]
+    gbs_max = max(1, math.ceil(max(gbs_values, default=0)))
+
+    def y_msg(v):
+        frac = v / msg_max if msg_max > 0 else 0
+        return t1_bot - frac * t1_h
+
+    def y_gbs(v):
+        frac = v / gbs_max if gbs_max > 0 else 0
+        return t1_bot - frac * t1_h
+
+    lat_values = [v for values in data["latency"].values() for v in values]
+    lat_max = _nice_ceil(max(lat_values, default=1))
+    if lat_max < 100:
+        lat_step = 10
+    else:
+        lat_step = max(10, lat_max // 10)
+
+    def y_lat(v):
+        return t2_bot - (v / lat_max) * t2_h
+
+    L = []
+    L.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {svg_w} {svg_h}"'
+        f' font-family="system-ui, -apple-system, sans-serif">'
+    )
+    L.append(f'  <rect width="{svg_w}" height="{svg_h}" fill="#000000"/>')
+
+    # TOP PANEL: THROUGHPUT
+
+    L.append(
+        f'  <text x="{mid_x}" y="{t1_top - 65}" text-anchor="middle" fill="#f9fafb"'
+        f' font-size="13" font-weight="700">'
+        f"PUSH/PULL throughput: 2-process, TCP loopback (higher is better)</text>"
+    )
+    if hw_label:
+        L.append(
+            f'  <text x="{mid_x}" y="{t1_top - 51}" text-anchor="middle"'
+            f' fill="#9ca3af" font-size="10">{hw_label}</text>'
+        )
+
+    left_ticks = [msg_max * i / 5 for i in range(1, 6)]
+    right_ticks = [i / 2 for i in range(1, int(gbs_max * 2) + 1)]
+    for panel_left, panel_right, panel_xs, ticks, panel_max, formatter, label_x in (
+        (top_left, top_mid, small_xs, left_ticks, msg_max, _fmt_y_rate, top_left - 8),
+        (
+            top_right_left,
+            top_right,
+            large_xs,
+            right_ticks,
+            gbs_max,
+            lambda value: f"{value:g} GB/s",
+            top_right + 8,
+        ),
+    ):
+        for tick in ticks:
+            yy = t1_bot - (tick / panel_max) * t1_h
+            L.append(
+                f'  <line x1="{panel_left}" y1="{yy:.1f}" x2="{panel_right}" y2="{yy:.1f}" stroke="#374151" stroke-width="1"/>'
+            )
+            anchor = "end" if label_x < panel_left else "start"
+            L.append(
+                f'  <text x="{label_x}" y="{yy:.1f}" text-anchor="{anchor}" dominant-baseline="middle" fill="#e5e7eb" font-size="10">{formatter(tick)}</text>'
+            )
+        for x in panel_xs:
+            L.append(
+                f'  <line x1="{x:.1f}" y1="{t1_top}" x2="{x:.1f}" y2="{t1_bot}" stroke="#374151" stroke-width="1"/>'
+            )
+        if panel_left == top_left:
+            L.append(
+                f'  <line x1="{panel_left}" y1="{t1_top}" x2="{panel_left}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+            )
+        if panel_right == top_right:
+            L.append(
+                f'  <line x1="{panel_right}" y1="{t1_top}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+            )
+        L.append(
+            f'  <line x1="{panel_left}" y1="{t1_bot}" x2="{panel_right}" y2="{t1_bot}" stroke="#9ca3af" stroke-width="1.5"/>'
+        )
+
+    L.append(
+        f'  <text x="{(top_left + top_mid) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>'
+    )
+    L.append(
+        f'  <text x="{(top_right_left + top_right) / 2:.1f}" y="{t1_top - 17}" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>'
+    )
+
+    for _, color, vals in tp_series:
+        pts = " ".join(
+            f"{small_xs[j]:.1f},{y_msg(vals[i]):.1f}"
+            for j, i in enumerate(small_indices)
+        )
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2" stroke-dasharray="6,4"/>'
+        )
+
+    for _, color, vals in tp_series:
+        gbs = [vals[i] * SIZES[i] / 1e9 for i in large_indices]
+        pts = " ".join(f"{large_xs[j]:.1f},{y_gbs(v):.1f}" for j, v in enumerate(gbs))
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for j, v in enumerate(gbs):
+            yy = y_gbs(v)
+            L.append(
+                f'  <circle cx="{large_xs[j]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
+            )
+
+    for i, size in enumerate(small_sizes):
+        L.append(
+            f'  <text x="{small_xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
+        )
+    for i, size in enumerate(large_sizes):
+        L.append(
+            f'  <text x="{large_xs[i]:.1f}" y="{t1_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(size)}</text>'
+        )
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{t1_bot + 32}" text-anchor="middle" fill="#9ca3af" font-size="9">dashed = message rate - solid = bandwidth</text>'
+    )
+
+    # BOTTOM PANEL: LATENCY
+
+    L.append(
+        f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
+        f' font-size="13" font-weight="700">'
+        f"REQ/REP latency: TCP loopback, p50 us (lower is better)</text>"
+    )
+
+    for v in range(int(lat_step), int(lat_max) + 1, int(lat_step)):
+        yy = y_lat(v)
+        L.append(
+            f'  <line x1="{x_left}" y1="{yy:.1f}" x2="{x_right}" y2="{yy:.1f}"'
+            f' stroke="#374151" stroke-width="1"/>'
+        )
+        L.append(
+            f'  <text x="{x_left - 8}" y="{yy:.1f}" text-anchor="end"'
+            f' dominant-baseline="middle" fill="#e5e7eb" font-size="10">'
+            f"{_fmt_y_us(v)}</text>"
+        )
+
+    for x in lat_xs:
+        L.append(
+            f'  <line x1="{x:.1f}" y1="{t2_top}" x2="{x:.1f}" y2="{t2_bot}"'
+            f' stroke="#374151" stroke-width="1"/>'
+        )
+
+    L.append(f'  <line x1="{x_left}" y1="{t2_top}" x2="{x_left}" y2="{t2_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+    L.append(f'  <line x1="{x_left}" y1="{t2_bot}" x2="{x_right}" y2="{t2_bot}" stroke="#9ca3af" stroke-width="1.5"/>')
+
+    for label, color in CHART_SERIES:
+        vals = data["latency"][label]
+        pts = " ".join(f"{lat_xs[i]:.1f},{y_lat(v):.1f}" for i, v in enumerate(vals))
+        L.append(
+            f'  <polyline points="{pts}" fill="none" stroke="{color}"'
+            f' stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+        )
+        for i, v in enumerate(vals):
+            yy = y_lat(v)
+            L.append(
+                f'  <circle cx="{lat_xs[i]:.1f}" cy="{yy:.1f}" r="3"'
+                f' fill="{color}" stroke="#000000" stroke-width="1"/>'
+            )
+
+    for i in range(lat_n):
+        L.append(
+            f'  <text x="{lat_xs[i]:.1f}" y="{t2_bot + 14}" text-anchor="middle"'
+            f' fill="#e5e7eb" font-size="8.5">{fmt_size(latency_sizes[i])}</text>'
+        )
+
+    # LEGEND
+
+    leg_y = t2_bot + 40
+    item_w = 120
+    total_w = len(CHART_SERIES) * item_w
+    start_x = mid_x - total_w / 2
+
+    for idx, (label, color) in enumerate(CHART_SERIES):
+        lx = start_x + idx * item_w
+        L.append(
+            f'  <line x1="{lx:.0f}" y1="{leg_y}" x2="{lx + 14:.0f}" y2="{leg_y}"'
+            f' stroke="{color}" stroke-width="2.5"/>'
+        )
+        L.append(f'  <circle cx="{lx + 7:.0f}" cy="{leg_y}" r="2.5" fill="{color}"/>')
+        L.append(
+            f'  <text x="{lx + 20:.0f}" y="{leg_y + 4}" fill="#e5e7eb"'
+            f' font-size="11" font-weight="500">{label}</text>'
+        )
+
+    footer_y = leg_y + 18
+    L.append(
+        f'  <text x="{mid_x:.1f}" y="{footer_y}" text-anchor="middle"'
+        f' fill="#9ca3af" font-size="9">'
+        f"dashed = msg/s (left) - solid = throughput (right)</text>"
+    )
+
+    L.append("</svg>")
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("\n".join(L))
+        f.write("\n")
+    print(f"  wrote {path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--impl", action="append", dest="impls", choices=list(IMPLS), help="implementation(s) to benchmark")
+    parser.add_argument("--quick", action="store_true", help="run a short local-only benchmark")
+    parser.add_argument("--sizes", type=parse_sizes, help="comma-separated message sizes, e.g. 8,128,1k,32k")
+    parser.add_argument("--rounds", type=int, help="measured rounds per cell")
+    parser.add_argument("--target-runtime", type=float, help="throughput runtime per round in seconds")
+    parser.add_argument("--warmup-duration", type=float, help="throughput warmup duration per round in seconds")
+    parser.add_argument("--latency-warmup-duration", type=float, help="REQ/REP latency warmup duration in seconds")
+    parser.add_argument("--latency-duration", type=float, help="REQ/REP latency duration in seconds")
+    parser.add_argument("--timeout", type=float, help="subprocess timeout in seconds")
+    parser.add_argument("--no-save", action="store_true", help="print results without appending JSONL")
+    parser.add_argument("--no-chart", action="store_true", help="skip SVG generation")
+    parser.add_argument("--no-build", action="store_true", help="skip harness builds")
+    parser.add_argument("--chart-only", action="store_true", help="regenerate SVG from existing JSONL")
+    args = parser.parse_args()
+
+    if args.chart_only:
+        data = chart_data_from_jsonl()
+        gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
+        return
+
+    configure_benchmark(args)
+    impls = args.impls or list(IMPLS)
+    diagnostic_knobs = any(
+        value is not None
+        for value in (
+            args.sizes,
+            args.rounds,
+            args.target_runtime,
+            args.warmup_duration,
+            args.latency_warmup_duration,
+            args.latency_duration,
+            args.timeout,
+        )
+    )
+    save_enabled = not args.no_save and not args.quick and not diagnostic_knobs
+
+    if not args.no_build:
+        build_impls(impls)
+
+    run_id = time.strftime("%Y-%m-%dT%H:%M:%S")
+    for impl in impls:
+        print(f"\n{'=' * 40}")
+        print(f"Benchmarking {impl}")
+        print(f"{'=' * 40}")
+        print(f"\n{impl} TCP PUSH/PULL throughput...")
+        throughput = run_throughput(impl)
+        print(f"\n{impl} TCP REQ/REP latency...")
+        latency = run_latency(impl)
+        if save_enabled:
+            save_results(run_id, impl, throughput, latency)
+
+    if not save_enabled:
+        print("\nSkipping JSONL and chart updates.")
+        return
+    if not args.no_chart:
+        print("\nGenerating chart...")
+        data = chart_data_from_jsonl()
+        gen_combined_chart(data, os.path.join(CHART_DIR, "bindings.svg"))
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/zig/scripts/update_perf.py
+++ b/bindings/zig/scripts/update_perf.py
@@ -11,7 +11,6 @@ import math
 import os
 import select
 import shutil
-import socket
 import subprocess
 import sys
 import tempfile
@@ -20,6 +19,10 @@ import time
 DEFAULT_SIZES = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
 QUICK_SIZES = [16, 128, 1024, 4096, 32768]
 LATENCY_MAX_SIZE = 4096
+THROUGHPUT_MSG_MAX = 12_000_000
+THROUGHPUT_MSG_STEP = 2_000_000
+LATENCY_US_MAX = 120
+LATENCY_US_STEP = 20
 SIZES = DEFAULT_SIZES.copy()
 TARGET_RUNTIME_S = 2.5
 THROUGHPUT_WARMUP_S = 0.5
@@ -165,41 +168,43 @@ def build_omq():
 
 def build_zzmq():
     src = ensure_clone("zzmq")
-    work = tempfile.mkdtemp(prefix="omq-zig-zzmq-")
-    shutil.copytree(src, os.path.join(work, "zzmq"), symlinks=True)
-    patched = os.path.join(work, "zzmq", "src", "classes", "zmessage.zig")
-    with open(patched) as f:
-        content = f.read()
-    content = content.replace("callconv(.C)", "callconv(.c)")
-    with open(patched, "w") as f:
-        f.write(content)
-    out = IMPLS["zzmq"]["bench"]
-    os.makedirs(os.path.dirname(out), exist_ok=True)
-    run(
-        [
-            "zig",
-            "build-exe",
-            "-O",
-            "ReleaseFast",
-            "--dep",
-            "zzmq",
-            f"-Mroot={os.path.join(BINDING_DIR, 'scripts', 'bench', 'zzmq_bench.zig')}",
-            f"-Mzzmq={os.path.join(work, 'zzmq', 'src', 'zzmq.zig')}",
-            "-lc",
-            "-lzmq",
-            f"-femit-bin={out}",
-        ],
-        timeout=120,
-    )
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="zzmq-", dir=CACHE_DIR) as work:
+        shutil.copytree(src, os.path.join(work, "zzmq"), symlinks=True)
+        patched = os.path.join(work, "zzmq", "src", "classes", "zmessage.zig")
+        with open(patched) as f:
+            content = f.read()
+        content = content.replace("callconv(.C)", "callconv(.c)")
+        with open(patched, "w") as f:
+            f.write(content)
+        out = IMPLS["zzmq"]["bench"]
+        os.makedirs(os.path.dirname(out), exist_ok=True)
+        run(
+            [
+                "zig",
+                "build-exe",
+                "-O",
+                "ReleaseFast",
+                "--dep",
+                "zzmq",
+                f"-Mroot={os.path.join(BINDING_DIR, 'scripts', 'bench', 'zzmq_bench.zig')}",
+                f"-Mzzmq={os.path.join(work, 'zzmq', 'src', 'zzmq.zig')}",
+                "-lc",
+                "-lzmq",
+                f"-femit-bin={out}",
+            ],
+            timeout=120,
+        )
 
 
 def build_zimq():
     src = ensure_clone("zimq")
-    work = tempfile.mkdtemp(prefix="omq-zig-zimq-build-")
-    deps_dir = os.path.join(work, "deps")
-    os.makedirs(deps_dir, exist_ok=True)
-    os.symlink(src, os.path.join(deps_dir, "zimq"))
-    build_zig = f"""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="zimq-build-", dir=CACHE_DIR) as work:
+        deps_dir = os.path.join(work, "deps")
+        os.makedirs(deps_dir, exist_ok=True)
+        os.symlink(src, os.path.join(deps_dir, "zimq"))
+        build_zig = f"""
 const std = @import("std");
 pub fn build(b: *std.Build) void {{
     const target = b.standardTargetOptions(.{{}});
@@ -221,7 +226,7 @@ pub fn build(b: *std.Build) void {{
     b.installArtifact(exe);
 }}
 """
-    build_zon = f""".{{
+        build_zon = f""".{{
     .name = .zimq_bench,
     .version = "0.0.0",
     .fingerprint = 0xaef28a37f715d243,
@@ -232,11 +237,11 @@ pub fn build(b: *std.Build) void {{
     .paths = .{{ "build.zig" }},
 }}
 """
-    with open(os.path.join(work, "build.zig"), "w") as f:
-        f.write(build_zig)
-    with open(os.path.join(work, "build.zig.zon"), "w") as f:
-        f.write(build_zon)
-    run(["zig", "build", "-Doptimize=ReleaseFast", "--prefix", CACHE_DIR], cwd=work, timeout=240)
+        with open(os.path.join(work, "build.zig"), "w") as f:
+            f.write(build_zig)
+        with open(os.path.join(work, "build.zig.zon"), "w") as f:
+            f.write(build_zon)
+        run(["zig", "build", "-Doptimize=ReleaseFast", "--prefix", CACHE_DIR], cwd=work, timeout=240)
 
 
 def build_impls(impls):
@@ -296,16 +301,6 @@ def run_bench(exe, args, timeout):
     return float(r.stdout.strip())
 
 
-def free_tcp_endpoint():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-    finally:
-        sock.close()
-    return f"tcp://127.0.0.1:{port}"
-
-
 def _fail_process(proc):
     try:
         proc.kill()
@@ -360,6 +355,42 @@ def run_throughput_tcp(exe, size, duration):
             raise RuntimeError(f"{exe} throughput-push {size}B printed warning:\n{stdout}{stderr}")
 
 
+def run_latency_tcp(exe, size, warmup_s, duration_s):
+    rep_proc = subprocess.Popen(
+        [exe, "latency-rep", str(size)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert rep_proc.stdout is not None
+    assert rep_proc.stderr is not None
+    try:
+        ready, _, _ = select.select([rep_proc.stdout], [], [], SUBPROCESS_TIMEOUT_S)
+        if not ready:
+            _fail_process(rep_proc)
+            raise RuntimeError(f"{exe} latency-rep {size}B timed out before endpoint")
+        endpoint = rep_proc.stdout.readline().strip()
+        if not endpoint:
+            _, stderr = rep_proc.communicate(timeout=5)
+            raise RuntimeError(f"{exe} latency-rep {size}B failed:\n{stderr}")
+
+        req = run(
+            [exe, "latency", str(size), str(warmup_s), str(duration_s), endpoint],
+            timeout=SUBPROCESS_TIMEOUT_S,
+        )
+        return float(req.stdout.strip())
+    finally:
+        try:
+            stdout, stderr = rep_proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            _fail_process(rep_proc)
+            raise RuntimeError(f"{exe} latency-rep {size}B did not exit")
+        if rep_proc.returncode != 0:
+            raise RuntimeError(f"{exe} latency-rep {size}B failed:\n{stdout}{stderr}")
+        if "warning:" in stdout.lower() or "warning:" in stderr.lower():
+            raise RuntimeError(f"{exe} latency-rep {size}B printed warning:\n{stdout}{stderr}")
+
+
 def run_throughput(impl):
     results = []
     exe = IMPLS[impl]["bench"]
@@ -386,17 +417,7 @@ def run_latency(impl):
         sys.stdout.write(f"  {label:>7} ...")
         sys.stdout.flush()
         runs = [
-            run_bench(
-                exe,
-                [
-                    "latency",
-                    str(size),
-                    str(LATENCY_WARMUP_S),
-                    str(LATENCY_RUNTIME_S),
-                    free_tcp_endpoint(),
-                ],
-                SUBPROCESS_TIMEOUT_S,
-            )
+            run_latency_tcp(exe, size, LATENCY_WARMUP_S, LATENCY_RUNTIME_S)
             for _ in range(N_ROUNDS)
         ]
         p50 = median(runs)
@@ -483,7 +504,7 @@ def _fmt_y_rate(val):
 def _fmt_y_us(val):
     if val >= 1000:
         return f"{val / 1000:g} ms"
-    return f"{val:g} us"
+    return f"{val:g} μs"
 
 
 def _read_chart_hw():
@@ -563,12 +584,7 @@ def gen_combined_chart(data, path):
     mid_x = (x_left + x_right) / 2
 
     tp_series = [(label, color, data["throughput"][label]) for label, color in CHART_SERIES]
-    msg_max = _nice_ceil(
-        max(
-            [vals[i] for _, _, vals in tp_series for i in small_indices],
-            default=1,
-        )
-    )
+    msg_max = THROUGHPUT_MSG_MAX
     gbs_values = [
         vals[i] * SIZES[i] / 1_000_000_000
         for _, _, vals in tp_series
@@ -584,15 +600,11 @@ def gen_combined_chart(data, path):
         frac = v / gbs_max if gbs_max > 0 else 0
         return t1_bot - frac * t1_h
 
-    lat_values = [v for values in data["latency"].values() for v in values]
-    lat_max = _nice_ceil(max(lat_values, default=1))
-    if lat_max < 100:
-        lat_step = 10
-    else:
-        lat_step = max(10, lat_max // 10)
+    lat_max = LATENCY_US_MAX
+    lat_step = LATENCY_US_STEP
 
     def y_lat(v):
-        return t2_bot - (v / lat_max) * t2_h
+        return t2_bot - (min(v, lat_max) / lat_max) * t2_h
 
     L = []
     L.append(
@@ -614,7 +626,7 @@ def gen_combined_chart(data, path):
             f' fill="#9ca3af" font-size="10">{hw_label}</text>'
         )
 
-    left_ticks = [msg_max * i / 5 for i in range(1, 6)]
+    left_ticks = list(range(THROUGHPUT_MSG_STEP, THROUGHPUT_MSG_MAX + 1, THROUGHPUT_MSG_STEP))
     right_ticks = [i / 2 for i in range(1, int(gbs_max * 2) + 1)]
     for panel_left, panel_right, panel_xs, ticks, panel_max, formatter, label_x in (
         (top_left, top_mid, small_xs, left_ticks, msg_max, _fmt_y_rate, top_left - 8),
@@ -703,7 +715,7 @@ def gen_combined_chart(data, path):
     L.append(
         f'  <text x="{mid_x}" y="{t2_top - 17}" text-anchor="middle" fill="#f9fafb"'
         f' font-size="13" font-weight="700">'
-        f"REQ/REP latency: TCP loopback, p50 us (lower is better)</text>"
+        f"REQ/REP latency: TCP loopback, p50 μs (lower is better)</text>"
     )
 
     for v in range(int(lat_step), int(lat_max) + 1, int(lat_step)):

--- a/bindings/zig/src/omq.zig
+++ b/bindings/zig/src/omq.zig
@@ -1,0 +1,972 @@
+//! Zig binding for OMQ through the libzmq-compatible C ABI.
+//!
+//! The API follows pyomq names where they make sense in Zig while keeping
+//! allocator ownership explicit. Data returned from receive calls is owned by
+//! the caller and must be freed with the same allocator.
+
+const std = @import("std");
+
+/// Raw libzmq-compatible C ABI imported from `omq-libzmq/include/zmq.h`.
+pub const c = @cImport({
+    @cInclude("zmq.h");
+});
+
+pub const PAIR = c.ZMQ_PAIR;
+pub const PUB = c.ZMQ_PUB;
+pub const SUB = c.ZMQ_SUB;
+pub const REQ = c.ZMQ_REQ;
+pub const REP = c.ZMQ_REP;
+pub const DEALER = c.ZMQ_DEALER;
+pub const ROUTER = c.ZMQ_ROUTER;
+pub const PULL = c.ZMQ_PULL;
+pub const PUSH = c.ZMQ_PUSH;
+pub const XPUB = c.ZMQ_XPUB;
+pub const XSUB = c.ZMQ_XSUB;
+pub const STREAM = c.ZMQ_STREAM;
+pub const SERVER = c.ZMQ_SERVER;
+pub const CLIENT = c.ZMQ_CLIENT;
+pub const RADIO = c.ZMQ_RADIO;
+pub const DISH = c.ZMQ_DISH;
+pub const GATHER = c.ZMQ_GATHER;
+pub const SCATTER = c.ZMQ_SCATTER;
+pub const PEER = c.ZMQ_PEER;
+pub const CHANNEL = c.ZMQ_CHANNEL;
+
+pub const DONTWAIT = c.ZMQ_DONTWAIT;
+pub const NOBLOCK = c.ZMQ_NOBLOCK;
+pub const SNDMORE = c.ZMQ_SNDMORE;
+
+pub const SUBSCRIBE = c.ZMQ_SUBSCRIBE;
+pub const UNSUBSCRIBE = c.ZMQ_UNSUBSCRIBE;
+pub const RCVMORE = c.ZMQ_RCVMORE;
+pub const TYPE = c.ZMQ_TYPE;
+pub const LINGER = c.ZMQ_LINGER;
+pub const SNDHWM = c.ZMQ_SNDHWM;
+pub const RCVHWM = c.ZMQ_RCVHWM;
+pub const RCVTIMEO = c.ZMQ_RCVTIMEO;
+pub const SNDTIMEO = c.ZMQ_SNDTIMEO;
+pub const SNDBUF = c.ZMQ_SNDBUF;
+pub const RCVBUF = c.ZMQ_RCVBUF;
+pub const FD = c.ZMQ_FD;
+pub const EVENTS = c.ZMQ_EVENTS;
+pub const LAST_ENDPOINT = c.ZMQ_LAST_ENDPOINT;
+pub const ROUTER_MANDATORY = c.ZMQ_ROUTER_MANDATORY;
+pub const IDENTITY = c.ZMQ_IDENTITY;
+pub const ROUTING_ID = c.ZMQ_ROUTING_ID;
+pub const HEARTBEAT_IVL = c.ZMQ_HEARTBEAT_IVL;
+pub const HEARTBEAT_TTL = c.ZMQ_HEARTBEAT_TTL;
+pub const HEARTBEAT_TIMEOUT = c.ZMQ_HEARTBEAT_TIMEOUT;
+pub const HANDSHAKE_IVL = c.ZMQ_HANDSHAKE_IVL;
+pub const MAXMSGSIZE = c.ZMQ_MAXMSGSIZE;
+pub const CONFLATE = c.ZMQ_CONFLATE;
+pub const TCP_KEEPALIVE = c.ZMQ_TCP_KEEPALIVE;
+pub const TCP_KEEPALIVE_IDLE = c.ZMQ_TCP_KEEPALIVE_IDLE;
+pub const TCP_KEEPALIVE_INTVL = c.ZMQ_TCP_KEEPALIVE_INTVL;
+pub const TCP_KEEPALIVE_CNT = c.ZMQ_TCP_KEEPALIVE_CNT;
+pub const CURVE_SERVER = c.ZMQ_CURVE_SERVER;
+pub const CURVE_PUBLICKEY = c.ZMQ_CURVE_PUBLICKEY;
+pub const CURVE_SECRETKEY = c.ZMQ_CURVE_SECRETKEY;
+pub const CURVE_SERVERKEY = c.ZMQ_CURVE_SERVERKEY;
+pub const PLAIN_SERVER = c.ZMQ_PLAIN_SERVER;
+pub const PLAIN_USERNAME = c.ZMQ_PLAIN_USERNAME;
+pub const PLAIN_PASSWORD = c.ZMQ_PLAIN_PASSWORD;
+pub const AFFINITY = c.ZMQ_AFFINITY;
+pub const BACKLOG = c.ZMQ_BACKLOG;
+pub const IMMEDIATE = c.ZMQ_IMMEDIATE;
+pub const IPV6 = c.ZMQ_IPV6;
+pub const IPV4ONLY = c.ZMQ_IPV4ONLY;
+pub const RATE = c.ZMQ_RATE;
+pub const RECOVERY_IVL = c.ZMQ_RECOVERY_IVL;
+pub const MULTICAST_HOPS = c.ZMQ_MULTICAST_HOPS;
+pub const XPUB_VERBOSE = c.ZMQ_XPUB_VERBOSE;
+pub const XPUB_NODROP = c.ZMQ_XPUB_NODROP;
+pub const MECHANISM = c.ZMQ_MECHANISM;
+pub const PROBE_ROUTER = c.ZMQ_PROBE_ROUTER;
+pub const REQ_CORRELATE = c.ZMQ_REQ_CORRELATE;
+pub const REQ_RELAXED = c.ZMQ_REQ_RELAXED;
+pub const ZAP_DOMAIN = c.ZMQ_ZAP_DOMAIN;
+pub const ROUTER_HANDOVER = c.ZMQ_ROUTER_HANDOVER;
+pub const CONNECT_TIMEOUT = c.ZMQ_CONNECT_TIMEOUT;
+pub const RECONNECT_IVL = c.ZMQ_RECONNECT_IVL;
+pub const RECONNECT_IVL_MAX = c.ZMQ_RECONNECT_IVL_MAX;
+pub const RECONNECT_STOP = c.ZMQ_RECONNECT_STOP;
+pub const TCP_MAXRT = c.ZMQ_TCP_MAXRT;
+pub const OMQ_ON_MUTE = c.OMQ_ON_MUTE;
+pub const OMQ_COMPRESSION_LEVEL = c.OMQ_COMPRESSION_LEVEL;
+pub const OMQ_COMPRESSION_DICT = c.OMQ_COMPRESSION_DICT;
+pub const OMQ_COMPRESSION_AUTO_TRAIN = c.OMQ_COMPRESSION_AUTO_TRAIN;
+pub const OMQ_ARENA_THRESHOLD = c.OMQ_ARENA_THRESHOLD;
+pub const OMQ_ON_MUTE_BLOCK = c.OMQ_ON_MUTE_BLOCK;
+pub const OMQ_ON_MUTE_DROP_NEWEST = c.OMQ_ON_MUTE_DROP_NEWEST;
+pub const OMQ_ON_MUTE_DROP_OLDEST = c.OMQ_ON_MUTE_DROP_OLDEST;
+
+pub const POLLIN = c.ZMQ_POLLIN;
+pub const POLLOUT = c.ZMQ_POLLOUT;
+pub const POLLERR = c.ZMQ_POLLERR;
+pub const POLLPRI = c.ZMQ_POLLPRI;
+
+pub const NULL = c.ZMQ_NULL;
+pub const PLAIN = c.ZMQ_PLAIN;
+pub const CURVE = c.ZMQ_CURVE;
+
+pub const EVENT_CONNECTED = c.ZMQ_EVENT_CONNECTED;
+pub const EVENT_CONNECT_DELAYED = c.ZMQ_EVENT_CONNECT_DELAYED;
+pub const EVENT_CONNECT_RETRIED = c.ZMQ_EVENT_CONNECT_RETRIED;
+pub const EVENT_LISTENING = c.ZMQ_EVENT_LISTENING;
+pub const EVENT_BIND_FAILED = c.ZMQ_EVENT_BIND_FAILED;
+pub const EVENT_ACCEPTED = c.ZMQ_EVENT_ACCEPTED;
+pub const EVENT_ACCEPT_FAILED = c.ZMQ_EVENT_ACCEPT_FAILED;
+pub const EVENT_CLOSED = c.ZMQ_EVENT_CLOSED;
+pub const EVENT_CLOSE_FAILED = c.ZMQ_EVENT_CLOSE_FAILED;
+pub const EVENT_DISCONNECTED = c.ZMQ_EVENT_DISCONNECTED;
+pub const EVENT_MONITOR_STOPPED = c.ZMQ_EVENT_MONITOR_STOPPED;
+pub const EVENT_HANDSHAKE_FAILED_NO_DETAIL = c.ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL;
+pub const EVENT_HANDSHAKE_SUCCEEDED = c.ZMQ_EVENT_HANDSHAKE_SUCCEEDED;
+pub const EVENT_HANDSHAKE_FAILED_PROTOCOL = c.ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL;
+pub const EVENT_HANDSHAKE_FAILED_AUTH = c.ZMQ_EVENT_HANDSHAKE_FAILED_AUTH;
+pub const EVENT_ALL = c.ZMQ_EVENT_ALL;
+
+pub const Error = error{
+    Again,
+    AddressInUse,
+    AddressNotAvailable,
+    ContextTerminated,
+    Fault,
+    HostUnreachable,
+    Invalid,
+    Interrupted,
+    MessageTooLarge,
+    NoSocket,
+    NotConnected,
+    Protocol,
+    TimedOut,
+    Unsupported,
+    Unroutable,
+    Unknown,
+};
+
+/// Runtime ABI version returned by `zmq_version`.
+pub const Version = struct {
+    major: i32,
+    minor: i32,
+    patch: i32,
+};
+
+/// Opaque key used to create another Zig `Context` handle for the same OMQ
+/// context.
+pub const ShareKey = struct {
+    high: u64,
+    low: u64,
+};
+
+/// Z85 CURVE public/secret keypair.
+pub const CurveKeypair = struct {
+    public: [40]u8,
+    secret: [40]u8,
+
+    pub fn publicSlice(self: *const CurveKeypair) []const u8 {
+        return self.public[0..];
+    }
+
+    pub fn secretSlice(self: *const CurveKeypair) []const u8 {
+        return self.secret[0..];
+    }
+};
+
+/// Owned message frame with pyomq-style metadata.
+///
+/// `data` and optional `group` are allocator-owned. Call `deinit` when done.
+pub const Frame = struct {
+    allocator: std.mem.Allocator,
+    data: []u8,
+    more: bool = false,
+    routing_id: u32 = 0,
+    group: ?[]u8 = null,
+
+    pub fn init(allocator: std.mem.Allocator, data: []const u8) !Frame {
+        return .{
+            .allocator = allocator,
+            .data = try allocator.dupe(u8, data),
+        };
+    }
+
+    pub fn deinit(self: *Frame) void {
+        self.allocator.free(self.data);
+        if (self.group) |group| self.allocator.free(group);
+        self.data = &.{};
+        self.group = null;
+    }
+};
+
+/// Owned multipart message.
+///
+/// Every part is allocator-owned. Call `deinit` when done.
+pub const Message = struct {
+    allocator: std.mem.Allocator,
+    parts: [][]u8,
+
+    pub fn deinit(self: *Message) void {
+        for (self.parts) |part| {
+            self.allocator.free(part);
+        }
+        self.allocator.free(self.parts);
+        self.parts = &.{};
+    }
+
+    pub fn single(self: *const Message) ?[]const u8 {
+        if (self.parts.len != 1) return null;
+        return self.parts[0];
+    }
+};
+
+/// Owned multipart message preserving per-frame metadata.
+///
+/// Every frame is allocator-owned. Call `deinit` when done.
+pub const FrameMessage = struct {
+    allocator: std.mem.Allocator,
+    frames: []Frame,
+
+    pub fn deinit(self: *FrameMessage) void {
+        for (self.frames) |*frame| {
+            frame.deinit();
+        }
+        self.allocator.free(self.frames);
+        self.frames = &.{};
+    }
+};
+
+pub const PollItem = c.zmq_pollitem_t;
+
+pub const PollEvent = struct {
+    socket: *Socket,
+    events: i16,
+};
+
+const PollRegistration = struct {
+    socket: *Socket,
+    events: i16,
+};
+
+/// Small pyomq-like poller around `zmq_poll`.
+pub const Poller = struct {
+    allocator: std.mem.Allocator,
+    registrations: std.array_list.Managed(PollRegistration),
+    items: std.array_list.Managed(PollItem),
+
+    pub fn init(allocator: std.mem.Allocator) Poller {
+        return .{
+            .allocator = allocator,
+            .registrations = .init(allocator),
+            .items = .init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *Poller) void {
+        self.items.deinit();
+        self.registrations.deinit();
+    }
+
+    pub fn register(self: *Poller, socket: *Socket, events: i16) !void {
+        for (self.registrations.items) |*entry| {
+            if (entry.socket == socket) {
+                entry.events = events;
+                return;
+            }
+        }
+        try self.registrations.append(.{ .socket = socket, .events = events });
+    }
+
+    pub fn modify(self: *Poller, socket: *Socket, events: i16) Error!void {
+        for (self.registrations.items) |*entry| {
+            if (entry.socket == socket) {
+                entry.events = events;
+                return;
+            }
+        }
+        return Error.NoSocket;
+    }
+
+    pub fn unregister(self: *Poller, socket: *Socket) Error!void {
+        for (self.registrations.items, 0..) |entry, index| {
+            if (entry.socket == socket) {
+                _ = self.registrations.orderedRemove(index);
+                return;
+            }
+        }
+        return Error.NoSocket;
+    }
+
+    pub fn pollAlloc(self: *Poller, timeout_ms: i64) ![]PollEvent {
+        self.items.clearRetainingCapacity();
+        try self.items.ensureTotalCapacity(self.registrations.items.len);
+        for (self.registrations.items) |entry| {
+            self.items.appendAssumeCapacity(try entry.socket.pollItem(entry.events));
+        }
+
+        _ = try poll(self.items.items, timeout_ms);
+
+        var events: std.array_list.Managed(PollEvent) = .init(self.allocator);
+        errdefer events.deinit();
+        for (self.registrations.items, self.items.items) |registration, item| {
+            if (item.revents != 0) {
+                try events.append(.{
+                    .socket = registration.socket,
+                    .events = item.revents,
+                });
+            }
+        }
+        return events.toOwnedSlice();
+    }
+};
+
+/// Parsed socket monitor event.
+///
+/// `endpoint` is allocator-owned. Call `deinit` when done.
+pub const MonitorEvent = struct {
+    allocator: std.mem.Allocator,
+    event: u16,
+    value: u32,
+    endpoint: []u8,
+
+    pub fn deinit(self: *MonitorEvent) void {
+        self.allocator.free(self.endpoint);
+        self.endpoint = &.{};
+    }
+};
+
+/// PAIR socket wrapper connected to a monitored socket endpoint.
+pub const Monitor = struct {
+    socket: Socket,
+
+    pub fn deinit(self: *Monitor) void {
+        self.socket.deinit();
+    }
+
+    pub fn close(self: *Monitor) Error!void {
+        try self.socket.close();
+    }
+
+    pub fn recvAlloc(self: *Monitor, allocator: std.mem.Allocator, flags: i32) !MonitorEvent {
+        const header = try self.socket.recvAlloc(allocator, flags);
+        defer allocator.free(header);
+        if (header.len < 6) return Error.Protocol;
+
+        return .{
+            .allocator = allocator,
+            .event = std.mem.readInt(u16, header[0..2], .little),
+            .value = std.mem.readInt(u32, header[2..6], .little),
+            .endpoint = try self.socket.recvAlloc(allocator, flags),
+        };
+    }
+
+    pub fn setReceiveTimeout(self: *Monitor, millis: i32) Error!void {
+        try self.socket.setReceiveTimeout(millis);
+    }
+};
+
+/// OMQ context. Owns the underlying libzmq-compatible context handle.
+pub const Context = struct {
+    raw: ?*anyopaque,
+
+    pub fn init() Error!Context {
+        return initWithIoThreads(1);
+    }
+
+    pub fn initWithIoThreads(io_threads: i32) Error!Context {
+        const ctx = c.zmq_ctx_new() orelse return mapErrno();
+        errdefer _ = c.zmq_ctx_term(ctx);
+
+        try setCtxInt(ctx, c.ZMQ_IO_THREADS, @max(io_threads, 1));
+        return .{ .raw = ctx };
+    }
+
+    pub fn deinit(self: *Context) void {
+        if (self.raw) |ctx| {
+            self.raw = null;
+            _ = c.zmq_ctx_term(ctx);
+        }
+    }
+
+    pub fn term(self: *Context) Error!void {
+        const ctx = self.raw orelse return;
+        self.raw = null;
+        try check(c.zmq_ctx_term(ctx));
+    }
+
+    pub fn shutdown(self: *Context) Error!void {
+        try check(c.zmq_ctx_shutdown(try self.ptr()));
+    }
+
+    pub fn socket(self: *Context, socket_type: i32) Error!Socket {
+        const raw = c.zmq_socket(try self.ptr(), socket_type) orelse return mapErrno();
+        return .{ .raw = raw };
+    }
+
+    pub fn shareKey(self: *Context) Error!ShareKey {
+        var high: u64 = 0;
+        var low: u64 = 0;
+        try check(c.omq_ctx_share_key(try self.ptr(), &high, &low));
+        return .{ .high = high, .low = low };
+    }
+
+    pub fn fromShareKey(key: ShareKey) Error!Context {
+        const ctx = c.omq_ctx_from_share_key(key.high, key.low) orelse return mapErrno();
+        return .{ .raw = ctx };
+    }
+
+    pub fn setInt(self: *Context, option: i32, value: i32) Error!void {
+        try setCtxInt(try self.ptr(), option, value);
+    }
+
+    pub fn getInt(self: *Context, option: i32) Error!i32 {
+        const rc = c.zmq_ctx_get(try self.ptr(), option);
+        if (rc == -1) return mapErrno();
+        return rc;
+    }
+
+    fn ptr(self: *Context) Error!*anyopaque {
+        return self.raw orelse Error.ContextTerminated;
+    }
+};
+
+/// OMQ socket. One socket should be used from one thread unless migration is
+/// explicitly enabled by `allowThreadMigration`.
+pub const Socket = struct {
+    raw: ?*anyopaque,
+
+    pub fn deinit(self: *Socket) void {
+        if (self.raw) |socket_raw| {
+            self.raw = null;
+            _ = c.zmq_close(socket_raw);
+        }
+    }
+
+    pub fn close(self: *Socket) Error!void {
+        const socket_raw = self.raw orelse return;
+        self.raw = null;
+        try check(c.zmq_close(socket_raw));
+    }
+
+    pub fn bind(self: *Socket, allocator: std.mem.Allocator, endpoint: []const u8) ![]u8 {
+        const endpoint_z = try allocator.dupeZ(u8, endpoint);
+        defer allocator.free(endpoint_z);
+        try check(c.zmq_bind(try self.ptr(), endpoint_z.ptr));
+        return try self.getLastEndpoint(allocator);
+    }
+
+    pub fn connect(self: *Socket, allocator: std.mem.Allocator, endpoint: []const u8) !void {
+        const endpoint_z = try allocator.dupeZ(u8, endpoint);
+        defer allocator.free(endpoint_z);
+        try check(c.zmq_connect(try self.ptr(), endpoint_z.ptr));
+    }
+
+    pub fn unbind(self: *Socket, allocator: std.mem.Allocator, endpoint: []const u8) !void {
+        const endpoint_z = try allocator.dupeZ(u8, endpoint);
+        defer allocator.free(endpoint_z);
+        try check(c.zmq_unbind(try self.ptr(), endpoint_z.ptr));
+    }
+
+    pub fn disconnect(self: *Socket, allocator: std.mem.Allocator, endpoint: []const u8) !void {
+        const endpoint_z = try allocator.dupeZ(u8, endpoint);
+        defer allocator.free(endpoint_z);
+        try check(c.zmq_disconnect(try self.ptr(), endpoint_z.ptr));
+    }
+
+    pub fn send(self: *Socket, data: []const u8, flags: i32) Error!usize {
+        const sent = c.zmq_send(try self.ptr(), dataPtr(data), data.len, flags);
+        if (sent == -1) return mapErrno();
+        return @intCast(sent);
+    }
+
+    pub fn sendString(self: *Socket, data: []const u8) Error!usize {
+        return self.send(data, 0);
+    }
+
+    pub fn recvInto(self: *Socket, buffer: []u8, flags: i32) Error!usize {
+        const received = c.zmq_recv(try self.ptr(), buffer.ptr, buffer.len, flags);
+        if (received == -1) return mapErrno();
+        return @intCast(received);
+    }
+
+    pub fn sendMultipart(self: *Socket, parts: []const []const u8, flags: i32) Error!void {
+        for (parts, 0..) |part, index| {
+            const more = if (index + 1 == parts.len) 0 else SNDMORE;
+            _ = try self.send(part, flags | more);
+        }
+    }
+
+    pub fn sendGroup(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        group: []const u8,
+        data: []const u8,
+        flags: i32,
+    ) !void {
+        var msg: c.zmq_msg_t = undefined;
+        try check(c.zmq_msg_init_size(&msg, data.len));
+        defer _ = c.zmq_msg_close(&msg);
+
+        const dst: [*]u8 = @ptrCast(c.zmq_msg_data(&msg).?);
+        @memcpy(dst[0..data.len], data);
+
+        const group_z = try allocator.dupeZ(u8, group);
+        defer allocator.free(group_z);
+        try check(c.zmq_msg_set_group(&msg, group_z.ptr));
+        if (c.zmq_msg_send(&msg, try self.ptr(), flags) == -1) return mapErrno();
+    }
+
+    pub fn sendFrame(self: *Socket, allocator: std.mem.Allocator, frame: *const Frame, flags: i32) !void {
+        var msg: c.zmq_msg_t = undefined;
+        try check(c.zmq_msg_init_size(&msg, frame.data.len));
+        defer _ = c.zmq_msg_close(&msg);
+
+        const dst: [*]u8 = @ptrCast(c.zmq_msg_data(&msg).?);
+        @memcpy(dst[0..frame.data.len], frame.data);
+        if (frame.routing_id != 0) {
+            try check(c.zmq_msg_set_routing_id(&msg, frame.routing_id));
+        }
+        if (frame.group) |group| {
+            const group_z = try allocator.dupeZ(u8, group);
+            defer allocator.free(group_z);
+            try check(c.zmq_msg_set_group(&msg, group_z.ptr));
+        }
+        if (c.zmq_msg_send(&msg, try self.ptr(), flags) == -1) return mapErrno();
+    }
+
+    pub fn recvAlloc(self: *Socket, allocator: std.mem.Allocator, flags: i32) ![]u8 {
+        var msg: c.zmq_msg_t = undefined;
+        try check(c.zmq_msg_init(&msg));
+        defer _ = c.zmq_msg_close(&msg);
+
+        if (c.zmq_msg_recv(&msg, try self.ptr(), flags) == -1) return mapErrno();
+
+        const len = c.zmq_msg_size(&msg);
+        const src: [*]const u8 = @ptrCast(c.zmq_msg_data(&msg).?);
+        return allocator.dupe(u8, src[0..len]);
+    }
+
+    pub fn recvFrameAlloc(self: *Socket, allocator: std.mem.Allocator, flags: i32) !Frame {
+        var msg: c.zmq_msg_t = undefined;
+        try check(c.zmq_msg_init(&msg));
+        defer _ = c.zmq_msg_close(&msg);
+
+        if (c.zmq_msg_recv(&msg, try self.ptr(), flags) == -1) return mapErrno();
+
+        const len = c.zmq_msg_size(&msg);
+        const src: [*]const u8 = @ptrCast(c.zmq_msg_data(&msg).?);
+        const data = try allocator.dupe(u8, src[0..len]);
+        errdefer allocator.free(data);
+
+        const group = c.zmq_msg_group(&msg);
+        const group_copy = if (group == null) null else try allocator.dupe(u8, std.mem.span(group));
+        errdefer if (group_copy) |owned| allocator.free(owned);
+
+        return .{
+            .allocator = allocator,
+            .data = data,
+            .more = c.zmq_msg_more(&msg) != 0,
+            .routing_id = c.zmq_msg_routing_id(&msg),
+            .group = group_copy,
+        };
+    }
+
+    pub fn recvMultipartAlloc(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        flags: i32,
+    ) !Message {
+        var parts: std.array_list.Managed([]u8) = .init(allocator);
+        errdefer {
+            for (parts.items) |part| allocator.free(part);
+            parts.deinit();
+        }
+
+        while (true) {
+            const part = try self.recvAlloc(allocator, flags);
+            errdefer allocator.free(part);
+            try parts.append(part);
+            if (try self.getInt(RCVMORE) == 0) break;
+        }
+
+        return .{
+            .allocator = allocator,
+            .parts = try parts.toOwnedSlice(),
+        };
+    }
+
+    pub fn recvMultipartFramesAlloc(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        flags: i32,
+    ) !FrameMessage {
+        var frames: std.array_list.Managed(Frame) = .init(allocator);
+        errdefer {
+            for (frames.items) |*frame| frame.deinit();
+            frames.deinit();
+        }
+
+        while (true) {
+            const frame = try self.recvFrameAlloc(allocator, flags);
+            const more = frame.more;
+            errdefer {
+                var mutable = frame;
+                mutable.deinit();
+            }
+            try frames.append(frame);
+            if (!more) break;
+        }
+
+        return .{
+            .allocator = allocator,
+            .frames = try frames.toOwnedSlice(),
+        };
+    }
+
+    pub fn subscribe(self: *Socket, prefix: []const u8) Error!void {
+        try self.setBytes(SUBSCRIBE, prefix);
+    }
+
+    pub fn unsubscribe(self: *Socket, prefix: []const u8) Error!void {
+        try self.setBytes(UNSUBSCRIBE, prefix);
+    }
+
+    pub fn join(self: *Socket, allocator: std.mem.Allocator, group: []const u8) !void {
+        const group_z = try allocator.dupeZ(u8, group);
+        defer allocator.free(group_z);
+        try check(c.zmq_join(try self.ptr(), group_z.ptr));
+    }
+
+    pub fn leave(self: *Socket, allocator: std.mem.Allocator, group: []const u8) !void {
+        const group_z = try allocator.dupeZ(u8, group);
+        defer allocator.free(group_z);
+        try check(c.zmq_leave(try self.ptr(), group_z.ptr));
+    }
+
+    pub fn setInt(self: *Socket, option: i32, value: i32) Error!void {
+        var raw_value: c_int = @intCast(value);
+        try check(c.zmq_setsockopt(
+            try self.ptr(),
+            option,
+            &raw_value,
+            @sizeOf(c_int),
+        ));
+    }
+
+    pub fn setI64(self: *Socket, option: i32, value: i64) Error!void {
+        var raw_value: i64 = value;
+        try check(c.zmq_setsockopt(
+            try self.ptr(),
+            option,
+            &raw_value,
+            @sizeOf(i64),
+        ));
+    }
+
+    pub fn setBytes(self: *Socket, option: i32, data: []const u8) Error!void {
+        try check(c.zmq_setsockopt(try self.ptr(), option, dataPtr(data), data.len));
+    }
+
+    pub fn setString(self: *Socket, allocator: std.mem.Allocator, option: i32, value: []const u8) !void {
+        const value_z = try allocator.dupeZ(u8, value);
+        defer allocator.free(value_z);
+        try check(c.zmq_setsockopt(try self.ptr(), option, value_z.ptr, value.len));
+    }
+
+    pub fn getInt(self: *Socket, option: i32) Error!i32 {
+        var value: c_int = 0;
+        var len: usize = @sizeOf(c_int);
+        try check(c.zmq_getsockopt(try self.ptr(), option, &value, &len));
+        return value;
+    }
+
+    pub fn getI64(self: *Socket, option: i32) Error!i64 {
+        var value: i64 = 0;
+        var len: usize = @sizeOf(i64);
+        try check(c.zmq_getsockopt(try self.ptr(), option, &value, &len));
+        return value;
+    }
+
+    pub fn getBytesAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
+        const buffer = try allocator.alloc(u8, capacity);
+        errdefer allocator.free(buffer);
+
+        var len = capacity;
+        try check(c.zmq_getsockopt(try self.ptr(), option, buffer.ptr, &len));
+        return try allocator.realloc(buffer, len);
+    }
+
+    pub fn getStringAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
+        const bytes = try self.getBytesAlloc(allocator, option, capacity);
+        errdefer allocator.free(bytes);
+        const end = std.mem.indexOfScalar(u8, bytes, 0) orelse bytes.len;
+        return try allocator.realloc(bytes, end);
+    }
+
+    pub fn getLastEndpoint(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        var buffer: [512]u8 = undefined;
+        var len: usize = buffer.len;
+        try check(c.zmq_getsockopt(try self.ptr(), LAST_ENDPOINT, &buffer, &len));
+        const end = std.mem.indexOfScalar(u8, buffer[0..len], 0) orelse len;
+        return allocator.dupe(u8, buffer[0..end]);
+    }
+
+    pub fn pollItem(self: *Socket, events: i16) Error!PollItem {
+        return .{
+            .socket = try self.ptr(),
+            .fd = 0,
+            .events = events,
+            .revents = 0,
+        };
+    }
+
+    pub fn setLinger(self: *Socket, millis: i32) Error!void {
+        try self.setInt(LINGER, millis);
+    }
+
+    pub fn setSendTimeout(self: *Socket, millis: i32) Error!void {
+        try self.setInt(SNDTIMEO, millis);
+    }
+
+    pub fn setReceiveTimeout(self: *Socket, millis: i32) Error!void {
+        try self.setInt(RCVTIMEO, millis);
+    }
+
+    pub fn setSendHighWaterMark(self: *Socket, value: i32) Error!void {
+        try self.setInt(SNDHWM, value);
+    }
+
+    pub fn setReceiveHighWaterMark(self: *Socket, value: i32) Error!void {
+        try self.setInt(RCVHWM, value);
+    }
+
+    pub fn setIdentity(self: *Socket, value: []const u8) Error!void {
+        try self.setBytes(IDENTITY, value);
+    }
+
+    pub fn identityAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getBytesAlloc(allocator, IDENTITY, 255);
+    }
+
+    pub fn setRouterMandatory(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(ROUTER_MANDATORY, @intFromBool(enabled));
+    }
+
+    pub fn setConflate(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(CONFLATE, @intFromBool(enabled));
+    }
+
+    pub fn setImmediate(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(IMMEDIATE, @intFromBool(enabled));
+    }
+
+    pub fn setIpv6(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(IPV6, @intFromBool(enabled));
+    }
+
+    pub fn setXpubNoDrop(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(XPUB_NODROP, @intFromBool(enabled));
+    }
+
+    pub fn setPlainServer(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(PLAIN_SERVER, @intFromBool(enabled));
+    }
+
+    pub fn setPlainClient(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        username: []const u8,
+        password: []const u8,
+    ) !void {
+        try self.setString(allocator, PLAIN_USERNAME, username);
+        try self.setString(allocator, PLAIN_PASSWORD, password);
+    }
+
+    pub fn setCurveServer(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        public_key: []const u8,
+        secret_key: []const u8,
+    ) !void {
+        try self.setInt(CURVE_SERVER, 1);
+        try self.setString(allocator, CURVE_PUBLICKEY, public_key);
+        try self.setString(allocator, CURVE_SECRETKEY, secret_key);
+    }
+
+    pub fn setCurveClient(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        public_key: []const u8,
+        secret_key: []const u8,
+        server_key: []const u8,
+    ) !void {
+        try self.setString(allocator, CURVE_PUBLICKEY, public_key);
+        try self.setString(allocator, CURVE_SECRETKEY, secret_key);
+        try self.setString(allocator, CURVE_SERVERKEY, server_key);
+    }
+
+    pub fn setOnMute(self: *Socket, mode: i32) Error!void {
+        try self.setInt(OMQ_ON_MUTE, mode);
+    }
+
+    pub fn setCompressionLevel(self: *Socket, level: i32) Error!void {
+        try self.setInt(OMQ_COMPRESSION_LEVEL, level);
+    }
+
+    pub fn setCompressionDict(self: *Socket, dict: []const u8) Error!void {
+        try self.setBytes(OMQ_COMPRESSION_DICT, dict);
+    }
+
+    pub fn compressionDictAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getBytesAlloc(allocator, OMQ_COMPRESSION_DICT, 8 * 1024);
+    }
+
+    pub fn setCompressionAutoTrain(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(OMQ_COMPRESSION_AUTO_TRAIN, @intFromBool(enabled));
+    }
+
+    pub fn setArenaThreshold(self: *Socket, bytes: i64) Error!void {
+        try self.setI64(OMQ_ARENA_THRESHOLD, bytes);
+    }
+
+    pub fn arenaThreshold(self: *Socket) Error!i64 {
+        return self.getI64(OMQ_ARENA_THRESHOLD);
+    }
+
+    pub fn allowThreadMigration(self: *Socket) Error!void {
+        try check(c.omq_socket_allow_thread_migration(try self.ptr()));
+    }
+
+    pub fn monitor(
+        self: *Socket,
+        ctx: *Context,
+        allocator: std.mem.Allocator,
+        endpoint: []const u8,
+        events: i32,
+    ) !Monitor {
+        const endpoint_z = try allocator.dupeZ(u8, endpoint);
+        defer allocator.free(endpoint_z);
+        try check(c.zmq_socket_monitor(try self.ptr(), endpoint_z.ptr, events));
+
+        var monitor_socket = try ctx.socket(PAIR);
+        errdefer monitor_socket.deinit();
+        try monitor_socket.connect(allocator, endpoint);
+        return .{ .socket = monitor_socket };
+    }
+
+    fn ptr(self: *Socket) Error!*anyopaque {
+        return self.raw orelse Error.NoSocket;
+    }
+};
+
+/// Return the libzmq-compatible ABI version exposed by OMQ.
+pub fn version() Version {
+    var major: c_int = 0;
+    var minor: c_int = 0;
+    var patch: c_int = 0;
+    c.zmq_version(&major, &minor, &patch);
+    return .{
+        .major = major,
+        .minor = minor,
+        .patch = patch,
+    };
+}
+
+/// Probe a runtime capability such as `"curve"`, `"ipc"`, or `"draft"`.
+pub fn has(allocator: std.mem.Allocator, capability: []const u8) !bool {
+    const capability_z = try allocator.dupeZ(u8, capability);
+    defer allocator.free(capability_z);
+    return c.zmq_has(capability_z.ptr) == 1;
+}
+
+/// Generate a Z85 CURVE keypair.
+pub fn curveKeypair() Error!CurveKeypair {
+    var public_z: [41]u8 = undefined;
+    var secret_z: [41]u8 = undefined;
+    try check(c.zmq_curve_keypair(&public_z, &secret_z));
+    return .{
+        .public = public_z[0..40].*,
+        .secret = secret_z[0..40].*,
+    };
+}
+
+/// Derive the Z85 public CURVE key for a Z85 secret key.
+pub fn curvePublic(allocator: std.mem.Allocator, secret: []const u8) ![40]u8 {
+    const secret_z = try allocator.dupeZ(u8, secret);
+    defer allocator.free(secret_z);
+
+    var public_z: [41]u8 = undefined;
+    try check(c.zmq_curve_public(&public_z, secret_z.ptr));
+    return public_z[0..40].*;
+}
+
+/// Poll raw `PollItem` values and return the number with events.
+pub fn poll(items: []PollItem, timeout_ms: i64) Error!usize {
+    const rc = c.zmq_poll(items.ptr, @intCast(items.len), @intCast(timeout_ms));
+    if (rc == -1) return mapErrno();
+    return @intCast(rc);
+}
+
+/// Run the built-in proxy device until interrupted or terminated.
+pub fn proxy(frontend: *Socket, backend: *Socket, capture: ?*Socket) Error!void {
+    const capture_raw = if (capture) |socket| try socket.ptr() else null;
+    try check(c.zmq_proxy(try frontend.ptr(), try backend.ptr(), capture_raw));
+}
+
+/// Run the built-in steerable proxy device.
+pub fn proxySteerable(
+    frontend: *Socket,
+    backend: *Socket,
+    capture: ?*Socket,
+    control: ?*Socket,
+) Error!void {
+    const capture_raw = if (capture) |socket| try socket.ptr() else null;
+    const control_raw = if (control) |socket| try socket.ptr() else null;
+    try check(c.zmq_proxy_steerable(try frontend.ptr(), try backend.ptr(), capture_raw, control_raw));
+}
+
+/// Return the last ABI errno for the current thread.
+pub fn lastErrno() i32 {
+    return c.zmq_errno();
+}
+
+/// Return ABI error text for an errno value.
+pub fn strerror(errnum: i32) []const u8 {
+    return std.mem.span(c.zmq_strerror(errnum));
+}
+
+fn setCtxInt(ctx: *anyopaque, option: i32, value: i32) Error!void {
+    try check(c.zmq_ctx_set(ctx, option, value));
+}
+
+fn check(rc: c_int) Error!void {
+    if (rc == -1) return mapErrno();
+}
+
+fn mapErrno() Error {
+    const errnum = c.zmq_errno();
+    if (errnum == c.EAGAIN) return Error.Again;
+    if (errnum == c.EADDRINUSE) return Error.AddressInUse;
+    if (errnum == c.EADDRNOTAVAIL) return Error.AddressNotAvailable;
+    if (errnum == c.EFAULT) return Error.Fault;
+    if (errnum == c.EINVAL) return Error.Invalid;
+    if (errnum == c.EINTR) return Error.Interrupted;
+    if (errnum == c.EMSGSIZE) return Error.MessageTooLarge;
+    if (errnum == c.ENOTCONN) return Error.NotConnected;
+    if (errnum == c.ENOTSOCK) return Error.NoSocket;
+    if (errnum == c.ENOTSUP) return Error.Unsupported;
+    if (errnum == c.ETERM) return Error.ContextTerminated;
+    if (errnum == c.ETIMEDOUT) return Error.TimedOut;
+    if (errnum == c.EFSM) return Error.Protocol;
+    if (errnum == c.EHOSTUNREACH) return Error.Unroutable;
+    if (errnum == c.ENETUNREACH) return Error.HostUnreachable;
+    return Error.Unknown;
+}
+
+fn dataPtr(data: []const u8) *const anyopaque {
+    if (data.len == 0) return "";
+    return data.ptr;
+}
+
+test {
+    _ = c.ZMQ_VERSION;
+}

--- a/bindings/zig/src/omq.zig
+++ b/bindings/zig/src/omq.zig
@@ -246,6 +246,12 @@ pub const PollEvent = struct {
     events: i16,
 };
 
+pub const BindRandomPortOptions = struct {
+    min_port: u16 = 49152,
+    max_port: u16 = 65535,
+    max_tries: usize = 100,
+};
+
 const PollRegistration = struct {
     socket: *Socket,
     events: i16,
@@ -391,6 +397,10 @@ pub const Context = struct {
         }
     }
 
+    pub fn closed(self: *const Context) bool {
+        return self.raw == null;
+    }
+
     pub fn term(self: *Context) Error!void {
         const ctx = self.raw orelse return;
         self.raw = null;
@@ -418,11 +428,11 @@ pub const Context = struct {
         return .{ .raw = ctx };
     }
 
-    pub fn setInt(self: *Context, option: i32, value: i32) Error!void {
+    fn setInt(self: *Context, option: i32, value: i32) Error!void {
         try setCtxInt(try self.ptr(), option, value);
     }
 
-    pub fn getInt(self: *Context, option: i32) Error!i32 {
+    fn getInt(self: *Context, option: i32) Error!i32 {
         const rc = c.zmq_ctx_get(try self.ptr(), option);
         if (rc == -1) return mapErrno();
         return rc;
@@ -445,6 +455,10 @@ pub const Socket = struct {
         }
     }
 
+    pub fn closed(self: *const Socket) bool {
+        return self.raw == null;
+    }
+
     pub fn close(self: *Socket) Error!void {
         const socket_raw = self.raw orelse return;
         self.raw = null;
@@ -456,6 +470,43 @@ pub const Socket = struct {
         defer allocator.free(endpoint_z);
         try check(c.zmq_bind(try self.ptr(), endpoint_z.ptr));
         return try self.getLastEndpoint(allocator);
+    }
+
+    /// Bind to a TCP port and return the selected port. Default options ask
+    /// the OS for a free port with `:0`. Custom ranges try concrete ports in
+    /// order, bounded by `max_tries`.
+    pub fn bindToRandomPort(
+        self: *Socket,
+        allocator: std.mem.Allocator,
+        addr: []const u8,
+        options: BindRandomPortOptions,
+    ) !u16 {
+        if (options.min_port > options.max_port or options.max_tries == 0) return Error.Invalid;
+
+        if (std.meta.eql(options, BindRandomPortOptions{})) {
+            const endpoint = try std.fmt.allocPrint(allocator, "{s}:0", .{addr});
+            defer allocator.free(endpoint);
+
+            const bound = try self.bind(allocator, endpoint);
+            defer allocator.free(bound);
+            return try endpointPort(bound);
+        }
+
+        const range_len = @as(usize, options.max_port - options.min_port) + 1;
+        const attempts = @min(options.max_tries, range_len);
+        for (0..attempts) |offset| {
+            const port = options.min_port + @as(u16, @intCast(offset));
+            const endpoint = try std.fmt.allocPrint(allocator, "{s}:{d}", .{ addr, port });
+            defer allocator.free(endpoint);
+
+            const bound = self.bind(allocator, endpoint) catch |err| switch (err) {
+                Error.AddressInUse => continue,
+                else => return err,
+            };
+            allocator.free(bound);
+            return port;
+        }
+        return Error.AddressInUse;
     }
 
     pub fn connect(self: *Socket, allocator: std.mem.Allocator, endpoint: []const u8) !void {
@@ -644,7 +695,7 @@ pub const Socket = struct {
         try check(c.zmq_leave(try self.ptr(), group_z.ptr));
     }
 
-    pub fn setInt(self: *Socket, option: i32, value: i32) Error!void {
+    fn setInt(self: *Socket, option: i32, value: i32) Error!void {
         var raw_value: c_int = @intCast(value);
         try check(c.zmq_setsockopt(
             try self.ptr(),
@@ -654,7 +705,7 @@ pub const Socket = struct {
         ));
     }
 
-    pub fn setI64(self: *Socket, option: i32, value: i64) Error!void {
+    fn setI64(self: *Socket, option: i32, value: i64) Error!void {
         var raw_value: i64 = value;
         try check(c.zmq_setsockopt(
             try self.ptr(),
@@ -664,31 +715,31 @@ pub const Socket = struct {
         ));
     }
 
-    pub fn setBytes(self: *Socket, option: i32, data: []const u8) Error!void {
+    fn setBytes(self: *Socket, option: i32, data: []const u8) Error!void {
         try check(c.zmq_setsockopt(try self.ptr(), option, dataPtr(data), data.len));
     }
 
-    pub fn setString(self: *Socket, allocator: std.mem.Allocator, option: i32, value: []const u8) !void {
+    fn setString(self: *Socket, allocator: std.mem.Allocator, option: i32, value: []const u8) !void {
         const value_z = try allocator.dupeZ(u8, value);
         defer allocator.free(value_z);
         try check(c.zmq_setsockopt(try self.ptr(), option, value_z.ptr, value.len));
     }
 
-    pub fn getInt(self: *Socket, option: i32) Error!i32 {
+    fn getInt(self: *Socket, option: i32) Error!i32 {
         var value: c_int = 0;
         var len: usize = @sizeOf(c_int);
         try check(c.zmq_getsockopt(try self.ptr(), option, &value, &len));
         return value;
     }
 
-    pub fn getI64(self: *Socket, option: i32) Error!i64 {
+    fn getI64(self: *Socket, option: i32) Error!i64 {
         var value: i64 = 0;
         var len: usize = @sizeOf(i64);
         try check(c.zmq_getsockopt(try self.ptr(), option, &value, &len));
         return value;
     }
 
-    pub fn getBytesAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
+    fn getBytesAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
         const buffer = try allocator.alloc(u8, capacity);
         errdefer allocator.free(buffer);
 
@@ -697,7 +748,7 @@ pub const Socket = struct {
         return try allocator.realloc(buffer, len);
     }
 
-    pub fn getStringAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
+    fn getStringAlloc(self: *Socket, allocator: std.mem.Allocator, option: i32, capacity: usize) ![]u8 {
         const bytes = try self.getBytesAlloc(allocator, option, capacity);
         errdefer allocator.free(bytes);
         const end = std.mem.indexOfScalar(u8, bytes, 0) orelse bytes.len;
@@ -721,24 +772,69 @@ pub const Socket = struct {
         };
     }
 
+    /// Poll this socket and return the event mask, or 0 on timeout.
+    pub fn poll(self: *Socket, timeout_ms: i64, events: i16) Error!i16 {
+        var item = try self.pollItem(events);
+        const rc = c.zmq_poll(&item, 1, @intCast(timeout_ms));
+        if (rc == -1) return mapErrno();
+        return item.revents;
+    }
+
+    pub fn socketType(self: *Socket) Error!i32 {
+        return self.getInt(TYPE);
+    }
+
+    pub fn hasReceiveMore(self: *Socket) Error!bool {
+        return try self.getInt(RCVMORE) != 0;
+    }
+
     pub fn setLinger(self: *Socket, millis: i32) Error!void {
         try self.setInt(LINGER, millis);
+    }
+
+    pub fn linger(self: *Socket) Error!i32 {
+        return self.getInt(LINGER);
     }
 
     pub fn setSendTimeout(self: *Socket, millis: i32) Error!void {
         try self.setInt(SNDTIMEO, millis);
     }
 
+    pub fn sendTimeout(self: *Socket) Error!i32 {
+        return self.getInt(SNDTIMEO);
+    }
+
     pub fn setReceiveTimeout(self: *Socket, millis: i32) Error!void {
         try self.setInt(RCVTIMEO, millis);
+    }
+
+    pub fn receiveTimeout(self: *Socket) Error!i32 {
+        return self.getInt(RCVTIMEO);
     }
 
     pub fn setSendHighWaterMark(self: *Socket, value: i32) Error!void {
         try self.setInt(SNDHWM, value);
     }
 
+    pub fn sendHighWaterMark(self: *Socket) Error!i32 {
+        return self.getInt(SNDHWM);
+    }
+
     pub fn setReceiveHighWaterMark(self: *Socket, value: i32) Error!void {
         try self.setInt(RCVHWM, value);
+    }
+
+    pub fn receiveHighWaterMark(self: *Socket) Error!i32 {
+        return self.getInt(RCVHWM);
+    }
+
+    pub fn setHighWaterMark(self: *Socket, value: i32) Error!void {
+        try self.setSendHighWaterMark(value);
+        try self.setReceiveHighWaterMark(value);
+    }
+
+    pub fn highWaterMark(self: *Socket) Error!i32 {
+        return self.getInt(SNDHWM);
     }
 
     pub fn setIdentity(self: *Socket, value: []const u8) Error!void {
@@ -749,28 +845,68 @@ pub const Socket = struct {
         return self.getBytesAlloc(allocator, IDENTITY, 255);
     }
 
+    pub fn setSendBufferSize(self: *Socket, bytes: i32) Error!void {
+        try self.setInt(SNDBUF, bytes);
+    }
+
+    pub fn sendBufferSize(self: *Socket) Error!i32 {
+        return self.getInt(SNDBUF);
+    }
+
+    pub fn setReceiveBufferSize(self: *Socket, bytes: i32) Error!void {
+        try self.setInt(RCVBUF, bytes);
+    }
+
+    pub fn receiveBufferSize(self: *Socket) Error!i32 {
+        return self.getInt(RCVBUF);
+    }
+
     pub fn setRouterMandatory(self: *Socket, enabled: bool) Error!void {
         try self.setInt(ROUTER_MANDATORY, @intFromBool(enabled));
+    }
+
+    pub fn routerMandatory(self: *Socket) Error!bool {
+        return try self.getInt(ROUTER_MANDATORY) != 0;
     }
 
     pub fn setConflate(self: *Socket, enabled: bool) Error!void {
         try self.setInt(CONFLATE, @intFromBool(enabled));
     }
 
+    pub fn conflate(self: *Socket) Error!bool {
+        return try self.getInt(CONFLATE) != 0;
+    }
+
     pub fn setImmediate(self: *Socket, enabled: bool) Error!void {
         try self.setInt(IMMEDIATE, @intFromBool(enabled));
+    }
+
+    pub fn immediate(self: *Socket) Error!bool {
+        return try self.getInt(IMMEDIATE) != 0;
     }
 
     pub fn setIpv6(self: *Socket, enabled: bool) Error!void {
         try self.setInt(IPV6, @intFromBool(enabled));
     }
 
+    pub fn ipv6(self: *Socket) Error!bool {
+        return try self.getInt(IPV6) != 0;
+    }
+
     pub fn setXpubNoDrop(self: *Socket, enabled: bool) Error!void {
         try self.setInt(XPUB_NODROP, @intFromBool(enabled));
     }
 
+    pub fn xpubNoDrop(self: *Socket) Error!bool {
+        return try self.getInt(XPUB_NODROP) != 0;
+    }
+
     pub fn setPlainServer(self: *Socket, enabled: bool) Error!void {
         try self.setInt(PLAIN_SERVER, @intFromBool(enabled));
+    }
+
+    pub fn plainServer(self: *Socket) Error!bool {
+        return try self.getInt(PLAIN_SERVER) != 0;
     }
 
     pub fn setPlainClient(
@@ -783,14 +919,26 @@ pub const Socket = struct {
         try self.setString(allocator, PLAIN_PASSWORD, password);
     }
 
+    pub fn plainUsernameAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getStringAlloc(allocator, PLAIN_USERNAME, 64);
+    }
+
+    pub fn plainPasswordAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getStringAlloc(allocator, PLAIN_PASSWORD, 64);
+    }
+
+    pub fn mechanism(self: *Socket) Error!i32 {
+        return self.getInt(MECHANISM);
+    }
+
     pub fn setCurveServer(
         self: *Socket,
         allocator: std.mem.Allocator,
-        public_key: []const u8,
+        _public_key: []const u8,
         secret_key: []const u8,
     ) !void {
+        _ = _public_key;
         try self.setInt(CURVE_SERVER, 1);
-        try self.setString(allocator, CURVE_PUBLICKEY, public_key);
         try self.setString(allocator, CURVE_SECRETKEY, secret_key);
     }
 
@@ -810,8 +958,16 @@ pub const Socket = struct {
         try self.setInt(OMQ_ON_MUTE, mode);
     }
 
+    pub fn onMute(self: *Socket) Error!i32 {
+        return self.getInt(OMQ_ON_MUTE);
+    }
+
     pub fn setCompressionLevel(self: *Socket, level: i32) Error!void {
         try self.setInt(OMQ_COMPRESSION_LEVEL, level);
+    }
+
+    pub fn compressionLevel(self: *Socket) Error!i32 {
+        return self.getInt(OMQ_COMPRESSION_LEVEL);
     }
 
     pub fn setCompressionDict(self: *Socket, dict: []const u8) Error!void {
@@ -824,6 +980,10 @@ pub const Socket = struct {
 
     pub fn setCompressionAutoTrain(self: *Socket, enabled: bool) Error!void {
         try self.setInt(OMQ_COMPRESSION_AUTO_TRAIN, @intFromBool(enabled));
+    }
+
+    pub fn compressionAutoTrain(self: *Socket) Error!bool {
+        return try self.getInt(OMQ_COMPRESSION_AUTO_TRAIN) != 0;
     }
 
     pub fn setWorkloadProfile(self: *Socket, profile: i32) Error!void {
@@ -975,6 +1135,12 @@ fn mapErrno() Error {
 fn dataPtr(data: []const u8) *const anyopaque {
     if (data.len == 0) return "";
     return data.ptr;
+}
+
+fn endpointPort(endpoint: []const u8) Error!u16 {
+    const separator = std.mem.lastIndexOfScalar(u8, endpoint, ':') orelse return Error.Invalid;
+    if (separator + 1 == endpoint.len) return Error.Invalid;
+    return std.fmt.parseUnsigned(u16, endpoint[separator + 1 ..], 10) catch Error.Invalid;
 }
 
 fn msgDataSlice(msg: *c.zmq_msg_t, len: usize) Error![]const u8 {

--- a/bindings/zig/src/omq.zig
+++ b/bindings/zig/src/omq.zig
@@ -90,6 +90,9 @@ pub const CONNECT_TIMEOUT = c.ZMQ_CONNECT_TIMEOUT;
 pub const RECONNECT_IVL = c.ZMQ_RECONNECT_IVL;
 pub const RECONNECT_IVL_MAX = c.ZMQ_RECONNECT_IVL_MAX;
 pub const RECONNECT_STOP = c.ZMQ_RECONNECT_STOP;
+pub const RECONNECT_STOP_CONN_REFUSED = c.ZMQ_RECONNECT_STOP_CONN_REFUSED;
+pub const RECONNECT_STOP_HANDSHAKE_FAILED = c.ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED;
+pub const RECONNECT_STOP_AFTER_DISCONNECT = c.ZMQ_RECONNECT_STOP_AFTER_DISCONNECT;
 pub const TCP_MAXRT = c.ZMQ_TCP_MAXRT;
 pub const OMQ_ON_MUTE = c.OMQ_ON_MUTE;
 pub const OMQ_COMPRESSION_LEVEL = c.OMQ_COMPRESSION_LEVEL;
@@ -763,18 +766,18 @@ pub const Socket = struct {
         return allocator.dupe(u8, buffer[0..end]);
     }
 
-    pub fn pollItem(self: *Socket, events: i16) Error!PollItem {
+    pub fn pollItem(self: *Socket, event_mask: i16) Error!PollItem {
         return .{
             .socket = try self.ptr(),
             .fd = 0,
-            .events = events,
+            .events = event_mask,
             .revents = 0,
         };
     }
 
     /// Poll this socket and return the event mask, or 0 on timeout.
-    pub fn poll(self: *Socket, timeout_ms: i64, events: i16) Error!i16 {
-        var item = try self.pollItem(events);
+    pub fn poll(self: *Socket, timeout_ms: i64, event_mask: i16) Error!i16 {
+        var item = try self.pollItem(event_mask);
         const rc = c.zmq_poll(&item, 1, @intCast(timeout_ms));
         if (rc == -1) return mapErrno();
         return item.revents;
@@ -786,6 +789,14 @@ pub const Socket = struct {
 
     pub fn hasReceiveMore(self: *Socket) Error!bool {
         return try self.getInt(RCVMORE) != 0;
+    }
+
+    pub fn fd(self: *Socket) Error!i32 {
+        return self.getInt(FD);
+    }
+
+    pub fn pollEvents(self: *Socket) Error!i32 {
+        return self.getInt(EVENTS);
     }
 
     pub fn setLinger(self: *Socket, millis: i32) Error!void {
@@ -893,12 +904,96 @@ pub const Socket = struct {
         return try self.getInt(IPV6) != 0;
     }
 
+    pub fn setIpv4Only(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(IPV4ONLY, @intFromBool(enabled));
+    }
+
+    pub fn ipv4Only(self: *Socket) Error!bool {
+        return try self.getInt(IPV4ONLY) != 0;
+    }
+
+    pub fn setTcpKeepalive(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(TCP_KEEPALIVE, @intFromBool(enabled));
+    }
+
+    pub fn tcpKeepalive(self: *Socket) Error!bool {
+        return try self.getInt(TCP_KEEPALIVE) != 0;
+    }
+
+    pub fn setTcpKeepaliveIdle(self: *Socket, seconds: i32) Error!void {
+        try self.setInt(TCP_KEEPALIVE_IDLE, seconds);
+    }
+
+    pub fn tcpKeepaliveIdle(self: *Socket) Error!i32 {
+        return self.getInt(TCP_KEEPALIVE_IDLE);
+    }
+
+    pub fn setTcpKeepaliveInterval(self: *Socket, seconds: i32) Error!void {
+        try self.setInt(TCP_KEEPALIVE_INTVL, seconds);
+    }
+
+    pub fn tcpKeepaliveInterval(self: *Socket) Error!i32 {
+        return self.getInt(TCP_KEEPALIVE_INTVL);
+    }
+
+    pub fn setTcpKeepaliveCount(self: *Socket, count: i32) Error!void {
+        try self.setInt(TCP_KEEPALIVE_CNT, count);
+    }
+
+    pub fn tcpKeepaliveCount(self: *Socket) Error!i32 {
+        return self.getInt(TCP_KEEPALIVE_CNT);
+    }
+
+    pub fn setTcpMaxRetransmitTimeout(self: *Socket, millis: i32) Error!void {
+        try self.setInt(TCP_MAXRT, millis);
+    }
+
     pub fn setXpubNoDrop(self: *Socket, enabled: bool) Error!void {
         try self.setInt(XPUB_NODROP, @intFromBool(enabled));
     }
 
     pub fn xpubNoDrop(self: *Socket) Error!bool {
         return try self.getInt(XPUB_NODROP) != 0;
+    }
+
+    pub fn setXpubVerbose(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(XPUB_VERBOSE, @intFromBool(enabled));
+    }
+
+    pub fn xpubVerbose(self: *Socket) Error!bool {
+        return try self.getInt(XPUB_VERBOSE) != 0;
+    }
+
+    pub fn setProbeRouter(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(PROBE_ROUTER, @intFromBool(enabled));
+    }
+
+    pub fn probeRouter(self: *Socket) Error!bool {
+        return try self.getInt(PROBE_ROUTER) != 0;
+    }
+
+    pub fn setReqCorrelate(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(REQ_CORRELATE, @intFromBool(enabled));
+    }
+
+    pub fn reqCorrelate(self: *Socket) Error!bool {
+        return try self.getInt(REQ_CORRELATE) != 0;
+    }
+
+    pub fn setReqRelaxed(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(REQ_RELAXED, @intFromBool(enabled));
+    }
+
+    pub fn reqRelaxed(self: *Socket) Error!bool {
+        return try self.getInt(REQ_RELAXED) != 0;
+    }
+
+    pub fn setRouterHandover(self: *Socket, enabled: bool) Error!void {
+        try self.setInt(ROUTER_HANDOVER, @intFromBool(enabled));
+    }
+
+    pub fn routerHandover(self: *Socket) Error!bool {
+        return try self.getInt(ROUTER_HANDOVER) != 0;
     }
 
     pub fn setPlainServer(self: *Socket, enabled: bool) Error!void {
@@ -931,6 +1026,34 @@ pub const Socket = struct {
         return self.getInt(MECHANISM);
     }
 
+    pub fn curveServer(self: *Socket) Error!bool {
+        return try self.getInt(CURVE_SERVER) != 0;
+    }
+
+    pub fn setCurvePublicKey(self: *Socket, allocator: std.mem.Allocator, public_key: []const u8) !void {
+        try self.setString(allocator, CURVE_PUBLICKEY, public_key);
+    }
+
+    pub fn curvePublicKeyAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getStringAlloc(allocator, CURVE_PUBLICKEY, 41);
+    }
+
+    pub fn setCurveSecretKey(self: *Socket, allocator: std.mem.Allocator, secret_key: []const u8) !void {
+        try self.setString(allocator, CURVE_SECRETKEY, secret_key);
+    }
+
+    pub fn curveSecretKeyAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getStringAlloc(allocator, CURVE_SECRETKEY, 41);
+    }
+
+    pub fn setCurveServerKey(self: *Socket, allocator: std.mem.Allocator, server_key: []const u8) !void {
+        try self.setString(allocator, CURVE_SERVERKEY, server_key);
+    }
+
+    pub fn curveServerKeyAlloc(self: *Socket, allocator: std.mem.Allocator) ![]u8 {
+        return self.getStringAlloc(allocator, CURVE_SERVERKEY, 41);
+    }
+
     pub fn setCurveServer(
         self: *Socket,
         allocator: std.mem.Allocator,
@@ -939,7 +1062,7 @@ pub const Socket = struct {
     ) !void {
         _ = _public_key;
         try self.setInt(CURVE_SERVER, 1);
-        try self.setString(allocator, CURVE_SECRETKEY, secret_key);
+        try self.setCurveSecretKey(allocator, secret_key);
     }
 
     pub fn setCurveClient(
@@ -949,9 +1072,9 @@ pub const Socket = struct {
         secret_key: []const u8,
         server_key: []const u8,
     ) !void {
-        try self.setString(allocator, CURVE_PUBLICKEY, public_key);
-        try self.setString(allocator, CURVE_SECRETKEY, secret_key);
-        try self.setString(allocator, CURVE_SERVERKEY, server_key);
+        try self.setCurvePublicKey(allocator, public_key);
+        try self.setCurveSecretKey(allocator, secret_key);
+        try self.setCurveServerKey(allocator, server_key);
     }
 
     pub fn setOnMute(self: *Socket, mode: i32) Error!void {
@@ -994,6 +1117,94 @@ pub const Socket = struct {
         return self.getInt(OMQ_WORKLOAD_PROFILE);
     }
 
+    pub fn setReconnectInterval(self: *Socket, millis: i32) Error!void {
+        try self.setInt(RECONNECT_IVL, millis);
+    }
+
+    pub fn reconnectInterval(self: *Socket) Error!i32 {
+        return self.getInt(RECONNECT_IVL);
+    }
+
+    pub fn setMaxReconnectInterval(self: *Socket, millis: i32) Error!void {
+        try self.setInt(RECONNECT_IVL_MAX, millis);
+    }
+
+    pub fn maxReconnectInterval(self: *Socket) Error!i32 {
+        return self.getInt(RECONNECT_IVL_MAX);
+    }
+
+    pub fn setReconnectStop(self: *Socket, flags: i32) Error!void {
+        try self.setInt(RECONNECT_STOP, flags);
+    }
+
+    pub fn reconnectStop(self: *Socket) Error!i32 {
+        return self.getInt(RECONNECT_STOP);
+    }
+
+    pub fn setHeartbeatInterval(self: *Socket, millis: i32) Error!void {
+        try self.setInt(HEARTBEAT_IVL, millis);
+    }
+
+    pub fn heartbeatInterval(self: *Socket) Error!i32 {
+        return self.getInt(HEARTBEAT_IVL);
+    }
+
+    pub fn setHeartbeatTtl(self: *Socket, millis: i32) Error!void {
+        try self.setInt(HEARTBEAT_TTL, millis);
+    }
+
+    pub fn heartbeatTtl(self: *Socket) Error!i32 {
+        return self.getInt(HEARTBEAT_TTL);
+    }
+
+    pub fn setHeartbeatTimeout(self: *Socket, millis: i32) Error!void {
+        try self.setInt(HEARTBEAT_TIMEOUT, millis);
+    }
+
+    pub fn heartbeatTimeout(self: *Socket) Error!i32 {
+        return self.getInt(HEARTBEAT_TIMEOUT);
+    }
+
+    pub fn setHandshakeInterval(self: *Socket, millis: i32) Error!void {
+        try self.setInt(HANDSHAKE_IVL, millis);
+    }
+
+    pub fn handshakeInterval(self: *Socket) Error!i32 {
+        return self.getInt(HANDSHAKE_IVL);
+    }
+
+    pub fn setConnectTimeout(self: *Socket, millis: i32) Error!void {
+        try self.setInt(CONNECT_TIMEOUT, millis);
+    }
+
+    pub fn connectTimeout(self: *Socket) Error!i32 {
+        return self.getInt(CONNECT_TIMEOUT);
+    }
+
+    pub fn setMaxMessageSize(self: *Socket, bytes: i64) Error!void {
+        try self.setI64(MAXMSGSIZE, bytes);
+    }
+
+    pub fn maxMessageSize(self: *Socket) Error!i64 {
+        return self.getI64(MAXMSGSIZE);
+    }
+
+    pub fn setRate(self: *Socket, rate: i32) Error!void {
+        try self.setInt(RATE, rate);
+    }
+
+    pub fn setRecoveryInterval(self: *Socket, millis: i32) Error!void {
+        try self.setInt(RECOVERY_IVL, millis);
+    }
+
+    pub fn setMulticastHops(self: *Socket, hops: i32) Error!void {
+        try self.setInt(MULTICAST_HOPS, hops);
+    }
+
+    pub fn setZapDomain(self: *Socket, allocator: std.mem.Allocator, domain: []const u8) !void {
+        try self.setString(allocator, ZAP_DOMAIN, domain);
+    }
+
     pub fn setArenaThreshold(self: *Socket, bytes: i64) Error!void {
         try self.setI64(OMQ_ARENA_THRESHOLD, bytes);
     }
@@ -1011,11 +1222,11 @@ pub const Socket = struct {
         ctx: *Context,
         allocator: std.mem.Allocator,
         endpoint: []const u8,
-        events: i32,
+        event_mask: i32,
     ) !Monitor {
         const endpoint_z = try allocator.dupeZ(u8, endpoint);
         defer allocator.free(endpoint_z);
-        try check(c.zmq_socket_monitor(try self.ptr(), endpoint_z.ptr, events));
+        try check(c.zmq_socket_monitor(try self.ptr(), endpoint_z.ptr, event_mask));
 
         var monitor_socket = try ctx.socket(PAIR);
         errdefer monitor_socket.deinit();

--- a/bindings/zig/src/omq.zig
+++ b/bindings/zig/src/omq.zig
@@ -95,10 +95,14 @@ pub const OMQ_ON_MUTE = c.OMQ_ON_MUTE;
 pub const OMQ_COMPRESSION_LEVEL = c.OMQ_COMPRESSION_LEVEL;
 pub const OMQ_COMPRESSION_DICT = c.OMQ_COMPRESSION_DICT;
 pub const OMQ_COMPRESSION_AUTO_TRAIN = c.OMQ_COMPRESSION_AUTO_TRAIN;
+pub const OMQ_WORKLOAD_PROFILE = c.OMQ_WORKLOAD_PROFILE;
 pub const OMQ_ARENA_THRESHOLD = c.OMQ_ARENA_THRESHOLD;
 pub const OMQ_ON_MUTE_BLOCK = c.OMQ_ON_MUTE_BLOCK;
 pub const OMQ_ON_MUTE_DROP_NEWEST = c.OMQ_ON_MUTE_DROP_NEWEST;
 pub const OMQ_ON_MUTE_DROP_OLDEST = c.OMQ_ON_MUTE_DROP_OLDEST;
+pub const OMQ_WORKLOAD_DEFAULT = c.OMQ_WORKLOAD_DEFAULT;
+pub const OMQ_WORKLOAD_THROUGHPUT = c.OMQ_WORKLOAD_THROUGHPUT;
+pub const OMQ_WORKLOAD_LATENCY = c.OMQ_WORKLOAD_LATENCY;
 
 pub const POLLIN = c.ZMQ_POLLIN;
 pub const POLLOUT = c.ZMQ_POLLOUT;
@@ -541,8 +545,7 @@ pub const Socket = struct {
         if (c.zmq_msg_recv(&msg, try self.ptr(), flags) == -1) return mapErrno();
 
         const len = c.zmq_msg_size(&msg);
-        const src: [*]const u8 = @ptrCast(c.zmq_msg_data(&msg).?);
-        return allocator.dupe(u8, src[0..len]);
+        return allocator.dupe(u8, try msgDataSlice(&msg, len));
     }
 
     pub fn recvFrameAlloc(self: *Socket, allocator: std.mem.Allocator, flags: i32) !Frame {
@@ -553,8 +556,7 @@ pub const Socket = struct {
         if (c.zmq_msg_recv(&msg, try self.ptr(), flags) == -1) return mapErrno();
 
         const len = c.zmq_msg_size(&msg);
-        const src: [*]const u8 = @ptrCast(c.zmq_msg_data(&msg).?);
-        const data = try allocator.dupe(u8, src[0..len]);
+        const data = try allocator.dupe(u8, try msgDataSlice(&msg, len));
         errdefer allocator.free(data);
 
         const group = c.zmq_msg_group(&msg);
@@ -824,6 +826,14 @@ pub const Socket = struct {
         try self.setInt(OMQ_COMPRESSION_AUTO_TRAIN, @intFromBool(enabled));
     }
 
+    pub fn setWorkloadProfile(self: *Socket, profile: i32) Error!void {
+        try self.setInt(OMQ_WORKLOAD_PROFILE, profile);
+    }
+
+    pub fn workloadProfile(self: *Socket) Error!i32 {
+        return self.getInt(OMQ_WORKLOAD_PROFILE);
+    }
+
     pub fn setArenaThreshold(self: *Socket, bytes: i64) Error!void {
         try self.setI64(OMQ_ARENA_THRESHOLD, bytes);
     }
@@ -965,6 +975,16 @@ fn mapErrno() Error {
 fn dataPtr(data: []const u8) *const anyopaque {
     if (data.len == 0) return "";
     return data.ptr;
+}
+
+fn msgDataSlice(msg: *c.zmq_msg_t, len: usize) Error![]const u8 {
+    const raw = c.zmq_msg_data(msg);
+    if (raw == null) {
+        if (len == 0) return &.{};
+        return Error.Fault;
+    }
+    const src: [*]const u8 = @ptrCast(raw.?);
+    return src[0..len];
 }
 
 test {

--- a/bindings/zig/tests/basic.zig
+++ b/bindings/zig/tests/basic.zig
@@ -67,7 +67,7 @@ test "construct every socket type" {
 
     for (types) |socket_type| {
         var socket = try ctx.socket(socket_type);
-        try testing.expectEqual(socket_type, try socket.getInt(omq.TYPE));
+        try testing.expectEqual(socket_type, try socket.socketType());
         socket.deinit();
     }
 }
@@ -117,7 +117,7 @@ test "push pull multipart and rcvmore" {
     try testing.expectEqual(@as(usize, 2), got.parts.len);
     try testing.expectEqualStrings("meta", got.parts[0]);
     try testing.expectEqualStrings("trailer", got.parts[1]);
-    try testing.expectEqual(@as(i32, 0), try pull.getInt(omq.RCVMORE));
+    try testing.expect(!try pull.hasReceiveMore());
 }
 
 test "sndmore aggregates frames" {
@@ -371,13 +371,13 @@ test "option round trips" {
     defer push.deinit();
 
     try push.setLinger(50);
-    try testing.expectEqual(@as(i32, 50), try push.getInt(omq.LINGER));
+    try testing.expectEqual(@as(i32, 50), try push.linger());
 
     try push.setSendHighWaterMark(64);
-    try testing.expectEqual(@as(i32, 64), try push.getInt(omq.SNDHWM));
+    try testing.expectEqual(@as(i32, 64), try push.sendHighWaterMark());
 
     try push.setReceiveHighWaterMark(32);
-    try testing.expectEqual(@as(i32, 32), try push.getInt(omq.RCVHWM));
+    try testing.expectEqual(@as(i32, 32), try push.receiveHighWaterMark());
 }
 
 test "receive timeout maps to Again" {
@@ -412,23 +412,23 @@ test "extended option round trips" {
     var push = try ctx.socket(omq.PUSH);
     defer push.deinit();
 
-    try push.setInt(omq.SNDBUF, 65536);
-    try testing.expectEqual(@as(i32, 65536), try push.getInt(omq.SNDBUF));
+    try push.setSendBufferSize(65536);
+    try testing.expectEqual(@as(i32, 65536), try push.sendBufferSize());
 
-    try push.setInt(omq.RCVBUF, 32768);
-    try testing.expectEqual(@as(i32, 32768), try push.getInt(omq.RCVBUF));
+    try push.setReceiveBufferSize(32768);
+    try testing.expectEqual(@as(i32, 32768), try push.receiveBufferSize());
 
     try push.setRouterMandatory(true);
-    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.ROUTER_MANDATORY));
+    try testing.expect(try push.routerMandatory());
 
     try push.setConflate(true);
-    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.CONFLATE));
+    try testing.expect(try push.conflate());
 
     try push.setArenaThreshold(2048);
     try testing.expectEqual(@as(i64, 2048), try push.arenaThreshold());
 
     try push.setOnMute(omq.OMQ_ON_MUTE_DROP_NEWEST);
-    try testing.expectEqual(@as(i32, omq.OMQ_ON_MUTE_DROP_NEWEST), try push.getInt(omq.OMQ_ON_MUTE));
+    try testing.expectEqual(@as(i32, omq.OMQ_ON_MUTE_DROP_NEWEST), try push.onMute());
 
     try testing.expectEqual(@as(i32, omq.OMQ_WORKLOAD_DEFAULT), try push.workloadProfile());
     try push.setWorkloadProfile(omq.OMQ_WORKLOAD_LATENCY);
@@ -437,10 +437,10 @@ test "extended option round trips" {
     try testing.expectEqual(@as(i32, omq.OMQ_WORKLOAD_DEFAULT), try push.workloadProfile());
 
     try push.setCompressionLevel(1);
-    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.OMQ_COMPRESSION_LEVEL));
+    try testing.expectEqual(@as(i32, 1), try push.compressionLevel());
 
     try push.setCompressionAutoTrain(true);
-    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.OMQ_COMPRESSION_AUTO_TRAIN));
+    try testing.expect(try push.compressionAutoTrain());
 
     try push.setCompressionDict("my-dict-bytes");
     const dict = try push.compressionDictAlloc(allocator);
@@ -461,16 +461,16 @@ test "identity and plain option bytes round trip" {
     try testing.expectEqualStrings("zig-id", identity);
 
     try push.setPlainServer(true);
-    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.PLAIN_SERVER));
+    try testing.expect(try push.plainServer());
 
     try push.setPlainClient(allocator, "admin", "secret");
-    const username = try push.getStringAlloc(allocator, omq.PLAIN_USERNAME, 64);
+    const username = try push.plainUsernameAlloc(allocator);
     defer allocator.free(username);
-    const password = try push.getStringAlloc(allocator, omq.PLAIN_PASSWORD, 64);
+    const password = try push.plainPasswordAlloc(allocator);
     defer allocator.free(password);
     try testing.expectEqualStrings("admin", username);
     try testing.expectEqualStrings("secret", password);
-    try testing.expectEqual(@as(i32, omq.PLAIN), try push.getInt(omq.MECHANISM));
+    try testing.expectEqual(@as(i32, omq.PLAIN), try push.mechanism());
 }
 
 test "poll reports readable socket" {

--- a/bindings/zig/tests/basic.zig
+++ b/bindings/zig/tests/basic.zig
@@ -430,6 +430,12 @@ test "extended option round trips" {
     try push.setOnMute(omq.OMQ_ON_MUTE_DROP_NEWEST);
     try testing.expectEqual(@as(i32, omq.OMQ_ON_MUTE_DROP_NEWEST), try push.getInt(omq.OMQ_ON_MUTE));
 
+    try testing.expectEqual(@as(i32, omq.OMQ_WORKLOAD_DEFAULT), try push.workloadProfile());
+    try push.setWorkloadProfile(omq.OMQ_WORKLOAD_LATENCY);
+    try testing.expectEqual(@as(i32, omq.OMQ_WORKLOAD_LATENCY), try push.workloadProfile());
+    try push.setWorkloadProfile(omq.OMQ_WORKLOAD_DEFAULT);
+    try testing.expectEqual(@as(i32, omq.OMQ_WORKLOAD_DEFAULT), try push.workloadProfile());
+
     try push.setCompressionLevel(1);
     try testing.expectEqual(@as(i32, 1), try push.getInt(omq.OMQ_COMPRESSION_LEVEL));
 

--- a/bindings/zig/tests/basic.zig
+++ b/bindings/zig/tests/basic.zig
@@ -424,6 +424,64 @@ test "extended option round trips" {
     try push.setConflate(true);
     try testing.expect(try push.conflate());
 
+    try push.setImmediate(true);
+    try testing.expect(try push.immediate());
+
+    try push.setIpv6(false);
+    try testing.expect(!try push.ipv6());
+    try push.setIpv4Only(true);
+    try testing.expect(try push.ipv4Only());
+
+    try push.setTcpKeepalive(true);
+    try push.setTcpKeepaliveIdle(30);
+    try push.setTcpKeepaliveInterval(5);
+    try push.setTcpKeepaliveCount(3);
+    try testing.expect(try push.tcpKeepalive());
+    try testing.expectEqual(@as(i32, 30), try push.tcpKeepaliveIdle());
+    try testing.expectEqual(@as(i32, 5), try push.tcpKeepaliveInterval());
+    try testing.expectEqual(@as(i32, 3), try push.tcpKeepaliveCount());
+    try push.setTcpMaxRetransmitTimeout(0);
+
+    try push.setReconnectInterval(500);
+    try push.setMaxReconnectInterval(5000);
+    try push.setReconnectStop(omq.RECONNECT_STOP_CONN_REFUSED);
+    try testing.expectEqual(@as(i32, 500), try push.reconnectInterval());
+    try testing.expectEqual(@as(i32, 5000), try push.maxReconnectInterval());
+    try testing.expectEqual(@as(i32, omq.RECONNECT_STOP_CONN_REFUSED), try push.reconnectStop());
+
+    try push.setHeartbeatInterval(1000);
+    try push.setHeartbeatTtl(3000);
+    try push.setHeartbeatTimeout(5000);
+    try testing.expectEqual(@as(i32, 1000), try push.heartbeatInterval());
+    try testing.expectEqual(@as(i32, 3000), try push.heartbeatTtl());
+    try testing.expectEqual(@as(i32, 5000), try push.heartbeatTimeout());
+
+    try push.setHandshakeInterval(2000);
+    try testing.expectEqual(@as(i32, 2000), try push.handshakeInterval());
+
+    try push.setConnectTimeout(750);
+    try testing.expectEqual(@as(i32, 750), try push.connectTimeout());
+
+    try push.setMaxMessageSize(1024 * 1024);
+    try testing.expectEqual(@as(i64, 1024 * 1024), try push.maxMessageSize());
+    try push.setMaxMessageSize(-1);
+    try testing.expectEqual(@as(i64, -1), try push.maxMessageSize());
+
+    try push.setXpubVerbose(true);
+    try testing.expect(try push.xpubVerbose());
+    try push.setProbeRouter(true);
+    try testing.expect(try push.probeRouter());
+    try push.setReqCorrelate(true);
+    try testing.expect(try push.reqCorrelate());
+    try push.setReqRelaxed(true);
+    try testing.expect(try push.reqRelaxed());
+    try push.setRouterHandover(true);
+    try testing.expect(try push.routerHandover());
+    try push.setRate(0);
+    try push.setRecoveryInterval(0);
+    try push.setMulticastHops(0);
+    try push.setZapDomain(allocator, "");
+
     try push.setArenaThreshold(2048);
     try testing.expectEqual(@as(i64, 2048), try push.arenaThreshold());
 

--- a/bindings/zig/tests/basic.zig
+++ b/bindings/zig/tests/basic.zig
@@ -1,0 +1,577 @@
+const std = @import("std");
+const omq = @import("omq");
+
+const testing = std.testing;
+const allocator = testing.allocator;
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+test "version reports libzmq ABI version" {
+    const got = omq.version();
+    try testing.expectEqual(@as(i32, 4), got.major);
+    try testing.expectEqual(@as(i32, 3), got.minor);
+}
+
+test "push pull inproc" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const endpoint = "inproc://zig-basic";
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("hello", 0);
+    const got = try pull.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualStrings("hello", got);
+}
+
+test "construct every socket type" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    const types = [_]i32{
+        omq.PAIR,
+        omq.PUB,
+        omq.SUB,
+        omq.REQ,
+        omq.REP,
+        omq.DEALER,
+        omq.ROUTER,
+        omq.PULL,
+        omq.PUSH,
+        omq.XPUB,
+        omq.XSUB,
+        omq.STREAM,
+        omq.SERVER,
+        omq.CLIENT,
+        omq.RADIO,
+        omq.DISH,
+        omq.GATHER,
+        omq.SCATTER,
+        omq.PEER,
+        omq.CHANNEL,
+    };
+
+    for (types) |socket_type| {
+        var socket = try ctx.socket(socket_type);
+        try testing.expectEqual(socket_type, try socket.getInt(omq.TYPE));
+        socket.deinit();
+    }
+}
+
+test "pair sockets exchange both directions" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var a = try ctx.socket(omq.PAIR);
+    defer a.deinit();
+    var b = try ctx.socket(omq.PAIR);
+    defer b.deinit();
+
+    const bound = try a.bind(allocator, "inproc://zig-pair");
+    defer allocator.free(bound);
+    try b.connect(allocator, bound);
+
+    _ = try a.send("left", 0);
+    const got_left = try b.recvAlloc(allocator, 0);
+    defer allocator.free(got_left);
+    try testing.expectEqualStrings("left", got_left);
+
+    _ = try b.send("right", 0);
+    const got_right = try a.recvAlloc(allocator, 0);
+    defer allocator.free(got_right);
+    try testing.expectEqualStrings("right", got_right);
+}
+
+test "push pull multipart and rcvmore" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const endpoint = "inproc://zig-multipart";
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    try push.sendMultipart(&.{ "meta", "trailer" }, 0);
+
+    var got = try pull.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqual(@as(usize, 2), got.parts.len);
+    try testing.expectEqualStrings("meta", got.parts[0]);
+    try testing.expectEqualStrings("trailer", got.parts[1]);
+    try testing.expectEqual(@as(i32, 0), try pull.getInt(omq.RCVMORE));
+}
+
+test "sndmore aggregates frames" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const endpoint = "inproc://zig-sndmore";
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("a", omq.SNDMORE);
+    _ = try push.send("b", omq.SNDMORE);
+    _ = try push.send("c", 0);
+
+    var got = try pull.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqual(@as(usize, 3), got.parts.len);
+    try testing.expectEqualStrings("a", got.parts[0]);
+    try testing.expectEqualStrings("b", got.parts[1]);
+    try testing.expectEqualStrings("c", got.parts[2]);
+}
+
+test "scatter gather single frames" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var gather = try ctx.socket(omq.GATHER);
+    defer gather.deinit();
+    var scatter = try ctx.socket(omq.SCATTER);
+    defer scatter.deinit();
+
+    const bound = try gather.bind(allocator, "inproc://zig-scatter-gather");
+    defer allocator.free(bound);
+    try scatter.connect(allocator, bound);
+
+    _ = try scatter.send("m0", 0);
+    _ = try scatter.send("m1", 0);
+
+    const first = try gather.recvAlloc(allocator, 0);
+    defer allocator.free(first);
+    const second = try gather.recvAlloc(allocator, 0);
+    defer allocator.free(second);
+    try testing.expectEqualStrings("m0", first);
+    try testing.expectEqualStrings("m1", second);
+}
+
+test "channel sockets exchange single frames" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var a = try ctx.socket(omq.CHANNEL);
+    defer a.deinit();
+    var b = try ctx.socket(omq.CHANNEL);
+    defer b.deinit();
+
+    const bound = try a.bind(allocator, "inproc://zig-channel");
+    defer allocator.free(bound);
+    try b.connect(allocator, bound);
+
+    _ = try a.send("hi", 0);
+    const hi = try b.recvAlloc(allocator, 0);
+    defer allocator.free(hi);
+    try testing.expectEqualStrings("hi", hi);
+
+    _ = try b.send("there", 0);
+    const there = try a.recvAlloc(allocator, 0);
+    defer allocator.free(there);
+    try testing.expectEqualStrings("there", there);
+}
+
+test "req rep roundtrip" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+
+    const bound = try rep.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try req.connect(allocator, bound);
+
+    _ = try req.send("ping", 0);
+    const request = try rep.recvAlloc(allocator, 0);
+    defer allocator.free(request);
+    try testing.expectEqualStrings("ping", request);
+
+    _ = try rep.send("pong", 0);
+    const reply = try req.recvAlloc(allocator, 0);
+    defer allocator.free(reply);
+    try testing.expectEqualStrings("pong", reply);
+}
+
+test "peer sockets route by identity" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var a = try ctx.socket(omq.PEER);
+    defer a.deinit();
+    var b = try ctx.socket(omq.PEER);
+    defer b.deinit();
+
+    try a.setIdentity("peer-a");
+    try b.setIdentity("peer-b");
+    const bound = try a.bind(allocator, "inproc://zig-peer");
+    defer allocator.free(bound);
+    try b.connect(allocator, bound);
+    try a.setSendTimeout(1000);
+    try a.setReceiveTimeout(1000);
+    try b.setSendTimeout(1000);
+    try b.setReceiveTimeout(1000);
+    sleepMillis(50);
+
+    try b.sendMultipart(&.{ "peer-a", "hello-a" }, 0);
+    var got_a = try a.recvMultipartAlloc(allocator, 0);
+    defer got_a.deinit();
+    try testing.expectEqual(@as(usize, 2), got_a.parts.len);
+    try testing.expectEqualStrings("peer-b", got_a.parts[0]);
+    try testing.expectEqualStrings("hello-a", got_a.parts[1]);
+
+    try a.sendMultipart(&.{ "peer-b", "hello-b" }, 0);
+    var got_b = try b.recvMultipartAlloc(allocator, 0);
+    defer got_b.deinit();
+    try testing.expectEqual(@as(usize, 2), got_b.parts.len);
+    try testing.expectEqualStrings("peer-a", got_b.parts[0]);
+    try testing.expectEqualStrings("hello-b", got_b.parts[1]);
+}
+
+test "dealer router identity routes back" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var router = try ctx.socket(omq.ROUTER);
+    defer router.deinit();
+    var dealer = try ctx.socket(omq.DEALER);
+    defer dealer.deinit();
+
+    try dealer.setIdentity("client-A");
+    const bound = try router.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try dealer.connect(allocator, bound);
+
+    _ = try dealer.send("hello", 0);
+    var got = try router.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expect(got.parts.len >= 2);
+    try testing.expectEqualStrings("client-A", got.parts[0]);
+    try testing.expectEqualStrings("hello", got.parts[got.parts.len - 1]);
+
+    try router.sendMultipart(&.{ "client-A", "hi-back" }, 0);
+    const reply = try dealer.recvAlloc(allocator, 0);
+    defer allocator.free(reply);
+    try testing.expectEqualStrings("hi-back", reply);
+}
+
+test "client server routing id routes reply" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var server = try ctx.socket(omq.SERVER);
+    defer server.deinit();
+    var client = try ctx.socket(omq.CLIENT);
+    defer client.deinit();
+
+    const bound = try server.bind(allocator, "inproc://zig-client-server");
+    defer allocator.free(bound);
+    try client.connect(allocator, bound);
+
+    _ = try client.send("ping", 0);
+    var request = try server.recvFrameAlloc(allocator, 0);
+    defer request.deinit();
+    try testing.expectEqualStrings("ping", request.data);
+    try testing.expect(request.routing_id > 0);
+
+    var reply = try omq.Frame.init(allocator, "pong");
+    defer reply.deinit();
+    reply.routing_id = request.routing_id;
+    try server.sendFrame(allocator, &reply, 0);
+
+    const got = try client.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualStrings("pong", got);
+}
+
+test "pub sub prefix filter" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var publisher = try ctx.socket(omq.PUB);
+    defer publisher.deinit();
+    var sub = try ctx.socket(omq.SUB);
+    defer sub.deinit();
+
+    const bound = try publisher.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try sub.connect(allocator, bound);
+    try sub.subscribe("weather/");
+    sleepMillis(200);
+
+    _ = try publisher.send("sports/score-12", 0);
+    _ = try publisher.send("weather/sunny", 0);
+    _ = try publisher.send("weather/rain", 0);
+
+    try sub.setReceiveTimeout(500);
+    const first = try sub.recvAlloc(allocator, 0);
+    defer allocator.free(first);
+    const second = try sub.recvAlloc(allocator, 0);
+    defer allocator.free(second);
+    try testing.expectEqualStrings("weather/sunny", first);
+    try testing.expectEqualStrings("weather/rain", second);
+}
+
+test "xpub xsub subscription and publish" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var xpub = try ctx.socket(omq.XPUB);
+    defer xpub.deinit();
+    var xsub = try ctx.socket(omq.XSUB);
+    defer xsub.deinit();
+
+    const bound = try xpub.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try xsub.connect(allocator, bound);
+    try xsub.subscribe("");
+
+    try xpub.setReceiveTimeout(1000);
+    const subscription = try xpub.recvAlloc(allocator, 0);
+    defer allocator.free(subscription);
+    try testing.expectEqualSlices(u8, &[_]u8{1}, subscription);
+
+    try xsub.setReceiveTimeout(1000);
+    _ = try xpub.send("hello", 0);
+    const got = try xsub.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualStrings("hello", got);
+}
+
+test "option round trips" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try push.setLinger(50);
+    try testing.expectEqual(@as(i32, 50), try push.getInt(omq.LINGER));
+
+    try push.setSendHighWaterMark(64);
+    try testing.expectEqual(@as(i32, 64), try push.getInt(omq.SNDHWM));
+
+    try push.setReceiveHighWaterMark(32);
+    try testing.expectEqual(@as(i32, 32), try push.getInt(omq.RCVHWM));
+}
+
+test "receive timeout maps to Again" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try pull.setReceiveTimeout(50);
+
+    try testing.expectError(error.Again, pull.recvAlloc(allocator, 0));
+}
+
+test "closed socket maps to NoSocket" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    try pull.close();
+
+    var buffer: [1]u8 = undefined;
+    try testing.expectError(error.NoSocket, pull.recvInto(&buffer, 0));
+}
+
+test "extended option round trips" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try push.setInt(omq.SNDBUF, 65536);
+    try testing.expectEqual(@as(i32, 65536), try push.getInt(omq.SNDBUF));
+
+    try push.setInt(omq.RCVBUF, 32768);
+    try testing.expectEqual(@as(i32, 32768), try push.getInt(omq.RCVBUF));
+
+    try push.setRouterMandatory(true);
+    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.ROUTER_MANDATORY));
+
+    try push.setConflate(true);
+    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.CONFLATE));
+
+    try push.setArenaThreshold(2048);
+    try testing.expectEqual(@as(i64, 2048), try push.arenaThreshold());
+
+    try push.setOnMute(omq.OMQ_ON_MUTE_DROP_NEWEST);
+    try testing.expectEqual(@as(i32, omq.OMQ_ON_MUTE_DROP_NEWEST), try push.getInt(omq.OMQ_ON_MUTE));
+
+    try push.setCompressionLevel(1);
+    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.OMQ_COMPRESSION_LEVEL));
+
+    try push.setCompressionAutoTrain(true);
+    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.OMQ_COMPRESSION_AUTO_TRAIN));
+
+    try push.setCompressionDict("my-dict-bytes");
+    const dict = try push.compressionDictAlloc(allocator);
+    defer allocator.free(dict);
+    try testing.expectEqualStrings("my-dict-bytes", dict);
+}
+
+test "identity and plain option bytes round trip" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try push.setIdentity("zig-id");
+    const identity = try push.identityAlloc(allocator);
+    defer allocator.free(identity);
+    try testing.expectEqualStrings("zig-id", identity);
+
+    try push.setPlainServer(true);
+    try testing.expectEqual(@as(i32, 1), try push.getInt(omq.PLAIN_SERVER));
+
+    try push.setPlainClient(allocator, "admin", "secret");
+    const username = try push.getStringAlloc(allocator, omq.PLAIN_USERNAME, 64);
+    defer allocator.free(username);
+    const password = try push.getStringAlloc(allocator, omq.PLAIN_PASSWORD, 64);
+    defer allocator.free(password);
+    try testing.expectEqualStrings("admin", username);
+    try testing.expectEqualStrings("secret", password);
+    try testing.expectEqual(@as(i32, omq.PLAIN), try push.getInt(omq.MECHANISM));
+}
+
+test "poll reports readable socket" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const endpoint = "inproc://zig-poll";
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+    _ = try push.send("ready", 0);
+
+    var items = [_]omq.PollItem{try pull.pollItem(omq.POLLIN)};
+    try testing.expectEqual(@as(usize, 1), try omq.poll(items[0..], 1000));
+    try testing.expect((items[0].revents & omq.POLLIN) != 0);
+}
+
+test "poller returns registered readable sockets" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull1 = try ctx.socket(omq.PULL);
+    defer pull1.deinit();
+    var push1 = try ctx.socket(omq.PUSH);
+    defer push1.deinit();
+    var pull2 = try ctx.socket(omq.PULL);
+    defer pull2.deinit();
+    var push2 = try ctx.socket(omq.PUSH);
+    defer push2.deinit();
+
+    const bound1 = try pull1.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound1);
+    try push1.connect(allocator, bound1);
+
+    const bound2 = try pull2.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound2);
+    try push2.connect(allocator, bound2);
+
+    _ = try push1.send("only-one", 0);
+
+    var poller = omq.Poller.init(allocator);
+    defer poller.deinit();
+    try poller.register(&pull1, omq.POLLIN);
+    try poller.register(&pull2, omq.POLLIN);
+
+    const events = try poller.pollAlloc(1000);
+    defer allocator.free(events);
+    try testing.expectEqual(@as(usize, 1), events.len);
+    try testing.expect(events[0].socket == &pull1);
+    try testing.expect((events[0].events & omq.POLLIN) != 0);
+}
+
+test "monitor receives listening event" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+
+    var monitor = try pull.monitor(&ctx, allocator, "inproc://zig-monitor", omq.EVENT_ALL);
+    defer monitor.deinit();
+    try monitor.setReceiveTimeout(1000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+
+    var event = try monitor.recvAlloc(allocator, 0);
+    defer event.deinit();
+    try testing.expectEqual(@as(u16, omq.EVENT_LISTENING), event.event);
+    try testing.expectEqualStrings(bound, event.endpoint);
+}
+
+test "shared contexts use same inproc namespace" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    const key = try ctx.shareKey();
+    var shared = try omq.Context.fromShareKey(key);
+    defer shared.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try shared.socket(omq.PUSH);
+    defer push.deinit();
+
+    const bound = try pull.bind(allocator, "inproc://zig-shared-context");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("shared", 0);
+    const got = try pull.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualStrings("shared", got);
+}
+
+test "curve key helpers" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    const pair = try omq.curveKeypair();
+    try testing.expectEqual(@as(usize, 40), pair.publicSlice().len);
+    try testing.expectEqual(@as(usize, 40), pair.secretSlice().len);
+
+    const public = try omq.curvePublic(allocator, pair.secretSlice());
+    try testing.expectEqualSlices(u8, pair.publicSlice(), public[0..]);
+}

--- a/bindings/zig/tests/parity.zig
+++ b/bindings/zig/tests/parity.zig
@@ -63,6 +63,18 @@ fn expectRecv(socket: *omq.Socket, expected: []const u8) !void {
     try testing.expectEqualStrings(expected, got);
 }
 
+fn configurePlain(server: *omq.Socket, client: *omq.Socket) !void {
+    try server.setPlainServer(true);
+    try client.setPlainClient(allocator, "alice", "secret");
+}
+
+fn configureCurve(server_sock: *omq.Socket, client_sock: *omq.Socket) !void {
+    const server = try omq.curveKeypair();
+    const client = try omq.curveKeypair();
+    try server_sock.setCurveServer(allocator, server.publicSlice(), server.secretSlice());
+    try client_sock.setCurveClient(allocator, client.publicSlice(), client.secretSlice(), server.publicSlice());
+}
+
 const ProxyState = struct {
     frontend: *omq.Socket,
     backend: *omq.Socket,
@@ -131,6 +143,30 @@ test "socket lifecycle and option helpers match pyomq shape" {
 
     try ctx.term();
     try testing.expect(ctx.closed());
+}
+
+test "named option helpers reject invalid values" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var sock = try ctx.socket(omq.PUSH);
+    defer sock.deinit();
+
+    try sock.setSendHighWaterMark(64);
+    try sock.setReceiveHighWaterMark(32);
+    try testing.expectError(error.Invalid, sock.setSendHighWaterMark(-1));
+    try testing.expectError(error.Invalid, sock.setReceiveHighWaterMark(-1));
+    try testing.expectEqual(@as(i32, 64), try sock.sendHighWaterMark());
+    try testing.expectEqual(@as(i32, 32), try sock.receiveHighWaterMark());
+
+    try testing.expectError(error.Invalid, sock.setOnMute(99));
+    try testing.expectError(error.Invalid, sock.setCompressionLevel(-9));
+    try testing.expectError(error.Invalid, sock.setCompressionLevel(5));
+
+    const oversize = try allocator.alloc(u8, 8 * 1024 + 1);
+    defer allocator.free(oversize);
+    @memset(oversize, 0);
+    try testing.expectError(error.Invalid, sock.setCompressionDict(oversize));
 }
 
 test "bindToRandomPort and getLastEndpoint" {
@@ -489,8 +525,7 @@ test "plain req rep tcp" {
     var req = try ctx.socket(omq.REQ);
     defer req.deinit();
 
-    try rep.setPlainServer(true);
-    try req.setPlainClient(allocator, "alice", "secret");
+    try configurePlain(&rep, &req);
     try rep.setReceiveTimeout(5000);
     try req.setReceiveTimeout(5000);
     try req.setSendTimeout(5000);
@@ -505,11 +540,83 @@ test "plain req rep tcp" {
     try expectRecv(&req, "pong");
 }
 
+test "plain push pull tcp" {
+    if (!try omq.has(allocator, "plain")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try configurePlain(&pull, &push);
+    try pull.setReceiveTimeout(5000);
+    try push.setSendTimeout(5000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("hello over plain", 0);
+    try expectRecv(&pull, "hello over plain");
+}
+
+test "plain pub sub tcp" {
+    if (!try omq.has(allocator, "plain")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var publisher = try ctx.socket(omq.PUB);
+    defer publisher.deinit();
+    var sub = try ctx.socket(omq.SUB);
+    defer sub.deinit();
+
+    try configurePlain(&publisher, &sub);
+    try sub.subscribe("hot/");
+    try sub.setReceiveTimeout(5000);
+
+    const bound = try publisher.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try sub.connect(allocator, bound);
+    sleepMillis(300);
+
+    _ = try publisher.send("cold/skip", 0);
+    _ = try publisher.send("hot/take", 0);
+    try expectRecv(&sub, "hot/take");
+}
+
+test "plain multipart tcp" {
+    if (!try omq.has(allocator, "plain")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try configurePlain(&pull, &push);
+    try pull.setReceiveTimeout(5000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    try push.sendMultipart(&.{ "a", "bb", "ccc" }, 0);
+    var got = try pull.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqual(@as(usize, 3), got.parts.len);
+    try testing.expectEqualStrings("a", got.parts[0]);
+    try testing.expectEqualStrings("bb", got.parts[1]);
+    try testing.expectEqualStrings("ccc", got.parts[2]);
+}
+
 test "curve req rep tcp" {
     if (!try omq.has(allocator, "curve")) return;
-
-    const server = try omq.curveKeypair();
-    const client = try omq.curveKeypair();
 
     var ctx = try omq.Context.init();
     defer ctx.deinit();
@@ -519,8 +626,7 @@ test "curve req rep tcp" {
     var req = try ctx.socket(omq.REQ);
     defer req.deinit();
 
-    try rep.setCurveServer(allocator, server.publicSlice(), server.secretSlice());
-    try req.setCurveClient(allocator, client.publicSlice(), client.secretSlice(), server.publicSlice());
+    try configureCurve(&rep, &req);
     try rep.setReceiveTimeout(5000);
     try req.setReceiveTimeout(5000);
     try req.setSendTimeout(5000);
@@ -533,6 +639,107 @@ test "curve req rep tcp" {
     try expectRecv(&rep, "ping");
     _ = try rep.send("pong", 0);
     try expectRecv(&req, "pong");
+}
+
+test "curve push pull tcp" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try configureCurve(&pull, &push);
+    try pull.setReceiveTimeout(5000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("hello over curve", 0);
+    try expectRecv(&pull, "hello over curve");
+}
+
+test "curve pub sub tcp" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var publisher = try ctx.socket(omq.PUB);
+    defer publisher.deinit();
+    var sub = try ctx.socket(omq.SUB);
+    defer sub.deinit();
+
+    try configureCurve(&publisher, &sub);
+    try sub.subscribe("hot/");
+    try sub.setReceiveTimeout(5000);
+
+    const bound = try publisher.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try sub.connect(allocator, bound);
+    sleepMillis(300);
+
+    _ = try publisher.send("cold/skip", 0);
+    _ = try publisher.send("hot/take", 0);
+    try expectRecv(&sub, "hot/take");
+}
+
+test "curve multipart tcp" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try configureCurve(&pull, &push);
+    try pull.setReceiveTimeout(5000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    try push.sendMultipart(&.{ "a", "bb", "ccc" }, 0);
+    var got = try pull.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqual(@as(usize, 3), got.parts.len);
+    try testing.expectEqualStrings("a", got.parts[0]);
+    try testing.expectEqualStrings("bb", got.parts[1]);
+    try testing.expectEqualStrings("ccc", got.parts[2]);
+}
+
+test "curve bad server key rejects" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    const server = try omq.curveKeypair();
+    const wrong = try omq.curveKeypair();
+    const client = try omq.curveKeypair();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try pull.setCurveServer(allocator, server.publicSlice(), server.secretSlice());
+    try push.setCurveClient(allocator, client.publicSlice(), client.secretSlice(), wrong.publicSlice());
+    try pull.setReceiveTimeout(1000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("should not arrive", 0);
+    try testing.expectError(error.Again, pull.recvAlloc(allocator, 0));
 }
 
 test "curve option helpers round trip" {
@@ -587,6 +794,58 @@ test "zstd tcp static dict" {
     const payload = try allocator.alloc(u8, 4096);
     defer allocator.free(payload);
     @memset(payload, 'A');
+
+    _ = try push.send(payload, 0);
+    const got = try pull.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualSlices(u8, payload, got);
+}
+
+test "zstd tcp custom level" {
+    if (!try omq.has(allocator, "zstd")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveTimeout(2000);
+    try push.setCompressionLevel(3);
+    try testing.expectEqual(@as(i32, 3), try push.compressionLevel());
+
+    const bound = try pull.bind(allocator, "zstd+tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.send("compressed-level", 0);
+    try expectRecv(&pull, "compressed-level");
+}
+
+test "zstd tcp auto train" {
+    if (!try omq.has(allocator, "zstd")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveTimeout(2000);
+    try push.setCompressionAutoTrain(true);
+    try testing.expect(try push.compressionAutoTrain());
+
+    const bound = try pull.bind(allocator, "zstd+tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const payload = try allocator.alloc(u8, 2048);
+    defer allocator.free(payload);
+    @memset(payload, 'z');
 
     _ = try push.send(payload, 0);
     const got = try pull.recvAlloc(allocator, 0);

--- a/bindings/zig/tests/parity.zig
+++ b/bindings/zig/tests/parity.zig
@@ -1,0 +1,326 @@
+const std = @import("std");
+const omq = @import("omq");
+
+const testing = std.testing;
+const allocator = testing.allocator;
+
+const ZSTD_DICT = [_]u8{
+    0x37, 0xa4, 0x30, 0xec, 0xbe, 0xaa, 0xdd, 0x5c, 0x81, 0x11, 0x20, 0x84,
+    0x10, 0x42, 0x66, 0x46, 0x44, 0x44, 0x44, 0x42, 0x44, 0x90, 0x20, 0x02,
+    0x11, 0x4c, 0x41, 0x86, 0x38, 0xc2, 0x18, 0x41, 0x04, 0x20, 0x82, 0x18,
+    0x41, 0x04, 0x20, 0x82, 0x14, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+    0x44, 0x24, 0x09, 0x00, 0x00, 0x51, 0x10, 0x63, 0x8c, 0x31, 0xc6, 0x18,
+    0x63, 0x0c, 0x21, 0xc4, 0x18, 0x63, 0x66, 0x66, 0x86, 0x46, 0x92, 0x04,
+    0x00, 0x80, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x00,
+};
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn inprocEndpoint(comptime label: []const u8) []const u8 {
+    return "inproc://zig-parity-" ++ label;
+}
+
+fn expectRecv(socket: *omq.Socket, expected: []const u8) !void {
+    const got = try socket.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualStrings(expected, got);
+}
+
+test "convenience methods cover pyomq behavior" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try push.setSendTimeout(1000);
+    try testing.expectEqual(@as(i32, 1000), try push.sendTimeout());
+    try push.setIdentity("alias-id");
+
+    const bound = try pull.bind(allocator, inprocEndpoint("aliases"));
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    _ = try push.sendString("hello");
+    try expectRecv(&pull, "hello");
+
+    try push.sendMultipart(&.{ "a", "b", "c" }, 0);
+    var got = try pull.recvMultipartAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqual(@as(usize, 3), got.parts.len);
+    try testing.expectEqualStrings("a", got.parts[0]);
+    try testing.expectEqualStrings("b", got.parts[1]);
+    try testing.expectEqualStrings("c", got.parts[2]);
+
+    try push.close();
+    try pull.close();
+    try ctx.term();
+}
+
+test "socket lifecycle and option helpers match pyomq shape" {
+    var ctx = try omq.Context.init();
+    try testing.expect(!ctx.closed());
+
+    var sock = try ctx.socket(omq.DEALER);
+    try testing.expect(!sock.closed());
+
+    try sock.setHighWaterMark(500);
+    try testing.expectEqual(@as(i32, 500), try sock.highWaterMark());
+    try testing.expectEqual(@as(i32, 500), try sock.sendHighWaterMark());
+    try testing.expectEqual(@as(i32, 500), try sock.receiveHighWaterMark());
+
+    try sock.setIdentity("dealer-a");
+    const identity = try sock.identityAlloc(allocator);
+    defer allocator.free(identity);
+    try testing.expectEqualStrings("dealer-a", identity);
+
+    try sock.close();
+    try testing.expect(sock.closed());
+
+    try ctx.term();
+    try testing.expect(ctx.closed());
+}
+
+test "bindToRandomPort and getLastEndpoint" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var sock = try ctx.socket(omq.PULL);
+    defer sock.deinit();
+
+    const port = try sock.bindToRandomPort(allocator, "tcp://127.0.0.1", .{});
+    try testing.expect(port >= 1024);
+
+    const endpoint = try sock.getLastEndpoint(allocator);
+    defer allocator.free(endpoint);
+    try testing.expect(std.mem.startsWith(u8, endpoint, "tcp://127.0.0.1:"));
+
+    var suffix_buf: [16]u8 = undefined;
+    const suffix = try std.fmt.bufPrint(&suffix_buf, ":{d}", .{port});
+    try testing.expect(std.mem.endsWith(u8, endpoint, suffix));
+
+    var conflict = try ctx.socket(omq.PULL);
+    defer conflict.deinit();
+    try testing.expectError(
+        error.AddressInUse,
+        conflict.bindToRandomPort(allocator, "tcp://127.0.0.1", .{
+            .min_port = port,
+            .max_port = port,
+            .max_tries = 1,
+        }),
+    );
+}
+
+test "rcvmore iterates multipart frames" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    try push.sendMultipart(&.{ "x", "y", "z" }, 0);
+    try expectRecv(&pull, "x");
+    try testing.expect(try pull.hasReceiveMore());
+    try expectRecv(&pull, "y");
+    try testing.expect(try pull.hasReceiveMore());
+    try expectRecv(&pull, "z");
+    try testing.expect(!try pull.hasReceiveMore());
+}
+
+test "socket poll helper reports timeout and readiness" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    try testing.expectEqual(@as(i16, 0), try pull.poll(20, omq.POLLIN));
+    _ = try push.send("ready", 0);
+    try testing.expect((try pull.poll(1000, omq.POLLIN)) & omq.POLLIN != 0);
+    try expectRecv(&pull, "ready");
+}
+
+test "connect before bind works for inproc req rep" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+
+    const endpoint = inprocEndpoint("cbb-req-rep");
+    try req.connect(allocator, endpoint);
+    sleepMillis(20);
+    const bound = try rep.bind(allocator, endpoint);
+    defer allocator.free(bound);
+
+    _ = try req.send("q", 0);
+    try expectRecv(&rep, "q");
+    _ = try rep.send("a", 0);
+    try expectRecv(&req, "a");
+}
+
+test "connect before bind works for inproc pair" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var a = try ctx.socket(omq.PAIR);
+    defer a.deinit();
+    var b = try ctx.socket(omq.PAIR);
+    defer b.deinit();
+
+    const endpoint = inprocEndpoint("cbb-pair");
+    try a.connect(allocator, endpoint);
+    sleepMillis(20);
+    const bound = try b.bind(allocator, endpoint);
+    defer allocator.free(bound);
+
+    _ = try a.send("from-a", 0);
+    try expectRecv(&b, "from-a");
+    _ = try b.send("from-b", 0);
+    try expectRecv(&a, "from-b");
+}
+
+test "poller timeout unregister and modify" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    var poller = omq.Poller.init(allocator);
+    defer poller.deinit();
+
+    try poller.register(&pull, omq.POLLIN);
+    const timeout_events = try poller.pollAlloc(20);
+    defer allocator.free(timeout_events);
+    try testing.expectEqual(@as(usize, 0), timeout_events.len);
+
+    _ = try push.send("ready", 0);
+    const events = try poller.pollAlloc(1000);
+    defer allocator.free(events);
+    try testing.expectEqual(@as(usize, 1), events.len);
+
+    try poller.modify(&pull, 0);
+    try expectRecv(&pull, "ready");
+    const disabled_events = try poller.pollAlloc(20);
+    defer allocator.free(disabled_events);
+    try testing.expectEqual(@as(usize, 0), disabled_events.len);
+
+    try poller.unregister(&pull);
+    try testing.expectError(error.NoSocket, poller.modify(&pull, omq.POLLIN));
+}
+
+test "plain req rep tcp" {
+    if (!try omq.has(allocator, "plain")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+
+    try rep.setPlainServer(true);
+    try req.setPlainClient(allocator, "alice", "secret");
+    try rep.setReceiveTimeout(5000);
+    try req.setReceiveTimeout(5000);
+    try req.setSendTimeout(5000);
+
+    const bound = try rep.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try req.connect(allocator, bound);
+
+    _ = try req.send("ping", 0);
+    try expectRecv(&rep, "ping");
+    _ = try rep.send("pong", 0);
+    try expectRecv(&req, "pong");
+}
+
+test "curve req rep tcp" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    const server = try omq.curveKeypair();
+    const client = try omq.curveKeypair();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+
+    try rep.setCurveServer(allocator, server.publicSlice(), server.secretSlice());
+    try req.setCurveClient(allocator, client.publicSlice(), client.secretSlice(), server.publicSlice());
+    try rep.setReceiveTimeout(5000);
+    try req.setReceiveTimeout(5000);
+    try req.setSendTimeout(5000);
+
+    const bound = try rep.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try req.connect(allocator, bound);
+
+    _ = try req.send("ping", 0);
+    try expectRecv(&rep, "ping");
+    _ = try rep.send("pong", 0);
+    try expectRecv(&req, "pong");
+}
+
+test "zstd tcp static dict" {
+    if (!try omq.has(allocator, "zstd")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveTimeout(2000);
+    try push.setCompressionLevel(1);
+    try push.setCompressionDict(ZSTD_DICT[0..]);
+
+    const bound = try pull.bind(allocator, "zstd+tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const payload = try allocator.alloc(u8, 4096);
+    defer allocator.free(payload);
+    @memset(payload, 'A');
+
+    _ = try push.send(payload, 0);
+    const got = try pull.recvAlloc(allocator, 0);
+    defer allocator.free(got);
+    try testing.expectEqualSlices(u8, payload, got);
+}

--- a/bindings/zig/tests/parity.zig
+++ b/bindings/zig/tests/parity.zig
@@ -1,6 +1,13 @@
 const std = @import("std");
 const omq = @import("omq");
 
+const c = @cImport({
+    @cInclude("arpa/inet.h");
+    @cInclude("netinet/in.h");
+    @cInclude("sys/socket.h");
+    @cInclude("unistd.h");
+});
+
 const testing = std.testing;
 const allocator = testing.allocator;
 
@@ -27,10 +34,46 @@ fn inprocEndpoint(comptime label: []const u8) []const u8 {
     return "inproc://zig-parity-" ++ label;
 }
 
+fn freeUdpPort() !u16 {
+    const fd = c.socket(c.AF_INET, c.SOCK_DGRAM, 0);
+    try testing.expect(fd >= 0);
+    defer _ = c.close(fd);
+
+    var addr: c.struct_sockaddr_in = std.mem.zeroes(c.struct_sockaddr_in);
+    addr.sin_family = c.AF_INET;
+    addr.sin_port = c.htons(0);
+    addr.sin_addr.s_addr = c.htonl(0x7f000001);
+
+    try testing.expectEqual(
+        @as(c_int, 0),
+        c.bind(fd, @ptrCast(&addr), @sizeOf(c.struct_sockaddr_in)),
+    );
+
+    var len: c.socklen_t = @sizeOf(c.struct_sockaddr_in);
+    try testing.expectEqual(
+        @as(c_int, 0),
+        c.getsockname(fd, @ptrCast(&addr), &len),
+    );
+    return c.ntohs(addr.sin_port);
+}
+
 fn expectRecv(socket: *omq.Socket, expected: []const u8) !void {
     const got = try socket.recvAlloc(allocator, 0);
     defer allocator.free(got);
     try testing.expectEqualStrings(expected, got);
+}
+
+const ProxyState = struct {
+    frontend: *omq.Socket,
+    backend: *omq.Socket,
+    control: *omq.Socket,
+    failed: *bool,
+};
+
+fn proxySteerableThread(state: *ProxyState) void {
+    omq.proxySteerable(state.frontend, state.backend, null, state.control) catch {
+        state.failed.* = true;
+    };
 }
 
 test "convenience methods cover pyomq behavior" {
@@ -155,9 +198,11 @@ test "socket poll helper reports timeout and readiness" {
     defer allocator.free(bound);
     try push.connect(allocator, bound);
 
+    try testing.expect(try pull.fd() >= 0);
     try testing.expectEqual(@as(i16, 0), try pull.poll(20, omq.POLLIN));
     _ = try push.send("ready", 0);
     try testing.expect((try pull.poll(1000, omq.POLLIN)) & omq.POLLIN != 0);
+    try testing.expect((try pull.pollEvents()) & omq.POLLIN != 0);
     try expectRecv(&pull, "ready");
 }
 
@@ -203,6 +248,65 @@ test "connect before bind works for inproc pair" {
     try expectRecv(&a, "from-b");
 }
 
+test "connect before bind works for ipc push pull" {
+    if (!try omq.has(allocator, "ipc")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+
+    const path_raw = try std.fmt.allocPrint(allocator, "/tmp/omq-zig-cbb-{d}", .{c.getpid()});
+    defer allocator.free(path_raw);
+    const path = try allocator.dupeZ(u8, path_raw);
+    defer allocator.free(path);
+    _ = c.unlink(path.ptr);
+    defer _ = c.unlink(path.ptr);
+
+    const endpoint = try std.fmt.allocPrint(allocator, "ipc://{s}", .{path});
+    defer allocator.free(endpoint);
+
+    try pull.setReceiveTimeout(2000);
+    try push.setSendTimeout(2000);
+    try push.connect(allocator, endpoint);
+    sleepMillis(20);
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+
+    _ = try push.send("ipc-cbb", 0);
+    try expectRecv(&pull, "ipc-cbb");
+}
+
+test "connect before bind works for tcp push pull" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var probe = try ctx.socket(omq.PULL);
+    const port = try probe.bindToRandomPort(allocator, "tcp://127.0.0.1", .{});
+    try probe.close();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+    var pull = try ctx.socket(omq.PULL);
+    defer pull.deinit();
+
+    const endpoint = try std.fmt.allocPrint(allocator, "tcp://127.0.0.1:{d}", .{port});
+    defer allocator.free(endpoint);
+
+    try pull.setReceiveTimeout(5000);
+    try push.setSendTimeout(5000);
+    try push.connect(allocator, endpoint);
+    sleepMillis(20);
+    const bound = try pull.bind(allocator, endpoint);
+    defer allocator.free(bound);
+
+    _ = try push.send("tcp-cbb", 0);
+    try expectRecv(&pull, "tcp-cbb");
+}
+
 test "poller timeout unregister and modify" {
     var ctx = try omq.Context.init();
     defer ctx.deinit();
@@ -237,6 +341,141 @@ test "poller timeout unregister and modify" {
 
     try poller.unregister(&pull);
     try testing.expectError(error.NoSocket, poller.modify(&pull, omq.POLLIN));
+}
+
+test "proxy steerable forwards and terminates" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var frontend = try ctx.socket(omq.PULL);
+    defer frontend.deinit();
+    var backend = try ctx.socket(omq.PUSH);
+    defer backend.deinit();
+    var control = try ctx.socket(omq.PULL);
+    defer control.deinit();
+    var sender = try ctx.socket(omq.PUSH);
+    defer sender.deinit();
+    var receiver = try ctx.socket(omq.PULL);
+    defer receiver.deinit();
+    var controller = try ctx.socket(omq.PUSH);
+    defer controller.deinit();
+
+    try frontend.allowThreadMigration();
+    try backend.allowThreadMigration();
+    try control.allowThreadMigration();
+
+    const frontend_endpoint = try frontend.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(frontend_endpoint);
+    const backend_endpoint = try backend.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(backend_endpoint);
+    const control_endpoint = try control.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(control_endpoint);
+
+    try sender.connect(allocator, frontend_endpoint);
+    try receiver.connect(allocator, backend_endpoint);
+    try controller.connect(allocator, control_endpoint);
+    try receiver.setReceiveTimeout(2000);
+
+    var failed = false;
+    var state: ProxyState = .{
+        .frontend = &frontend,
+        .backend = &backend,
+        .control = &control,
+        .failed = &failed,
+    };
+    const thread = try std.Thread.spawn(.{}, proxySteerableThread, .{&state});
+    sleepMillis(50);
+
+    _ = try sender.send("through-proxy", 0);
+    try expectRecv(&receiver, "through-proxy");
+    _ = try controller.send("TERMINATE", 0);
+    thread.join();
+    try testing.expect(!failed);
+}
+
+test "stream socket accepts raw tcp" {
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var stream = try ctx.socket(omq.STREAM);
+    defer stream.deinit();
+    try stream.setReceiveTimeout(2000);
+
+    const port = try stream.bindToRandomPort(allocator, "tcp://127.0.0.1", .{});
+
+    const fd = c.socket(c.AF_INET, c.SOCK_STREAM, 0);
+    try testing.expect(fd >= 0);
+    defer _ = c.close(fd);
+
+    var addr: c.struct_sockaddr_in = std.mem.zeroes(c.struct_sockaddr_in);
+    addr.sin_family = c.AF_INET;
+    addr.sin_port = c.htons(port);
+    addr.sin_addr.s_addr = c.htonl(0x7f000001);
+
+    try testing.expectEqual(
+        @as(c_int, 0),
+        c.connect(
+            fd,
+            @ptrCast(&addr),
+            @sizeOf(c.struct_sockaddr_in),
+        ),
+    );
+
+    try testing.expectEqual(@as(isize, 5), c.send(fd, "hello", 5, 0));
+
+    var opened = try stream.recvMultipartAlloc(allocator, 0);
+    defer opened.deinit();
+    try testing.expectEqual(@as(usize, 2), opened.parts.len);
+    try testing.expect(opened.parts[0].len > 0);
+    try testing.expectEqualStrings("", opened.parts[1]);
+
+    var data = try stream.recvMultipartAlloc(allocator, 0);
+    defer data.deinit();
+    try testing.expectEqual(@as(usize, 2), data.parts.len);
+    try testing.expectEqualSlices(u8, opened.parts[0], data.parts[0]);
+    try testing.expectEqualStrings("hello", data.parts[1]);
+
+    const reply = [_][]const u8{ data.parts[0], "world" };
+    try stream.sendMultipart(&reply, 0);
+
+    var buffer: [16]u8 = undefined;
+    const received = c.recv(fd, &buffer, buffer.len, 0);
+    try testing.expectEqual(@as(isize, 5), received);
+    try testing.expectEqualStrings("world", buffer[0..5]);
+}
+
+test "radio dish udp filters groups" {
+    if (!try omq.has(allocator, "udp")) return;
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var dish = try ctx.socket(omq.DISH);
+    defer dish.deinit();
+    var radio = try ctx.socket(omq.RADIO);
+    defer radio.deinit();
+
+    const port = try freeUdpPort();
+    const endpoint = try std.fmt.allocPrint(allocator, "udp://127.0.0.1:{d}", .{port});
+    defer allocator.free(endpoint);
+
+    try dish.setReceiveTimeout(500);
+    try dish.join(allocator, "weather");
+    const bound = try dish.bind(allocator, endpoint);
+    defer allocator.free(bound);
+    try radio.connect(allocator, endpoint);
+    sleepMillis(50);
+
+    try radio.sendGroup(allocator, "news", "ignored", 0);
+    try radio.sendGroup(allocator, "weather", "sunny", 0);
+
+    var got = try dish.recvFrameAlloc(allocator, 0);
+    defer got.deinit();
+    try testing.expectEqualStrings("sunny", got.data);
+
+    try dish.leave(allocator, "weather");
+    try radio.sendGroup(allocator, "weather", "ignored", 0);
+    try testing.expectError(error.Again, dish.recvAlloc(allocator, 0));
 }
 
 test "plain req rep tcp" {
@@ -294,6 +533,36 @@ test "curve req rep tcp" {
     try expectRecv(&rep, "ping");
     _ = try rep.send("pong", 0);
     try expectRecv(&req, "pong");
+}
+
+test "curve option helpers round trip" {
+    if (!try omq.has(allocator, "curve")) return;
+
+    const keys = try omq.curveKeypair();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var sock = try ctx.socket(omq.PUSH);
+    defer sock.deinit();
+
+    try sock.setCurveServer(allocator, keys.publicSlice(), keys.secretSlice());
+    try testing.expect(try sock.curveServer());
+
+    try sock.setCurvePublicKey(allocator, keys.publicSlice());
+    try sock.setCurveSecretKey(allocator, keys.secretSlice());
+    const public = try sock.curvePublicKeyAlloc(allocator);
+    defer allocator.free(public);
+    try testing.expectEqualStrings(keys.publicSlice(), public);
+
+    const secret = try sock.curveSecretKeyAlloc(allocator);
+    defer allocator.free(secret);
+    try testing.expectEqualStrings(keys.secretSlice(), secret);
+
+    try sock.setCurveServerKey(allocator, keys.publicSlice());
+    const server_key = try sock.curveServerKeyAlloc(allocator);
+    defer allocator.free(server_key);
+    try testing.expectEqualStrings(keys.publicSlice(), server_key);
 }
 
 test "zstd tcp static dict" {

--- a/bindings/zig/tests/soak.zig
+++ b/bindings/zig/tests/soak.zig
@@ -13,7 +13,8 @@ const testing = std.testing;
 const allocator = std.heap.page_allocator;
 const ns_per_s = std.time.ns_per_s;
 const default_duration_ns: i128 = 120 * ns_per_s;
-const scenario_count: i128 = 3;
+const mib = 1_048_576;
+const large_message_size = 1024 * 1024;
 
 const Sample = struct {
     rss_bytes: u64,
@@ -55,12 +56,12 @@ const ResourceMonitor = struct {
         }
 
         std.debug.print(
-            "[{s}] RSS start {} MiB, final {} MiB, peak {} MiB; FDs start {}, final {}, peak {}\n",
+            "[{s}] resources: RSS start {} MiB, final {} MiB, peak {} MiB; FDs start {}, final {}, peak {}\n",
             .{
                 label,
-                baseline.rss_bytes / 1_048_576,
-                final.rss_bytes / 1_048_576,
-                peak_rss / 1_048_576,
+                baseline.rss_bytes / mib,
+                final.rss_bytes / mib,
+                peak_rss / mib,
                 baseline.fd_count,
                 final.fd_count,
                 peak_fds,
@@ -73,13 +74,61 @@ const ResourceMonitor = struct {
         if (baseline.fd_count != 0 and peak_fds > baseline.fd_count + peak_fd_slack) {
             return error.FdLeak;
         }
-        if (baseline.rss_bytes != 0) {
-            const rss_growth = final.rss_bytes -| baseline.rss_bytes;
-            const allowed = @max(baseline.rss_bytes, 10 * 1_048_576);
-            if (rss_growth > allowed) return error.RssLeak;
+
+        if (samples.len < 10) {
+            std.debug.print("[{s}] too few RSS samples ({}) to check for leaks\n", .{ label, samples.len });
+            return;
         }
+
+        const warmup = samples.len / 5;
+        const post_warmup = samples[warmup..];
+        if (post_warmup.len == 0) return;
+
+        const baseline_count = @max(post_warmup.len / 10, 1);
+        var baseline_sum: u128 = 0;
+        for (post_warmup[0..baseline_count]) |entry| {
+            baseline_sum += entry.rss_bytes;
+        }
+        const rss_baseline: u64 = @intCast(baseline_sum / baseline_count);
+
+        const tail_start = post_warmup.len * 4 / 5;
+        var tail_max: u64 = 0;
+        for (post_warmup[tail_start..]) |entry| {
+            tail_max = @max(tail_max, entry.rss_bytes);
+        }
+
+        const tail_growth = tail_max -| rss_baseline;
+        const final_growth = final.rss_bytes -| rss_baseline;
+        const final_growth_mib = bytesToMib(final_growth);
+        const tail_growth_pct = percentGrowth(tail_growth, rss_baseline);
+        const final_growth_pct = percentGrowth(final_growth, rss_baseline);
+
+        std.debug.print(
+            "[{s}] RSS: baseline {d:.1} MiB, tail max {d:.1} MiB, final {d:.1} MiB, peak {d:.1} MiB, tail growth {d:.1}%, final growth {d:.1}%\n",
+            .{
+                label,
+                bytesToMib(rss_baseline),
+                bytesToMib(tail_max),
+                bytesToMib(final.rss_bytes),
+                bytesToMib(peak_rss),
+                tail_growth_pct,
+                final_growth_pct,
+            },
+        );
+
+        const threshold_pct: f64 = if (samples.len >= 120) 25.0 else 100.0;
+        if (final_growth_pct >= threshold_pct and final_growth_mib >= 10.0) return error.RssLeak;
     }
 };
+
+fn bytesToMib(bytes: u64) f64 {
+    return @as(f64, @floatFromInt(bytes)) / mib;
+}
+
+fn percentGrowth(growth: u64, baseline: u64) f64 {
+    if (baseline == 0) return 0.0;
+    return @as(f64, @floatFromInt(growth)) / @as(f64, @floatFromInt(baseline)) * 100.0;
+}
 
 fn readRssBytes() u64 {
     if (builtin.os.tag != .linux) return 0;
@@ -113,10 +162,6 @@ fn soakDurationNs() i128 {
     return @intFromFloat(seconds * @as(f64, @floatFromInt(ns_per_s)));
 }
 
-fn scenarioDurationNs() i128 {
-    return @max(@divTrunc(soakDurationNs(), scenario_count), ns_per_s);
-}
-
 fn nowNs() i128 {
     var ts: c.struct_timespec = undefined;
     if (c.clock_gettime(c.CLOCK_MONOTONIC, &ts) != 0) return 0;
@@ -147,6 +192,13 @@ fn loadCounter(ptr: *u64) u64 {
     return @atomicLoad(u64, ptr, .monotonic);
 }
 
+fn soakSocket(ctx: *omq.Context, socket_type: i32) !omq.Socket {
+    var socket = try ctx.socket(socket_type);
+    errdefer socket.deinit();
+    try socket.setLinger(0);
+    return socket;
+}
+
 const ReqRepServer = struct {
     rep: *omq.Socket,
     stop: *bool,
@@ -162,16 +214,17 @@ fn reqRepServer(state: *ReqRepServer) void {
                 return;
             },
         };
-        defer allocator.free(msg);
         _ = state.rep.send(msg, 0) catch {
+            allocator.free(msg);
             storeBool(state.failed, true);
             return;
         };
+        allocator.free(msg);
     }
 }
 
 test "context churn tracks resources" {
-    const duration_ns = scenarioDurationNs();
+    const duration_ns = soakDurationNs();
     var monitor = try ResourceMonitor.init(allocator);
     defer monitor.deinit();
 
@@ -182,9 +235,9 @@ test "context churn tracks resources" {
     while (nowNs() - start < duration_ns) {
         var ctx = try omq.Context.init();
 
-        var pull = try ctx.socket(omq.PULL);
+        var pull = try soakSocket(&ctx, omq.PULL);
         errdefer pull.deinit();
-        var push = try ctx.socket(omq.PUSH);
+        var push = try soakSocket(&ctx, omq.PUSH);
         errdefer push.deinit();
 
         try pull.setReceiveTimeout(1000);
@@ -219,16 +272,16 @@ test "context churn tracks resources" {
 }
 
 test "req rep cycles track resources" {
-    const duration_ns = scenarioDurationNs();
+    const duration_ns = soakDurationNs();
     var monitor = try ResourceMonitor.init(allocator);
     defer monitor.deinit();
 
     var ctx = try omq.Context.init();
     defer ctx.deinit();
 
-    var rep = try ctx.socket(omq.REP);
+    var rep = try soakSocket(&ctx, omq.REP);
     defer rep.deinit();
-    var req = try ctx.socket(omq.REQ);
+    var req = try soakSocket(&ctx, omq.REQ);
     defer req.deinit();
 
     try rep.setReceiveTimeout(100);
@@ -253,8 +306,8 @@ test "req rep cycles track resources" {
         const text = try std.fmt.bufPrint(&payload, "r-{d}", .{cycles});
         _ = try req.send(text, 0);
         const reply = try req.recvAlloc(allocator, 0);
-        defer allocator.free(reply);
         try testing.expectEqualStrings(text, reply);
+        allocator.free(reply);
         cycles += 1;
 
         const now = nowNs();
@@ -277,20 +330,367 @@ test "req rep cycles track resources" {
     try monitor.assertNoLeak("req_rep", 32);
 }
 
-const Peer = struct {
-    socket: omq.Socket,
-    connected: bool,
-};
-
-test "peer churn tracks resources" {
-    const duration_ns = scenarioDurationNs();
+test "push pull sustained tracks resources" {
+    const duration_ns = soakDurationNs();
     var monitor = try ResourceMonitor.init(allocator);
     defer monitor.deinit();
 
     var ctx = try omq.Context.init();
     defer ctx.deinit();
 
-    var push = try ctx.socket(omq.PUSH);
+    var pull = try soakSocket(&ctx, omq.PULL);
+    defer pull.deinit();
+    var push = try soakSocket(&ctx, omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveTimeout(1000);
+    try push.setSendTimeout(1000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var messages: u64 = 0;
+    var payload: [32]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const text = try std.fmt.bufPrint(&payload, "p-{d}", .{messages});
+        _ = try push.send(text, 0);
+        const got = try pull.recvAlloc(allocator, 0);
+        try testing.expectEqualStrings(text, got);
+        allocator.free(got);
+        messages += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[push_pull] {} messages\n", .{messages});
+        }
+    }
+
+    try push.close();
+    try pull.close();
+    try ctx.term();
+
+    try testing.expect(messages > 0);
+    try monitor.assertNoLeak("push_pull", 32);
+}
+
+test "pair bidirectional tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var a = try soakSocket(&ctx, omq.PAIR);
+    defer a.deinit();
+    var b = try soakSocket(&ctx, omq.PAIR);
+    defer b.deinit();
+
+    try a.setReceiveTimeout(1000);
+    try b.setReceiveTimeout(1000);
+    try a.setSendTimeout(1000);
+    try b.setSendTimeout(1000);
+
+    const bound = try a.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try b.connect(allocator, bound);
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var cycles: u64 = 0;
+    var payload: [32]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const text = try std.fmt.bufPrint(&payload, "pair-{d}", .{cycles});
+        _ = try a.send(text, 0);
+        const left = try b.recvAlloc(allocator, 0);
+        try testing.expectEqualStrings(text, left);
+        allocator.free(left);
+
+        _ = try b.send(text, 0);
+        const right = try a.recvAlloc(allocator, 0);
+        try testing.expectEqualStrings(text, right);
+        allocator.free(right);
+        cycles += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[pair] {} cycles\n", .{cycles});
+        }
+    }
+
+    try b.close();
+    try a.close();
+    try ctx.term();
+
+    try testing.expect(cycles > 0);
+    try monitor.assertNoLeak("pair", 32);
+}
+
+test "multipart push pull tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try soakSocket(&ctx, omq.PULL);
+    defer pull.deinit();
+    var push = try soakSocket(&ctx, omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveTimeout(1000);
+    try push.setSendTimeout(1000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var messages: u64 = 0;
+    var tail_buf: [32]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const tail = try std.fmt.bufPrint(&tail_buf, "tail-{d}", .{messages});
+        try push.sendMultipart(&.{ "head", "body", tail }, 0);
+        var got = try pull.recvMultipartAlloc(allocator, 0);
+        try testing.expectEqual(@as(usize, 3), got.parts.len);
+        try testing.expectEqualStrings("head", got.parts[0]);
+        try testing.expectEqualStrings("body", got.parts[1]);
+        try testing.expectEqualStrings(tail, got.parts[2]);
+        got.deinit();
+        messages += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[multipart] {} messages\n", .{messages});
+        }
+    }
+
+    try push.close();
+    try pull.close();
+    try ctx.term();
+
+    try testing.expect(messages > 0);
+    try monitor.assertNoLeak("multipart", 32);
+}
+
+test "pub sub sustained tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var publisher = try soakSocket(&ctx, omq.PUB);
+    defer publisher.deinit();
+    var sub = try soakSocket(&ctx, omq.SUB);
+    defer sub.deinit();
+
+    try sub.subscribe("topic/");
+    try sub.setReceiveTimeout(100);
+
+    const bound = try publisher.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try sub.connect(allocator, bound);
+    sleepMillis(300);
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var sent: u64 = 0;
+    var received: u64 = 0;
+    var payload: [48]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const text = try std.fmt.bufPrint(&payload, "topic/{d}", .{sent});
+        _ = try publisher.send(text, 0);
+        sent += 1;
+
+        const got = sub.recvAlloc(allocator, 0) catch |err| switch (err) {
+            error.Again => null,
+            else => return err,
+        };
+        if (got) |msg| {
+            allocator.free(msg);
+            received += 1;
+        }
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[pub_sub] sent {}, received {}\n", .{ sent, received });
+        }
+    }
+
+    try sub.close();
+    try publisher.close();
+    try ctx.term();
+
+    try testing.expect(sent > 0);
+    try testing.expect(received > 0);
+    try monitor.assertNoLeak("pub_sub", 32);
+}
+
+test "large messages track resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var pull = try soakSocket(&ctx, omq.PULL);
+    defer pull.deinit();
+    var push = try soakSocket(&ctx, omq.PUSH);
+    defer push.deinit();
+
+    try pull.setReceiveHighWaterMark(4);
+    try push.setSendHighWaterMark(4);
+    try pull.setReceiveTimeout(5000);
+    try push.setSendTimeout(5000);
+
+    const bound = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try push.connect(allocator, bound);
+
+    const payload = try allocator.alloc(u8, large_message_size);
+    defer allocator.free(payload);
+    for (payload, 0..) |*byte, index| {
+        byte.* = @intCast(index & 0xff);
+    }
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var messages: u64 = 0;
+    while (nowNs() - start < duration_ns) {
+        _ = try push.send(payload, 0);
+        const got = try pull.recvAlloc(allocator, 0);
+        try testing.expectEqual(@as(usize, large_message_size), got.len);
+        try testing.expectEqual(payload[0], got[0]);
+        try testing.expectEqual(payload[payload.len - 1], got[got.len - 1]);
+        allocator.free(got);
+        messages += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[large_msg] {} messages\n", .{messages});
+        }
+    }
+
+    try push.close();
+    try pull.close();
+    try ctx.term();
+
+    try testing.expect(messages > 0);
+    try monitor.assertNoLeak("large_msg", 32);
+}
+
+fn bindReconnectPull(ctx: *omq.Context, endpoint: []const u8) !omq.Socket {
+    var pull = try soakSocket(ctx, omq.PULL);
+    errdefer pull.deinit();
+    try pull.setReceiveTimeout(500);
+
+    for (0..40) |_| {
+        const bound = pull.bind(allocator, endpoint) catch |err| switch (err) {
+            error.AddressInUse => {
+                sleepMillis(25);
+                continue;
+            },
+            else => return err,
+        };
+        allocator.free(bound);
+        return pull;
+    }
+    return error.AddressInUse;
+}
+
+test "reconnect storm tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try soakSocket(&ctx, omq.PUSH);
+    defer push.deinit();
+    try push.setSendTimeout(500);
+    try push.setReconnectInterval(10);
+
+    var pull = try soakSocket(&ctx, omq.PULL);
+    try pull.setReceiveTimeout(500);
+    const endpoint = try pull.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(endpoint);
+    try push.connect(allocator, endpoint);
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var cycles: u64 = 0;
+    var delivered: u64 = 0;
+    var payload: [32]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const text = try std.fmt.bufPrint(&payload, "c-{d}", .{cycles});
+        _ = push.send(text, 0) catch |err| switch (err) {
+            error.Again => {},
+            else => return err,
+        };
+
+        const got = pull.recvAlloc(allocator, 0) catch |err| switch (err) {
+            error.Again => null,
+            else => return err,
+        };
+        if (got) |msg| {
+            try testing.expectEqualStrings(text, msg);
+            allocator.free(msg);
+            delivered += 1;
+        }
+
+        try pull.close();
+        pull = try bindReconnectPull(&ctx, endpoint);
+        cycles += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[reconnect_storm] cycles {}, delivered {}\n", .{ cycles, delivered });
+        }
+    }
+
+    try pull.close();
+    try push.close();
+    try ctx.term();
+
+    try testing.expect(cycles > 0);
+    try monitor.assertNoLeak("reconnect_storm", 32);
+}
+
+const Peer = struct {
+    socket: omq.Socket,
+    connected: bool,
+};
+
+test "peer churn tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try soakSocket(&ctx, omq.PUSH);
     defer push.deinit();
     try push.setSendTimeout(1);
     try push.setSendHighWaterMark(1024);
@@ -304,7 +704,7 @@ test "peer churn tracks resources" {
     }
 
     for (0..20) |_| {
-        var pull = try ctx.socket(omq.PULL);
+        var pull = try soakSocket(&ctx, omq.PULL);
         try pull.setReceiveTimeout(0);
         try pull.connect(allocator, bound);
         try peers.append(.{ .socket = pull, .connected = true });
@@ -333,7 +733,7 @@ test "peer churn tracks resources" {
         if (ticks % 19 == 0) {
             const index = ticks % peers.items.len;
             peers.items[index].socket.deinit();
-            var pull = try ctx.socket(omq.PULL);
+            var pull = try soakSocket(&ctx, omq.PULL);
             try pull.setReceiveTimeout(0);
             try pull.connect(allocator, bound);
             peers.items[index] = .{ .socket = pull, .connected = true };

--- a/bindings/zig/tests/soak.zig
+++ b/bindings/zig/tests/soak.zig
@@ -13,6 +13,7 @@ const testing = std.testing;
 const allocator = std.heap.page_allocator;
 const ns_per_s = std.time.ns_per_s;
 const default_duration_ns: i128 = 120 * ns_per_s;
+const scenario_count: i128 = 3;
 
 const Sample = struct {
     rss_bytes: u64,
@@ -112,6 +113,10 @@ fn soakDurationNs() i128 {
     return @intFromFloat(seconds * @as(f64, @floatFromInt(ns_per_s)));
 }
 
+fn scenarioDurationNs() i128 {
+    return @max(@divTrunc(soakDurationNs(), scenario_count), ns_per_s);
+}
+
 fn nowNs() i128 {
     var ts: c.struct_timespec = undefined;
     if (c.clock_gettime(c.CLOCK_MONOTONIC, &ts) != 0) return 0;
@@ -165,8 +170,56 @@ fn reqRepServer(state: *ReqRepServer) void {
     }
 }
 
+test "context churn tracks resources" {
+    const duration_ns = scenarioDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var iterations: u64 = 0;
+
+    while (nowNs() - start < duration_ns) {
+        var ctx = try omq.Context.init();
+
+        var pull = try ctx.socket(omq.PULL);
+        errdefer pull.deinit();
+        var push = try ctx.socket(omq.PUSH);
+        errdefer push.deinit();
+
+        try pull.setReceiveTimeout(1000);
+        try push.setSendTimeout(1000);
+
+        var endpoint_buf: [96]u8 = undefined;
+        const endpoint = try std.fmt.bufPrint(&endpoint_buf, "inproc://zig-soak-context-{d}", .{iterations});
+        const bound = try pull.bind(allocator, endpoint);
+        try push.connect(allocator, bound);
+
+        _ = try push.send("churn", 0);
+        const got = try pull.recvAlloc(allocator, 0);
+        try testing.expectEqualStrings("churn", got);
+        allocator.free(got);
+
+        try push.close();
+        try pull.close();
+        try ctx.term();
+        allocator.free(bound);
+        iterations += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[context_churn] {} contexts\n", .{iterations});
+        }
+    }
+
+    try testing.expect(iterations > 0);
+    try monitor.assertNoLeak("context_churn", 16);
+}
+
 test "req rep cycles track resources" {
-    const duration_ns = soakDurationNs();
+    const duration_ns = scenarioDurationNs();
     var monitor = try ResourceMonitor.init(allocator);
     defer monitor.deinit();
 
@@ -230,7 +283,7 @@ const Peer = struct {
 };
 
 test "peer churn tracks resources" {
-    const duration_ns = soakDurationNs();
+    const duration_ns = scenarioDurationNs();
     var monitor = try ResourceMonitor.init(allocator);
     defer monitor.deinit();
 

--- a/bindings/zig/tests/soak.zig
+++ b/bindings/zig/tests/soak.zig
@@ -1,0 +1,340 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const omq = @import("omq");
+
+const c = @cImport({
+    @cInclude("dirent.h");
+    @cInclude("stdio.h");
+    @cInclude("stdlib.h");
+    @cInclude("time.h");
+});
+
+const testing = std.testing;
+const allocator = std.heap.page_allocator;
+const ns_per_s = std.time.ns_per_s;
+const default_duration_ns: i128 = 120 * ns_per_s;
+
+const Sample = struct {
+    rss_bytes: u64,
+    fd_count: u64,
+};
+
+const ResourceMonitor = struct {
+    samples: std.array_list.Managed(Sample),
+
+    fn init(alloc: std.mem.Allocator) !ResourceMonitor {
+        var monitor: ResourceMonitor = .{ .samples = .init(alloc) };
+        try monitor.sample();
+        return monitor;
+    }
+
+    fn deinit(self: *ResourceMonitor) void {
+        self.samples.deinit();
+    }
+
+    fn sample(self: *ResourceMonitor) !void {
+        try self.samples.append(.{
+            .rss_bytes = readRssBytes(),
+            .fd_count = readFdCount(),
+        });
+    }
+
+    fn assertNoLeak(self: *ResourceMonitor, label: []const u8, peak_fd_slack: u64) !void {
+        try self.sample();
+        const samples = self.samples.items;
+        if (samples.len == 0) return;
+
+        const baseline = samples[0];
+        const final = samples[samples.len - 1];
+        var peak_rss: u64 = 0;
+        var peak_fds: u64 = 0;
+        for (samples) |entry| {
+            peak_rss = @max(peak_rss, entry.rss_bytes);
+            peak_fds = @max(peak_fds, entry.fd_count);
+        }
+
+        std.debug.print(
+            "[{s}] RSS start {} MiB, final {} MiB, peak {} MiB; FDs start {}, final {}, peak {}\n",
+            .{
+                label,
+                baseline.rss_bytes / 1_048_576,
+                final.rss_bytes / 1_048_576,
+                peak_rss / 1_048_576,
+                baseline.fd_count,
+                final.fd_count,
+                peak_fds,
+            },
+        );
+
+        if (baseline.fd_count != 0 and final.fd_count > baseline.fd_count + 4) {
+            return error.FdLeak;
+        }
+        if (baseline.fd_count != 0 and peak_fds > baseline.fd_count + peak_fd_slack) {
+            return error.FdLeak;
+        }
+        if (baseline.rss_bytes != 0) {
+            const rss_growth = final.rss_bytes -| baseline.rss_bytes;
+            const allowed = @max(baseline.rss_bytes, 10 * 1_048_576);
+            if (rss_growth > allowed) return error.RssLeak;
+        }
+    }
+};
+
+fn readRssBytes() u64 {
+    if (builtin.os.tag != .linux) return 0;
+    const file = c.fopen("/proc/self/statm", "r") orelse return 0;
+    defer _ = c.fclose(file);
+
+    var buf = std.mem.zeroes([128]u8);
+    _ = c.fgets(&buf, buf.len, file) orelse return 0;
+    var it = std.mem.tokenizeScalar(u8, std.mem.sliceTo(&buf, 0), ' ');
+    _ = it.next() orelse return 0;
+    const resident = it.next() orelse return 0;
+    const pages = std.fmt.parseUnsigned(u64, resident, 10) catch return 0;
+    return pages * 4096;
+}
+
+fn readFdCount() u64 {
+    if (builtin.os.tag != .linux) return 0;
+    const dir = c.opendir("/proc/self/fd") orelse return 0;
+    defer _ = c.closedir(dir);
+
+    var count: u64 = 0;
+    while (c.readdir(dir) != null) {
+        count += 1;
+    }
+    return count;
+}
+
+fn soakDurationNs() i128 {
+    const raw = c.getenv("OMQ_ZIG_SOAK_DURATION_SECS") orelse return default_duration_ns;
+    const seconds = std.fmt.parseFloat(f64, std.mem.span(raw)) catch return default_duration_ns;
+    return @intFromFloat(seconds * @as(f64, @floatFromInt(ns_per_s)));
+}
+
+fn nowNs() i128 {
+    var ts: c.struct_timespec = undefined;
+    if (c.clock_gettime(c.CLOCK_MONOTONIC, &ts) != 0) return 0;
+    return (@as(i128, ts.tv_sec) * ns_per_s) + ts.tv_nsec;
+}
+
+fn sleepMillis(ms: u64) void {
+    const request: std.c.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn loadBool(ptr: *bool) bool {
+    return @atomicLoad(bool, ptr, .acquire);
+}
+
+fn storeBool(ptr: *bool, value: bool) void {
+    @atomicStore(bool, ptr, value, .release);
+}
+
+fn addCounter(ptr: *u64, value: u64) void {
+    _ = @atomicRmw(u64, ptr, .Add, value, .monotonic);
+}
+
+fn loadCounter(ptr: *u64) u64 {
+    return @atomicLoad(u64, ptr, .monotonic);
+}
+
+const ReqRepServer = struct {
+    rep: *omq.Socket,
+    stop: *bool,
+    failed: *bool,
+};
+
+fn reqRepServer(state: *ReqRepServer) void {
+    while (!loadBool(state.stop)) {
+        const msg = state.rep.recvAlloc(allocator, 0) catch |err| switch (err) {
+            error.Again => continue,
+            else => {
+                storeBool(state.failed, true);
+                return;
+            },
+        };
+        defer allocator.free(msg);
+        _ = state.rep.send(msg, 0) catch {
+            storeBool(state.failed, true);
+            return;
+        };
+    }
+}
+
+test "req rep cycles track resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var rep = try ctx.socket(omq.REP);
+    defer rep.deinit();
+    var req = try ctx.socket(omq.REQ);
+    defer req.deinit();
+
+    try rep.setReceiveTimeout(100);
+    try rep.setSendTimeout(5000);
+    try req.setReceiveTimeout(5000);
+    try req.setSendTimeout(5000);
+
+    const bound = try rep.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+    try req.connect(allocator, bound);
+
+    var stop = false;
+    var failed = false;
+    var server_state: ReqRepServer = .{ .rep = &rep, .stop = &stop, .failed = &failed };
+    const thread = try std.Thread.spawn(.{}, reqRepServer, .{&server_state});
+
+    const start = nowNs();
+    var next_sample = start + ns_per_s;
+    var cycles: u64 = 0;
+    var payload: [32]u8 = undefined;
+    while (nowNs() - start < duration_ns) {
+        const text = try std.fmt.bufPrint(&payload, "r-{d}", .{cycles});
+        _ = try req.send(text, 0);
+        const reply = try req.recvAlloc(allocator, 0);
+        defer allocator.free(reply);
+        try testing.expectEqualStrings(text, reply);
+        cycles += 1;
+
+        const now = nowNs();
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print("[req_rep] {} cycles\n", .{cycles});
+        }
+        try testing.expect(!loadBool(&failed));
+    }
+
+    storeBool(&stop, true);
+    thread.join();
+    try testing.expect(!loadBool(&failed));
+    try testing.expect(cycles > 0);
+
+    try req.close();
+    try rep.close();
+    try ctx.term();
+    try monitor.assertNoLeak("req_rep", 32);
+}
+
+const Peer = struct {
+    socket: omq.Socket,
+    connected: bool,
+};
+
+test "peer churn tracks resources" {
+    const duration_ns = soakDurationNs();
+    var monitor = try ResourceMonitor.init(allocator);
+    defer monitor.deinit();
+
+    var ctx = try omq.Context.init();
+    defer ctx.deinit();
+
+    var push = try ctx.socket(omq.PUSH);
+    defer push.deinit();
+    try push.setSendTimeout(1);
+    try push.setSendHighWaterMark(1024);
+    const bound = try push.bind(allocator, "tcp://127.0.0.1:*");
+    defer allocator.free(bound);
+
+    var peers: std.array_list.Managed(Peer) = .init(allocator);
+    defer {
+        for (peers.items) |*peer| peer.socket.deinit();
+        peers.deinit();
+    }
+
+    for (0..20) |_| {
+        var pull = try ctx.socket(omq.PULL);
+        try pull.setReceiveTimeout(0);
+        try pull.connect(allocator, bound);
+        try peers.append(.{ .socket = pull, .connected = true });
+    }
+    sleepMillis(100);
+
+    const start = nowNs();
+    var next_tick = start;
+    var next_sample = start + ns_per_s;
+    var ticks: u64 = 0;
+    var sent: u64 = 0;
+    var partitions: u64 = 0;
+    var heals: u64 = 0;
+    var replaced: u64 = 0;
+    var buf: [64]u8 = undefined;
+
+    while (nowNs() - start < duration_ns) {
+        const now = nowNs();
+        if (now < next_tick) {
+            sleepMillis(1);
+            continue;
+        }
+        next_tick = now + 100 * std.time.ns_per_ms;
+        ticks += 1;
+
+        if (ticks % 19 == 0) {
+            const index = ticks % peers.items.len;
+            peers.items[index].socket.deinit();
+            var pull = try ctx.socket(omq.PULL);
+            try pull.setReceiveTimeout(0);
+            try pull.connect(allocator, bound);
+            peers.items[index] = .{ .socket = pull, .connected = true };
+            replaced += 1;
+        } else if (ticks % 7 == 0) {
+            const index = ticks % peers.items.len;
+            if (peers.items[index].connected) {
+                try peers.items[index].socket.disconnect(allocator, bound);
+                peers.items[index].connected = false;
+                partitions += 1;
+            } else {
+                try peers.items[index].socket.connect(allocator, bound);
+                peers.items[index].connected = true;
+                heals += 1;
+            }
+        }
+
+        for (0..100) |_| {
+            const msg = try std.fmt.bufPrint(&buf, "soak-{d}", .{sent});
+            _ = push.send(msg, 0) catch |err| switch (err) {
+                error.Again => break,
+                else => return err,
+            };
+            sent += 1;
+        }
+
+        for (peers.items) |*peer| {
+            if (!peer.connected) continue;
+            while (true) {
+                var recv_buf: [64]u8 = undefined;
+                _ = peer.socket.recvInto(&recv_buf, 0) catch |err| switch (err) {
+                    error.Again => break,
+                    else => return err,
+                };
+            }
+        }
+
+        if (now >= next_sample) {
+            try monitor.sample();
+            next_sample = now + ns_per_s;
+            std.debug.print(
+                "[peer_churn] sent {}, partitions {}, heals {}, replaced {}\n",
+                .{ sent, partitions, heals, replaced },
+            );
+        }
+    }
+
+    for (peers.items) |*peer| {
+        try peer.socket.close();
+    }
+    peers.clearRetainingCapacity();
+    try push.close();
+    try ctx.term();
+
+    try testing.expect(sent > 0);
+    try monitor.assertNoLeak("peer_churn", 128);
+}

--- a/omq-libzmq/include/zmq.h
+++ b/omq-libzmq/include/zmq.h
@@ -270,7 +270,15 @@ extern "C" {
 #define ZMQ_NORM_PUSH               124
 
 /*  OMQ extension socket options.                                            */
+#define OMQ_ON_MUTE                 1004
+#define OMQ_COMPRESSION_LEVEL       1005
+#define OMQ_COMPRESSION_DICT        1006
+#define OMQ_COMPRESSION_AUTO_TRAIN  1007
 #define OMQ_ARENA_THRESHOLD         10001
+
+#define OMQ_ON_MUTE_BLOCK           0
+#define OMQ_ON_MUTE_DROP_NEWEST     1
+#define OMQ_ON_MUTE_DROP_OLDEST     2
 
 /*  Deprecated options and aliases.                                          */
 #define ZMQ_CONNECT_RID ZMQ_CONNECT_ROUTING_ID

--- a/omq-libzmq/include/zmq.h
+++ b/omq-libzmq/include/zmq.h
@@ -274,11 +274,15 @@ extern "C" {
 #define OMQ_COMPRESSION_LEVEL       1005
 #define OMQ_COMPRESSION_DICT        1006
 #define OMQ_COMPRESSION_AUTO_TRAIN  1007
+#define OMQ_WORKLOAD_PROFILE        1008
 #define OMQ_ARENA_THRESHOLD         10001
 
 #define OMQ_ON_MUTE_BLOCK           0
 #define OMQ_ON_MUTE_DROP_NEWEST     1
 #define OMQ_ON_MUTE_DROP_OLDEST     2
+#define OMQ_WORKLOAD_DEFAULT        -1
+#define OMQ_WORKLOAD_THROUGHPUT     0
+#define OMQ_WORKLOAD_LATENCY        1
 
 /*  Deprecated options and aliases.                                          */
 #define ZMQ_CONNECT_RID ZMQ_CONNECT_ROUTING_ID
@@ -330,6 +334,11 @@ extern "C" {
     this are copied into OMQ's frame arena; payloads at or above this value
     use gather-write from their Bytes payload. Set before first bind/connect.
     -1 restores the OMQ default.
+
+    OMQ_WORKLOAD_PROFILE is an int32_t scheduling hint. The default (-1) uses
+    OMQ's socket-type default: REQ/REP latency profile, other sockets
+    throughput profile. Set 1 for latency-sensitive SERVER/CLIENT,
+    ROUTER/DEALER, or PAIR sockets. Set 0 to force throughput.
 */
 
 /*  Message options ---------------------------------------------------------- */

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use omq_tokio::MechanismSetup;
-use omq_tokio::options::{KeepAlive, ReconnectPolicy};
+use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy};
 
 use crate::error::fail;
 #[cfg(unix)]
@@ -52,6 +52,10 @@ pub(crate) struct SocketOverlay {
     pub sndbuf: Option<usize>,
     pub rcvbuf: Option<usize>,
     pub xpub_verbose: bool,
+    pub on_mute: OnMute,
+    pub compression_level: Option<i32>,
+    pub compression_dict: Option<Bytes>,
+    pub compression_auto_train: bool,
     pub ipv6: bool,
     pub backlog: i32,
     pub immediate: bool,
@@ -93,6 +97,10 @@ impl Default for SocketOverlay {
             sndbuf: None,
             rcvbuf: None,
             xpub_verbose: false,
+            on_mute: OnMute::Block,
+            compression_level: None,
+            compression_dict: None,
+            compression_auto_train: false,
             ipv6: false,
             backlog: 0,
             immediate: false,
@@ -225,6 +233,10 @@ impl SocketOverlay {
             send_buffer_size: self.sndbuf,
             recv_buffer_size: self.rcvbuf,
             mechanism,
+            on_mute: self.on_mute,
+            compression_level: self.compression_level,
+            compression_dict: self.compression_dict.clone(),
+            compression_auto_train: self.compression_auto_train,
             xpub_nodrop: self.xpub_nodrop,
             reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             wss_tls: omq_tokio::options::WssTls {
@@ -365,7 +377,17 @@ const ZMQ_PLAIN: c_int = 1;
 const ZMQ_CURVE: c_int = 2;
 
 const DEFAULT_HANDSHAKE_IVL_MS: i32 = 30_000;
+const OMQ_ON_MUTE: c_int = 1004;
+const OMQ_COMPRESSION_LEVEL: c_int = 1005;
+const OMQ_COMPRESSION_DICT: c_int = 1006;
+const OMQ_COMPRESSION_AUTO_TRAIN: c_int = 1007;
 const OMQ_ARENA_THRESHOLD: c_int = 10_001;
+const OMQ_ON_MUTE_BLOCK: c_int = 0;
+const OMQ_ON_MUTE_DROP_NEWEST: c_int = 1;
+const OMQ_ON_MUTE_DROP_OLDEST: c_int = 2;
+const ZSTD_LEVEL_MIN: i32 = -8;
+const ZSTD_LEVEL_MAX: i32 = 4;
+const COMPRESSION_DICT_MAX: usize = 8 * 1024;
 
 #[expect(clippy::too_many_lines)]
 #[unsafe(no_mangle)]
@@ -577,6 +599,46 @@ pub extern "C" fn zmq_setsockopt(
                 return fail(libc::EINVAL);
             };
             lock_overlay!(sock_arc).xpub_verbose = v != 0;
+        }
+        OMQ_ON_MUTE => {
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            let on_mute = match v {
+                OMQ_ON_MUTE_BLOCK => OnMute::Block,
+                OMQ_ON_MUTE_DROP_NEWEST => OnMute::DropNewest,
+                OMQ_ON_MUTE_DROP_OLDEST => OnMute::DropOldest,
+                _ => return fail(libc::EINVAL),
+            };
+            lock_overlay!(sock_arc).on_mute = on_mute;
+        }
+        OMQ_COMPRESSION_LEVEL => {
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            if !(ZSTD_LEVEL_MIN..=ZSTD_LEVEL_MAX).contains(&v) {
+                return fail(libc::EINVAL);
+            }
+            lock_overlay!(sock_arc).compression_level = Some(v);
+        }
+        OMQ_COMPRESSION_DICT => {
+            let Some(v) = read_bytes(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            if v.len() > COMPRESSION_DICT_MAX {
+                return fail(libc::EINVAL);
+            }
+            lock_overlay!(sock_arc).compression_dict = if v.is_empty() {
+                None
+            } else {
+                Some(Bytes::from(v))
+            };
+        }
+        OMQ_COMPRESSION_AUTO_TRAIN => {
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).compression_auto_train = v != 0;
         }
         ZMQ_SUBSCRIBE => {
             return do_subscribe(sock_arc, optval, optvallen, true);
@@ -1090,6 +1152,32 @@ pub extern "C" fn zmq_getsockopt(
             let v = lock_overlay!(sock_arc).xpub_verbose;
             write_i32(optval, optvallen, i32::from(v))
         }
+        #[expect(clippy::match_same_arms)]
+        OMQ_ON_MUTE => {
+            let v = match lock_overlay!(sock_arc).on_mute {
+                OnMute::Block => OMQ_ON_MUTE_BLOCK,
+                OnMute::DropNewest => OMQ_ON_MUTE_DROP_NEWEST,
+                OnMute::DropOldest => OMQ_ON_MUTE_DROP_OLDEST,
+                _ => OMQ_ON_MUTE_BLOCK,
+            };
+            write_i32(optval, optvallen, v)
+        }
+        OMQ_COMPRESSION_LEVEL => {
+            let v = lock_overlay!(sock_arc).compression_level.unwrap_or(0);
+            write_i32(optval, optvallen, v)
+        }
+        OMQ_COMPRESSION_DICT => {
+            let ov = lock_overlay!(sock_arc);
+            write_bytes(
+                optval,
+                optvallen,
+                ov.compression_dict.as_deref().unwrap_or(b""),
+            )
+        }
+        OMQ_COMPRESSION_AUTO_TRAIN => {
+            let v = lock_overlay!(sock_arc).compression_auto_train;
+            write_i32(optval, optvallen, i32::from(v))
+        }
         ZMQ_LAST_ENDPOINT => {
             let Ok(ep) = sock_arc.last_endpoint.lock() else {
                 return crate::error::fail(crate::error::ETERM);
@@ -1516,6 +1604,31 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(overlay.to_options().arena_threshold, Some(2048));
+    }
+
+    #[test]
+    fn compression_fields_map_to_backend_options() {
+        let overlay = SocketOverlay {
+            compression_level: Some(1),
+            compression_dict: Some(Bytes::from_static(b"dict")),
+            compression_auto_train: true,
+            ..Default::default()
+        };
+        let opts = overlay.to_options();
+
+        assert_eq!(opts.compression_level, Some(1));
+        assert_eq!(opts.compression_dict.as_deref(), Some(&b"dict"[..]));
+        assert!(opts.compression_auto_train);
+    }
+
+    #[test]
+    fn on_mute_maps_to_backend_options() {
+        let overlay = SocketOverlay {
+            on_mute: OnMute::DropOldest,
+            ..Default::default()
+        };
+
+        assert_eq!(overlay.to_options().on_mute, OnMute::DropOldest);
     }
 
     #[test]

--- a/omq-libzmq/src/opts.rs
+++ b/omq-libzmq/src/opts.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use omq_tokio::MechanismSetup;
-use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy};
+use omq_tokio::options::{KeepAlive, OnMute, ReconnectPolicy, WorkloadProfile};
 
 use crate::error::fail;
 #[cfg(unix)]
@@ -56,6 +56,7 @@ pub(crate) struct SocketOverlay {
     pub compression_level: Option<i32>,
     pub compression_dict: Option<Bytes>,
     pub compression_auto_train: bool,
+    pub workload_profile: Option<WorkloadProfile>,
     pub ipv6: bool,
     pub backlog: i32,
     pub immediate: bool,
@@ -101,6 +102,7 @@ impl Default for SocketOverlay {
             compression_level: None,
             compression_dict: None,
             compression_auto_train: false,
+            workload_profile: None,
             ipv6: false,
             backlog: 0,
             immediate: false,
@@ -237,6 +239,7 @@ impl SocketOverlay {
             compression_level: self.compression_level,
             compression_dict: self.compression_dict.clone(),
             compression_auto_train: self.compression_auto_train,
+            workload_profile: self.workload_profile,
             xpub_nodrop: self.xpub_nodrop,
             reconnect_stop_conn_refused: (self.reconnect_stop & 1) != 0,
             wss_tls: omq_tokio::options::WssTls {
@@ -381,10 +384,14 @@ const OMQ_ON_MUTE: c_int = 1004;
 const OMQ_COMPRESSION_LEVEL: c_int = 1005;
 const OMQ_COMPRESSION_DICT: c_int = 1006;
 const OMQ_COMPRESSION_AUTO_TRAIN: c_int = 1007;
+const OMQ_WORKLOAD_PROFILE: c_int = 1008;
 const OMQ_ARENA_THRESHOLD: c_int = 10_001;
 const OMQ_ON_MUTE_BLOCK: c_int = 0;
 const OMQ_ON_MUTE_DROP_NEWEST: c_int = 1;
 const OMQ_ON_MUTE_DROP_OLDEST: c_int = 2;
+const OMQ_WORKLOAD_DEFAULT: c_int = -1;
+const OMQ_WORKLOAD_THROUGHPUT: c_int = 0;
+const OMQ_WORKLOAD_LATENCY: c_int = 1;
 const ZSTD_LEVEL_MIN: i32 = -8;
 const ZSTD_LEVEL_MAX: i32 = 4;
 const COMPRESSION_DICT_MAX: usize = 8 * 1024;
@@ -639,6 +646,17 @@ pub extern "C" fn zmq_setsockopt(
                 return fail(libc::EINVAL);
             };
             lock_overlay!(sock_arc).compression_auto_train = v != 0;
+        }
+        OMQ_WORKLOAD_PROFILE => {
+            let Some(v) = read_i32(optval, optvallen) else {
+                return fail(libc::EINVAL);
+            };
+            lock_overlay!(sock_arc).workload_profile = match v {
+                OMQ_WORKLOAD_DEFAULT => None,
+                OMQ_WORKLOAD_THROUGHPUT => Some(WorkloadProfile::Throughput),
+                OMQ_WORKLOAD_LATENCY => Some(WorkloadProfile::Latency),
+                _ => return fail(libc::EINVAL),
+            };
         }
         ZMQ_SUBSCRIBE => {
             return do_subscribe(sock_arc, optval, optvallen, true);
@@ -1178,6 +1196,14 @@ pub extern "C" fn zmq_getsockopt(
             let v = lock_overlay!(sock_arc).compression_auto_train;
             write_i32(optval, optvallen, i32::from(v))
         }
+        OMQ_WORKLOAD_PROFILE => {
+            let v = match lock_overlay!(sock_arc).workload_profile {
+                None => OMQ_WORKLOAD_DEFAULT,
+                Some(WorkloadProfile::Throughput) => OMQ_WORKLOAD_THROUGHPUT,
+                Some(WorkloadProfile::Latency) => OMQ_WORKLOAD_LATENCY,
+            };
+            write_i32(optval, optvallen, v)
+        }
         ZMQ_LAST_ENDPOINT => {
             let Ok(ep) = sock_arc.last_endpoint.lock() else {
                 return crate::error::fail(crate::error::ETERM);
@@ -1629,6 +1655,26 @@ mod tests {
         };
 
         assert_eq!(overlay.to_options().on_mute, OnMute::DropOldest);
+    }
+
+    #[test]
+    fn workload_profile_defaults_to_backend_socket_type_selection() {
+        let overlay = SocketOverlay::default();
+
+        assert_eq!(overlay.to_options().workload_profile, None);
+    }
+
+    #[test]
+    fn workload_profile_maps_to_backend_options() {
+        let overlay = SocketOverlay {
+            workload_profile: Some(WorkloadProfile::Latency),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            overlay.to_options().workload_profile,
+            Some(WorkloadProfile::Latency)
+        );
     }
 
     #[test]

--- a/omq-libzmq/src/send_recv.rs
+++ b/omq-libzmq/src/send_recv.rs
@@ -694,6 +694,7 @@ fn recv_msg_to_buf(
     let data = m.get(start).unwrap_or(&[]);
     copy_to_buf(buf, buf_len, data);
     stash_remaining_parts(sock, m, start);
+    mark_external_req_recv(sock);
     match checked_c_int_len(data.len()) {
         Ok(n) => n,
         Err(e) => fail(e),
@@ -782,6 +783,7 @@ pub(crate) fn pop_recv_frame(sock: &OmqSocket, flags: c_int) -> Result<(Bytes, b
             let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
             let bytes = Bytes::copy_from_slice(slice);
             bypass.advance(len);
+            mark_external_req_recv(sock);
             return Ok((bytes, false));
         }
         if dontwait {
@@ -827,6 +829,7 @@ pub(crate) fn pop_recv_frame(sock: &OmqSocket, flags: c_int) -> Result<(Bytes, b
                 let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
                 let bytes = Bytes::copy_from_slice(slice);
                 bypass.advance(len);
+                mark_external_req_recv(sock);
                 return Ok(Some((bytes, false)));
             }
             if bypass.pipe.closed.load(Ordering::Acquire) {
@@ -905,9 +908,11 @@ fn recv_bypass_direct(
         && let Some(popped) = try_pop_dual(cons, sock)
     {
         signal_recv_space_if_full(sock, popped.released_full_slot);
-        let data = popped.message.get(0).unwrap_or(&[]);
+        let start = msg_start_index(sock, &popped.message);
+        let data = popped.message.get(start).unwrap_or(&[]);
         copy_to_buf(buf, buf_len, data);
-        stash_remaining_parts(sock, &popped.message, 0);
+        stash_remaining_parts(sock, &popped.message, start);
+        mark_external_req_recv(sock);
         return checked_c_int_len(data.len());
     }
 
@@ -1019,6 +1024,7 @@ fn try_recv_bypass_or_yring(
             }
         }
         bypass.advance(len);
+        mark_external_req_recv(sock);
         return checked_c_int_len(len).map(Some);
     }
     // SAFETY: libzmq sockets are accessed by at most one application thread.
@@ -1026,10 +1032,12 @@ fn try_recv_bypass_or_yring(
         && let Some(popped) = try_pop_dual(cons, sock)
     {
         signal_recv_space_if_full(sock, popped.released_full_slot);
-        let data = popped.message.get(0).unwrap_or(&[]);
+        let start = msg_start_index(sock, &popped.message);
+        let data = popped.message.get(start).unwrap_or(&[]);
         let frame_len = data.len();
         copy_to_buf(buf, buf_len, data);
-        stash_remaining_parts(sock, &popped.message, 0);
+        stash_remaining_parts(sock, &popped.message, start);
+        mark_external_req_recv(sock);
         return checked_c_int_len(frame_len).map(Some);
     }
     if bypass
@@ -1076,7 +1084,24 @@ fn try_pop_dual(
 
 #[inline]
 fn msg_start_index(sock: &OmqSocket, msg: &omq_tokio::Message) -> usize {
-    usize::from(sock.socket_type == omq_tokio::SocketType::Dish && msg.len() >= 2)
+    if sock.socket_type == omq_tokio::SocketType::Dish && msg.len() >= 2 {
+        return 1;
+    }
+    if sock.socket_type == omq_tokio::SocketType::Req
+        && msg.len() >= 2
+        && msg.get(0).is_some_and(<[u8]>::is_empty)
+    {
+        return 1;
+    }
+    0
+}
+
+fn mark_external_req_recv(sock: &OmqSocket) {
+    if sock.socket_type == omq_tokio::SocketType::Req
+        && let Some(inner) = sock.inner.get()
+    {
+        inner.mark_req_reply_received_for_external_recv();
+    }
 }
 
 fn stash_remaining_parts(sock: &OmqSocket, msg: &omq_tokio::Message, start: usize) {
@@ -1097,15 +1122,15 @@ fn stash_remaining_parts(sock: &OmqSocket, msg: &omq_tokio::Message, start: usiz
 fn decompose_message(sock: &OmqSocket, msg: &omq_tokio::Message) -> Result<(Bytes, bool), c_int> {
     use std::sync::atomic::Ordering;
 
-    let dish = sock.socket_type == omq_tokio::SocketType::Dish;
     let nparts = msg.len();
 
-    if nparts <= 1 && !dish {
+    let start = msg_start_index(sock, msg);
+    if nparts <= 1 && start == 0 {
         let head = msg.part_bytes(0).unwrap_or_default();
+        mark_external_req_recv(sock);
         return Ok((head, false));
     }
 
-    let start = usize::from(dish && nparts >= 2);
     let head = msg.part_bytes(start).unwrap_or_default();
 
     let remaining = start + 1;
@@ -1121,6 +1146,7 @@ fn decompose_message(sock: &OmqSocket, msg: &omq_tokio::Message) -> Result<(Byte
         }
     }
 
+    mark_external_req_recv(sock);
     Ok((head, remaining < nparts))
 }
 

--- a/omq-libzmq/src/socket.rs
+++ b/omq-libzmq/src/socket.rs
@@ -406,9 +406,7 @@ pub(crate) fn ensure_materialized(sock: &Arc<OmqSocket>) -> bool {
     let Ok(overlay) = sock.overlay.lock() else {
         return false;
     };
-    let opts = overlay
-        .to_options()
-        .workload_profile(omq_tokio::options::WorkloadProfile::Throughput);
+    let opts = overlay.to_options();
     let recv_hwm = overlay.recv_hwm.unwrap_or(DEFAULT_HWM as u32) as usize;
     // SAFETY: materialization runs before hot-path send ownership and freezes
     // bind/connect-scoped options for this socket.

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -58,9 +58,13 @@ const OMQ_ON_MUTE: i32 = 1004;
 const OMQ_COMPRESSION_LEVEL: i32 = 1005;
 const OMQ_COMPRESSION_DICT: i32 = 1006;
 const OMQ_COMPRESSION_AUTO_TRAIN: i32 = 1007;
+const OMQ_WORKLOAD_PROFILE: i32 = 1008;
 const OMQ_ON_MUTE_BLOCK: i32 = 0;
 const OMQ_ON_MUTE_DROP_NEWEST: i32 = 1;
 const OMQ_ON_MUTE_DROP_OLDEST: i32 = 2;
+const OMQ_WORKLOAD_DEFAULT: i32 = -1;
+const OMQ_WORKLOAD_THROUGHPUT: i32 = 0;
+const OMQ_WORKLOAD_LATENCY: i32 = 1;
 
 const ZMQ_NULL: i32 = 0;
 const ZMQ_PLAIN: i32 = 1;
@@ -594,6 +598,30 @@ fn omq_on_mute_roundtrip() {
     assert_eq!(set_i32(s, OMQ_ON_MUTE, 99), -1);
     assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
     assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_BLOCK);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn omq_workload_profile_roundtrip() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_DEALER);
+
+    assert_eq!(get_i32(s, OMQ_WORKLOAD_PROFILE), OMQ_WORKLOAD_DEFAULT);
+
+    assert_eq!(set_i32(s, OMQ_WORKLOAD_PROFILE, OMQ_WORKLOAD_LATENCY), 0);
+    assert_eq!(get_i32(s, OMQ_WORKLOAD_PROFILE), OMQ_WORKLOAD_LATENCY);
+
+    assert_eq!(set_i32(s, OMQ_WORKLOAD_PROFILE, OMQ_WORKLOAD_THROUGHPUT), 0);
+    assert_eq!(get_i32(s, OMQ_WORKLOAD_PROFILE), OMQ_WORKLOAD_THROUGHPUT);
+
+    assert_eq!(set_i32(s, OMQ_WORKLOAD_PROFILE, OMQ_WORKLOAD_DEFAULT), 0);
+    assert_eq!(get_i32(s, OMQ_WORKLOAD_PROFILE), OMQ_WORKLOAD_DEFAULT);
+
+    assert_eq!(set_i32(s, OMQ_WORKLOAD_PROFILE, 99), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, OMQ_WORKLOAD_PROFILE), OMQ_WORKLOAD_DEFAULT);
 
     zmq_close(s);
     zmq_ctx_term(ctx);

--- a/omq-libzmq/tests/opts.rs
+++ b/omq-libzmq/tests/opts.rs
@@ -54,6 +54,13 @@ const ZMQ_CURVE_SERVER: i32 = 47;
 const ZMQ_CURVE_PUBLICKEY: i32 = 48;
 const ZMQ_CURVE_SECRETKEY: i32 = 49;
 const ZMQ_CURVE_SERVERKEY: i32 = 50;
+const OMQ_ON_MUTE: i32 = 1004;
+const OMQ_COMPRESSION_LEVEL: i32 = 1005;
+const OMQ_COMPRESSION_DICT: i32 = 1006;
+const OMQ_COMPRESSION_AUTO_TRAIN: i32 = 1007;
+const OMQ_ON_MUTE_BLOCK: i32 = 0;
+const OMQ_ON_MUTE_DROP_NEWEST: i32 = 1;
+const OMQ_ON_MUTE_DROP_OLDEST: i32 = 2;
 
 const ZMQ_NULL: i32 = 0;
 const ZMQ_PLAIN: i32 = 1;
@@ -563,6 +570,71 @@ fn arena_threshold_roundtrip() {
     assert_eq!(set_i64(s, OMQ_ARENA_THRESHOLD, -2), -1);
     assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
     assert_eq!(get_i64(s, OMQ_ARENA_THRESHOLD), 4 * 1024);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn omq_on_mute_roundtrip() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_PUSH);
+
+    assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_BLOCK);
+
+    assert_eq!(set_i32(s, OMQ_ON_MUTE, OMQ_ON_MUTE_DROP_NEWEST), 0);
+    assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_DROP_NEWEST);
+
+    assert_eq!(set_i32(s, OMQ_ON_MUTE, OMQ_ON_MUTE_DROP_OLDEST), 0);
+    assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_DROP_OLDEST);
+
+    assert_eq!(set_i32(s, OMQ_ON_MUTE, OMQ_ON_MUTE_BLOCK), 0);
+    assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_BLOCK);
+
+    assert_eq!(set_i32(s, OMQ_ON_MUTE, 99), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, OMQ_ON_MUTE), OMQ_ON_MUTE_BLOCK);
+
+    zmq_close(s);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn omq_compression_options_roundtrip() {
+    let ctx = zmq_ctx_new();
+    let s = zmq_socket(ctx, ZMQ_PUSH);
+
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_LEVEL), 0);
+    assert_eq!(set_i32(s, OMQ_COMPRESSION_LEVEL, 1), 0);
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_LEVEL), 1);
+
+    assert_eq!(set_i32(s, OMQ_COMPRESSION_LEVEL, -9), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_LEVEL), 1);
+
+    assert_eq!(set_i32(s, OMQ_COMPRESSION_LEVEL, 5), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_LEVEL), 1);
+
+    let mut buf = [0u8; 64];
+    assert_eq!(get_bytes(s, OMQ_COMPRESSION_DICT, &mut buf), 0);
+
+    assert_eq!(set_bytes(s, OMQ_COMPRESSION_DICT, b"dict-bytes"), 0);
+    let len = get_bytes(s, OMQ_COMPRESSION_DICT, &mut buf);
+    assert_eq!(&buf[..len], b"dict-bytes");
+
+    assert_eq!(set_bytes(s, OMQ_COMPRESSION_DICT, b""), 0);
+    assert_eq!(get_bytes(s, OMQ_COMPRESSION_DICT, &mut buf), 0);
+
+    let too_big = vec![0u8; 8 * 1024 + 1];
+    assert_eq!(set_bytes(s, OMQ_COMPRESSION_DICT, &too_big), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_AUTO_TRAIN), 0);
+    assert_eq!(set_i32(s, OMQ_COMPRESSION_AUTO_TRAIN, 1), 0);
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_AUTO_TRAIN), 1);
+    assert_eq!(set_i32(s, OMQ_COMPRESSION_AUTO_TRAIN, 0), 0);
+    assert_eq!(get_i32(s, OMQ_COMPRESSION_AUTO_TRAIN), 0);
 
     zmq_close(s);
     zmq_ctx_term(ctx);

--- a/omq-tokio/src/socket/handle.rs
+++ b/omq-tokio/src/socket/handle.rs
@@ -272,6 +272,15 @@ impl Socket {
             .load(std::sync::atomic::Ordering::Acquire)
     }
 
+    #[doc(hidden)]
+    pub fn mark_req_reply_received_for_external_recv(&self) {
+        if self.inner.socket_type == SocketType::Req {
+            self.inner
+                .req_awaiting_reply
+                .store(false, Ordering::Release);
+        }
+    }
+
     /// Bind to an endpoint. Returns the resolved endpoint once the
     /// listener is active. For wildcard binds (`tcp://...:0`) the
     /// returned endpoint contains the actual port.


### PR DESCRIPTION
- Add `bindings/zig` as a Zig 0.16 binding over `omq-libzmq`.
- Cover core send/recv, multipart, poller, transports, auth, compression, proxy, and named socket option helpers.
- Add pyomq-style benchmark wiring, charts, architecture docs, development docs, and soak runner.
- List Zig in root `README.md` bindings.
