### PR TITLE
feat(pyomq): accept Python buffers in send

### DIFF
--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -78,7 +78,7 @@ See [COMPARISONS.md](https://github.com/paddor/omq.rs/blob/main/COMPARISONS.md) 
 |                    | pyomq     | pyzmq     | ratio     |
 |--------------------|----------:|----------:|----------:|
 | PUSH/PULL msg/s    |  2.93 M/s |  1.57 M/s | **1.87x** |
-| REQ/REP rt/s       |   7,817/s |   4,348/s | **1.80x** |
+| REQ/REP rt/s       |   8,161/s |   4,348/s | **1.88x** |
 <!-- PROXY_PERF:END -->
 
 pyomq's `proxy()` forwards directly between sockets on the tokio runtime,

--- a/bindings/pyomq/doc/charts/bindings.svg
+++ b/bindings/pyomq/doc/charts/bindings.svg
@@ -63,28 +63,28 @@
   <line x1="455" y1="444" x2="790" y2="444" stroke="#9ca3af" stroke-width="1.5"/>
   <text x="227.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">small messages</text>
   <text x="622.5" y="92" text-anchor="middle" fill="#f9fafb" font-size="12" font-weight="700">medium/large messages</text>
-  <polyline points="60.0,129.8 115.8,157.8 171.7,164.9 227.5,165.0 283.3,157.9 339.2,169.0 395.0,176.8" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="60.0,273.8 115.8,274.7 171.7,292.8 227.5,280.7 283.3,286.6 339.2,293.1 395.0,305.5" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,121.9 115.8,131.3 171.7,168.1 227.5,187.0 283.3,166.1 339.2,170.6 395.0,190.6" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4"/>
+  <polyline points="60.0,297.4 115.8,274.3 171.7,282.2 227.5,282.9 283.3,287.2 339.2,294.2 395.0,305.6" fill="none" stroke="#fb923c" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="60.0,266.0 115.8,270.0 171.7,285.9 227.5,311.2 283.3,335.9 339.2,321.3 395.0,345.8" fill="none" stroke="#60a5fa" stroke-width="2" stroke-dasharray="6,4"/>
   <polyline points="60.0,435.8 115.8,435.3 171.7,435.4 227.5,435.3 283.3,435.6 339.2,435.4 395.0,435.8" fill="none" stroke="#a855f7" stroke-width="2" stroke-dasharray="6,4"/>
-  <polyline points="455.0,414.7 502.9,387.7 550.7,334.5 598.6,249.3 646.4,205.8 694.3,181.4 742.1,164.0 790.0,157.6" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="455.0" cy="414.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="387.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="550.7" cy="334.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="249.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="205.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="181.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="164.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="157.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="455.0,427.9 502.9,413.1 550.7,387.3 598.6,347.9 646.4,298.8 694.3,223.3 742.1,217.4 790.0,230.2" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="455.0,415.5 502.9,388.0 550.7,340.2 598.6,243.6 646.4,211.7 694.3,189.0 742.1,168.0 790.0,161.1" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="455.0" cy="415.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="388.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="550.7" cy="340.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="243.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="211.7" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="189.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="168.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="161.1" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="455.0,427.9 502.9,413.3 550.7,387.3 598.6,349.7 646.4,287.1 694.3,235.3 742.1,230.3 790.0,192.4" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="455.0" cy="427.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="502.9" cy="413.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="502.9" cy="413.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
   <circle cx="550.7" cy="387.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="598.6" cy="347.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="646.4" cy="298.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="694.3" cy="223.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="742.1" cy="217.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="230.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="598.6" cy="349.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="646.4" cy="287.1" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="694.3" cy="235.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="742.1" cy="230.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="192.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
   <polyline points="455.0,432.9 502.9,418.9 550.7,403.8 598.6,387.3 646.4,376.8 694.3,372.5 742.1,367.6 790.0,321.4" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="455.0" cy="432.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="502.9" cy="418.9" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
@@ -151,26 +151,26 @@
   <line x1="790.0" y1="549" x2="790.0" y2="749" stroke="#374151" stroke-width="1"/>
   <line x1="60" y1="549" x2="60" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
   <line x1="60" y1="749" x2="790" y2="749" stroke="#9ca3af" stroke-width="1.5"/>
-  <polyline points="60.0,676.8 151.2,680.2 242.5,677.8 333.8,679.6 425.0,677.9 516.2,676.8 607.5,679.4 698.8,674.8 790.0,671.0" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="676.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,676.0 151.2,680.2 242.5,678.8 333.8,680.9 425.0,678.3 516.2,677.0 607.5,678.3 698.8,674.5 790.0,671.2" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="676.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
   <circle cx="151.2" cy="680.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="677.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="679.6" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="677.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="676.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="679.4" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="674.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="671.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
-  <polyline points="60.0,616.4 151.2,615.5 242.5,622.5 333.8,615.4 425.0,616.5 516.2,617.0 607.5,616.6 698.8,617.9 790.0,606.4" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="60.0" cy="616.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="151.2" cy="615.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="242.5" cy="622.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="333.8" cy="615.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="425.0" cy="616.5" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="516.2" cy="617.0" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="607.5" cy="616.6" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="698.8" cy="617.9" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
-  <circle cx="790.0" cy="606.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="678.8" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="680.9" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="678.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="677.0" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="678.3" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="674.5" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="671.2" r="3" fill="#ef4444" stroke="#000000" stroke-width="1"/>
+  <polyline points="60.0,620.3 151.2,618.8 242.5,620.7 333.8,618.8 425.0,615.8 516.2,616.8 607.5,615.4 698.8,616.2 790.0,607.3" fill="none" stroke="#fb923c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="60.0" cy="620.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="151.2" cy="618.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="242.5" cy="620.7" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="333.8" cy="618.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="425.0" cy="615.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="516.2" cy="616.8" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="607.5" cy="615.4" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="698.8" cy="616.2" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
+  <circle cx="790.0" cy="607.3" r="3" fill="#fb923c" stroke="#000000" stroke-width="1"/>
   <polyline points="60.0,639.6 151.2,640.5 242.5,639.0 333.8,640.1 425.0,637.9 516.2,639.7 607.5,638.2 698.8,636.0 790.0,633.5" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="60.0" cy="639.6" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>
   <circle cx="151.2" cy="640.5" r="3" fill="#60a5fa" stroke="#000000" stroke-width="1"/>

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -645,13 +645,13 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send(
         self,
-        data: bytes | str,
+        data: Any,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> MessageTracker | None:
         try:
-            self._sock.send(data, flags)
+            self._sock.send(data, flags, copy)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
         if track:
@@ -680,14 +680,14 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send_multipart(
         self,
-        parts: Iterable[bytes | str],
+        parts: Iterable[Any],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> MessageTracker | None:
         parts = [p.encode("utf-8") if isinstance(p, str) else p for p in parts]
         try:
-            self._sock.send_multipart(parts, flags)
+            self._sock.send_multipart(parts, flags, copy)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
         if track:
@@ -926,24 +926,24 @@ class _ShadowSocket(_SocketOptionsBase):
 
     def send(
         self,
-        data: bytes | str,
+        data: Any,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> MessageTracker | None:
-        self._blocking_send(lambda: self._native.send(data, flags))
+        self._blocking_send(lambda: self._native.send(data, flags, copy))
         if track:
             return MessageTracker(_pending=True)
         return None
 
     def send_multipart(
         self,
-        parts: list[bytes | str],
+        parts: list[Any],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> MessageTracker | None:
-        self._blocking_send(lambda: self._native.send_multipart(parts, flags))
+        self._blocking_send(lambda: self._native.send_multipart(parts, flags, copy))
         if track:
             return MessageTracker(_pending=True)
         return None

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -209,16 +209,16 @@ class Socket(_BaseSocket):
 
     def send(
         self,
-        data: bytes | str,
+        data: Any,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> Awaitable[Any | None]:
         try:
-            self._sock.send(data, flags)
+            self._sock.send(data, flags, copy)
         except _native.ZMQError as e:
             if e.errno == _EAGAIN:
-                return self._send_with_backpressure(data, flags)
+                return self._send_with_backpressure(data, flags, copy)
             raise error.from_native(e) from None
         return _SEND_DONE
 
@@ -231,16 +231,16 @@ class Socket(_BaseSocket):
 
     def send_multipart(
         self,
-        parts: list[bytes | str],
+        parts: list[Any],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
     ) -> Awaitable[Any | None]:
         try:
-            self._sock.send_multipart(parts, flags)
+            self._sock.send_multipart(parts, flags, copy)
         except _native.ZMQError as e:
             if e.errno == _EAGAIN:
-                return self._send_multipart_with_backpressure(parts, flags)
+                return self._send_multipart_with_backpressure(parts, flags, copy)
             raise error.from_native(e) from None
         return _SEND_DONE
 
@@ -400,11 +400,11 @@ class Socket(_BaseSocket):
             )
 
         def _send_with_backpressure(
-            self, data: bytes | str, flags: int
+            self, data: Any, flags: int, copy: bool
         ) -> asyncio.Future[Any]:
             def try_send() -> bool | None:
                 try:
-                    self._sock.send(data, flags)
+                    self._sock.send(data, flags, copy)
                     return True
                 except _native.ZMQError as e:
                     if e.errno == _errno.EAGAIN:
@@ -419,11 +419,11 @@ class Socket(_BaseSocket):
             )
 
         def _send_multipart_with_backpressure(
-            self, parts: list[bytes | str], flags: int
+            self, parts: list[Any], flags: int, copy: bool
         ) -> asyncio.Future[Any]:
             def try_send() -> bool | None:
                 try:
-                    self._sock.send_multipart(parts, flags)
+                    self._sock.send_multipart(parts, flags, copy)
                     return True
                 except _native.ZMQError as e:
                     if e.errno == _errno.EAGAIN:
@@ -462,12 +462,12 @@ class Socket(_BaseSocket):
 
             return _RecvFuture(try_fn, fd)
 
-        def _send_with_backpressure(self, data: bytes | str, flags: int) -> _RecvFuture:
+        def _send_with_backpressure(self, data: Any, flags: int, copy: bool) -> _RecvFuture:
             fd = self._sock._send_fd()
 
             def try_send() -> bool | None:
                 try:
-                    self._sock.send(data, flags)
+                    self._sock.send(data, flags, copy)
                     return True
                 except _native.ZMQError as e:
                     if e.errno == _EAGAIN:
@@ -477,13 +477,13 @@ class Socket(_BaseSocket):
             return _RecvFuture(try_send, fd)
 
         def _send_multipart_with_backpressure(
-            self, parts: list[bytes | str], flags: int
+            self, parts: list[Any], flags: int, copy: bool
         ) -> _RecvFuture:
             fd = self._sock._send_fd()
 
             def try_send() -> bool | None:
                 try:
-                    self._sock.send_multipart(parts, flags)
+                    self._sock.send_multipart(parts, flags, copy)
                     return True
                 except _native.ZMQError as e:
                     if e.errno == _EAGAIN:

--- a/bindings/pyomq/src/conversions.rs
+++ b/bindings/pyomq/src/conversions.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 use omq_proto::message::Message;
+use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList};
 
@@ -46,17 +47,50 @@ impl AsRef<[u8]> for PyBytesOwner {
     }
 }
 
-/// Build a `Bytes` from a Python `bytes`-like object. Uses the
-/// zero-copy `Bytes::from_owner` path when the input is an immutable
-/// `bytes`; falls back to `Bytes::copy_from_slice` for `bytearray` /
-/// `memoryview` / other buffer-protocol types whose backing storage
-/// might be mutable or transient.
-pub fn bytes_from_pyany(b: &Bound<'_, PyAny>) -> PyResult<Bytes> {
+/// Owner that holds a Python buffer export alive while exposing its
+/// backing storage as `&[u8]`.
+///
+/// SAFETY:
+/// - `PyBuffer<u8>` pins the exporter according to Python's buffer
+///   protocol until release/drop.
+/// - We only construct this for C-contiguous `u8` buffers.
+/// - `copy=False` callers are responsible for not mutating the backing
+///   object until the send completes, matching PyZMQ's zero-copy contract.
+struct PyBufferOwner {
+    _buffer: PyBuffer<u8>,
+    ptr: *const u8,
+    len: usize,
+}
+
+unsafe impl Send for PyBufferOwner {}
+unsafe impl Sync for PyBufferOwner {}
+
+impl AsRef<[u8]> for PyBufferOwner {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+/// Build a `Bytes` from a Python bytes-like object. Immutable `bytes`
+/// use zero-copy ownership. Buffer-protocol objects copy by default,
+/// and use zero-copy ownership for C-contiguous `u8` buffers only when
+/// the caller requested `copy=False`.
+pub fn bytes_from_pyany(b: &Bound<'_, PyAny>, copy: bool) -> PyResult<Bytes> {
     if let Ok(frame) = b.cast::<Frame>() {
         return Ok(frame.borrow().bytes_clone());
     }
     if let Ok(pb) = b.cast::<PyBytes>() {
         return Ok(Bytes::from_owner(PyBytesOwner::from_pybytes(pb)));
+    }
+    if let Ok(buffer) = PyBuffer::<u8>::get(b) {
+        if !copy && buffer.as_slice(b.py()).is_some() {
+            return Ok(Bytes::from_owner(PyBufferOwner {
+                ptr: buffer.buf_ptr().cast(),
+                len: buffer.len_bytes(),
+                _buffer: buffer,
+            }));
+        }
+        return Ok(Bytes::from(buffer.to_vec(b.py())?));
     }
     let view: &[u8] = b.extract()?;
     Ok(Bytes::copy_from_slice(view))
@@ -69,14 +103,14 @@ pub fn routing_id_from_pyany(b: &Bound<'_, PyAny>) -> u32 {
 }
 
 /// Build a multipart `Message` from a Python list/tuple of bytes-like.
-pub fn message_from_pylist(parts: &Bound<'_, PyAny>) -> PyResult<Message> {
+pub fn message_from_pylist(parts: &Bound<'_, PyAny>, copy: bool) -> PyResult<Message> {
     let it = parts.try_iter()?;
     let mut collected = Vec::new();
     let mut routing_id = 0;
     for part in it {
         let part = part?;
         routing_id = routing_id.max(routing_id_from_pyany(&part));
-        collected.push(bytes_from_pyany(&part)?);
+        collected.push(bytes_from_pyany(&part, copy)?);
     }
     let message = match collected.len() {
         0 => Message::new(),

--- a/bindings/pyomq/src/frame.rs
+++ b/bindings/pyomq/src/frame.rs
@@ -63,6 +63,7 @@ impl Frame {
         match data {
             Some(data) => Ok(Self::from_bytes(crate::conversions::bytes_from_pyany(
                 data,
+                copy.unwrap_or(true),
             )?)),
             None => Ok(Self::from_bytes(Bytes::new())),
         }

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -665,10 +665,16 @@ impl Socket {
         dispatch::blocking_unit(&self.inner, py, move |s| s.disconnect(ep))
     }
 
-    #[pyo3(signature = (payload, flags = 0))]
-    fn send(&self, py: Python<'_>, payload: &Bound<'_, PyAny>, flags: i32) -> PyResult<()> {
+    #[pyo3(signature = (payload, flags = 0, copy = true))]
+    fn send(
+        &self,
+        py: Python<'_>,
+        payload: &Bound<'_, PyAny>,
+        flags: i32,
+        copy: bool,
+    ) -> PyResult<()> {
         let routing_id = conversions::routing_id_from_pyany(payload);
-        let bytes = conversions::bytes_from_pyany(payload)?;
+        let bytes = conversions::bytes_from_pyany(payload, copy)?;
         let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
             return Ok(());
         };
@@ -678,10 +684,16 @@ impl Socket {
         self.send_message(py, msg)
     }
 
-    #[pyo3(signature = (parts, flags = 0))]
-    fn send_multipart(&self, py: Python<'_>, parts: &Bound<'_, PyAny>, flags: i32) -> PyResult<()> {
+    #[pyo3(signature = (parts, flags = 0, copy = true))]
+    fn send_multipart(
+        &self,
+        py: Python<'_>,
+        parts: &Bound<'_, PyAny>,
+        flags: i32,
+        copy: bool,
+    ) -> PyResult<()> {
         let _ = flags;
-        let msg = conversions::message_from_pylist(parts)?;
+        let msg = conversions::message_from_pylist(parts, copy)?;
         self.send_message(py, msg)
     }
 

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -76,10 +76,10 @@ impl AsyncSocket {
 
     // ── Send (sync push into yring) ─────────────────────────────────
 
-    #[pyo3(signature = (payload, flags = 0))]
-    fn send(&self, payload: &Bound<'_, PyAny>, flags: i32) -> PyResult<()> {
+    #[pyo3(signature = (payload, flags = 0, copy = true))]
+    fn send(&self, payload: &Bound<'_, PyAny>, flags: i32, copy: bool) -> PyResult<()> {
         let routing_id = conversions::routing_id_from_pyany(payload);
-        let bytes = conversions::bytes_from_pyany(payload)?;
+        let bytes = conversions::bytes_from_pyany(payload, copy)?;
         let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
             return Ok(());
         };
@@ -96,10 +96,10 @@ impl AsyncSocket {
         }
     }
 
-    #[pyo3(signature = (parts, flags = 0))]
-    fn send_multipart(&self, parts: &Bound<'_, PyAny>, flags: i32) -> PyResult<()> {
+    #[pyo3(signature = (parts, flags = 0, copy = true))]
+    fn send_multipart(&self, parts: &Bound<'_, PyAny>, flags: i32, copy: bool) -> PyResult<()> {
         let _ = flags;
-        let msg = conversions::message_from_pylist(parts)?;
+        let msg = conversions::message_from_pylist(parts, copy)?;
         self.inner.materialize()?;
         let materialized_guard = self.inner.materialized.read().unwrap();
         let materialized = materialized_guard.as_ref().unwrap();

--- a/bindings/pyomq/tests/test_async.py
+++ b/bindings/pyomq/tests/test_async.py
@@ -58,6 +58,38 @@ async def test_async_send_multipart(tcp_endpoint):
 
 
 @pytest.mark.asyncio
+async def test_async_send_accepts_memoryview_copy_false(tcp_endpoint):
+    ctx = zmq_async.Context()
+    pull = ctx.socket(pyomq.PULL)
+    push = ctx.socket(pyomq.PUSH)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        await push.send(memoryview(b"hello"), copy=False)
+        assert await pull.recv() == b"hello"
+    finally:
+        push.close()
+        pull.close()
+
+
+@pytest.mark.asyncio
+async def test_async_send_multipart_accepts_buffers_copy_false(tcp_endpoint):
+    ctx = zmq_async.Context()
+    pull = ctx.socket(pyomq.PULL)
+    push = ctx.socket(pyomq.PUSH)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        await push.send_multipart(
+            [bytearray(b"meta"), memoryview(b"payload")], copy=False
+        )
+        assert await pull.recv_multipart() == [b"meta", b"payload"]
+    finally:
+        push.close()
+        pull.close()
+
+
+@pytest.mark.asyncio
 async def test_async_pubsub(tcp_endpoint):
     ctx = zmq_async.Context()
     pub = ctx.socket(pyomq.PUB)

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -235,6 +235,107 @@ def test_copy_false_frames_can_be_rerouted():
         ctx.term()
 
 
+def test_send_accepts_bytearray_buffer(tcp_endpoint):
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        push.send(bytearray(b"hello"))
+        assert pull.recv() == b"hello"
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_send_copies_mutable_buffer_by_default(tcp_endpoint):
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        data = bytearray(b"hello")
+        push.send(data)
+        data[:] = b"xxxxx"
+        assert pull.recv() == b"hello"
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_send_accepts_memoryview_buffer_copy_false(tcp_endpoint):
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        push.send(memoryview(b"hello"), copy=False)
+        assert pull.recv() == b"hello"
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_frame_accepts_memoryview_buffer_copy_false():
+    frame = zmq.Frame(memoryview(b"hello"), copy=False)
+    assert bytes(frame) == b"hello"
+
+
+def test_send_multipart_accepts_buffer_parts(tcp_endpoint):
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        push.send_multipart([bytearray(b"meta"), memoryview(b"payload")], copy=False)
+        assert pull.recv_multipart() == [b"meta", b"payload"]
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_send_accepts_noncontiguous_numpy_array_copy_false(tcp_endpoint):
+    np = pytest.importorskip("numpy")
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        data = np.arange(16, dtype=np.uint8)[::2]
+        push.send(data, copy=False)
+        assert pull.recv() == data.tobytes()
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
+def test_send_accepts_numpy_uint8_array_copy_false(tcp_endpoint):
+    np = pytest.importorskip("numpy")
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+        data = np.arange(12, dtype=np.uint8).reshape((2, 2, 3))
+        push.send(data, copy=False)
+        assert pull.recv() == data.tobytes()
+    finally:
+        push.close()
+        pull.close()
+        ctx.term()
+
+
 def test_copy_false_send_accepted():
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)


### PR DESCRIPTION
- Add Python buffer-protocol support to pyomq send paths, including sync sockets, async sockets, multipart sends, and Frame construction.
- Preserve default copy behavior for mutable inputs and support zero-copy ownership for contiguous copy=False buffers.
- Cover bytearray, memoryview, contiguous NumPy arrays, non-contiguous NumPy fallback, and async multipart buffers.
- Refresh pyomq binding benchmark chart and proxy table from run 2026-09-01T12:58:03.