### PR TITLE
chore(bindings): prepare pyomq and omq-rs releases

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-09-01
+
+### Added
+
+- Accept Python buffer-protocol objects for sync and asyncio `send()` calls.
+
+### Changed
+
+- Refresh the pyomq vs pyzmq benchmark chart and proxy table.
+
 ## [0.20.1] - 2026-08-23
 
 ### Fixed

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.20.1"
+version = "0.20.2"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-09-01
+
+- Route `Socket#try_recv` directly through the native nonblocking receive path.
+- Avoid Ruby-side batch array churn in hot polling loops.
+
 ## [0.1.1] - 2026-08-23
 
 - Document the full public API and publish the RubyDoc documentation link.

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "omq_rs_native"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omq-rs (0.1.1)
+    omq-rs (0.1.2)
       rb_sys (~> 0.9)
 
 GEM
@@ -71,7 +71,7 @@ CHECKSUMS
   io-event (1.19.5) sha256=b168a9b7c5a0e894f2047f82f4bf831f59edd067843005e930a62f375738bad2
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  omq-rs (0.1.1)
+  omq-rs (0.1.2)
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/bindings/ruby/ext/omq_rs_native/Cargo.toml
+++ b/bindings/ruby/ext/omq_rs_native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq_rs_native"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/ruby/lib/omq/rs/version.rb
+++ b/bindings/ruby/lib/omq/rs/version.rb
@@ -5,6 +5,6 @@ module OMQ
   module Rust
     # Ruby binding version.
     # @return [String]
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
- Bump `pyomq` to `0.20.2` after Python buffer-protocol send support.
- Bump `omq-rs` to `0.1.2` after Ruby `Socket#try_recv` direct native receive changes.
- Update `bindings/pyomq/CHANGELOG.md`, `bindings/ruby/CHANGELOG.md`, and binding lockfiles for release tags.