### PR TITLE
chore(beam): prepare Hex package publishing

### DIFF
--- a/bindings/beam/DEVELOPMENT.md
+++ b/bindings/beam/DEVELOPMENT.md
@@ -154,3 +154,70 @@ Useful flags:
 - `--latency-duration SECONDS`
 - `--latency-warmup-duration SECONDS`
 - `--timeout SECONDS`
+
+## Publishing
+
+Hex package names:
+
+- `omq`: Erlang base package. Owns the Rust NIF and native OMQ runtime.
+- `omq_elixir`: Elixir wrapper. Depends on `omq`.
+- `omq_gleam`: Gleam wrapper. Depends on `omq`.
+
+Publish in that order. The wrapper packages cannot resolve until `omq` is
+published on Hex.
+
+One-time local setup:
+
+```sh
+mix local.hex --force
+mix hex.user auth
+mkdir -p ~/.config/rebar3
+$EDITOR ~/.config/rebar3/rebar.config
+rebar3 hex user auth
+~/src/gleam/target/release/gleam hex authenticate
+```
+
+No standalone `hex` command is needed. Mix, Rebar3, and Gleam each publish
+through their own Hex tasks.
+
+Add this line to `~/.config/rebar3/rebar.config` if it is not already there:
+
+```erlang
+{plugins, [rebar3_hex]}.
+```
+
+Dry-run/audit the Erlang package:
+
+```sh
+(cd bindings/beam && rebar3 compile)
+(cd bindings/beam && rebar3 hex build)
+```
+
+Publish `omq`:
+
+```sh
+(cd bindings/beam && rebar3 hex publish)
+```
+
+After Hex shows `omq` 0.1.0, dry-run/audit and publish the Elixir wrapper:
+
+```sh
+(cd bindings/beam/elixir && mix deps.get)
+(cd bindings/beam/elixir && mix compile --warnings-as-errors)
+(cd bindings/beam/elixir && mix hex.build --unpack)
+(cd bindings/beam/elixir && mix hex.publish)
+```
+
+After Hex shows `omq` 0.1.0, dry-run/audit and publish the Gleam wrapper:
+
+```sh
+(cd bindings/beam/gleam && ~/src/gleam/target/release/gleam update)
+(cd bindings/beam/gleam && ~/src/gleam/target/release/gleam check)
+(cd bindings/beam/gleam && ~/src/gleam/target/release/gleam test)
+(cd bindings/beam/gleam && ~/src/gleam/target/release/gleam export hex-tarball)
+(cd bindings/beam/gleam && ~/src/gleam/target/release/gleam publish)
+```
+
+For token-based publishing, Mix reads `HEX_API_KEY`; Gleam reads
+`HEXPM_API_KEY`. Prefer the interactive commands above for the first publish
+so package metadata and included files can be reviewed before confirming.

--- a/bindings/beam/README.md
+++ b/bindings/beam/README.md
@@ -11,6 +11,29 @@ Architecture detail: [`doc/architecture.md`](doc/architecture.md).
 Benchmarks compare the three OMQ wrappers against `erlzmq` and `chumak`.
 `exzmq` is not included because its current public API is CLIENT/SERVER-only.
 
+## Install
+
+Erlang:
+
+```erlang
+{deps, [{omq, "0.1.0"}]}.
+```
+
+Elixir:
+
+```elixir
+def deps do
+  [{:omq_elixir, "~> 0.1"}]
+end
+```
+
+Gleam:
+
+```toml
+[dependencies]
+omq_gleam = ">= 0.1.0 and < 1.0.0"
+```
+
 ## API Shape
 
 - `omq:context(...)` owns native IO threads and creates sockets.

--- a/bindings/beam/elixir/README.md
+++ b/bindings/beam/elixir/README.md
@@ -1,0 +1,19 @@
+# OMQ Elixir
+
+Elixir wrapper for OMQ.beam.
+
+This package depends on the Erlang `omq` package, which owns the Rust NIF and
+native OMQ runtime. The Elixir module keeps the same socket semantics while
+presenting Elixir-friendly names and return values.
+
+```elixir
+{:ok, ctx} = OMQ.context()
+{:ok, pull} = OMQ.socket(ctx, :pull)
+{:ok, push} = OMQ.socket(ctx, :push)
+{:ok, endpoint} = OMQ.bind(pull, "tcp://127.0.0.1:0")
+:ok = OMQ.connect(push, endpoint)
+:ok = OMQ.send(push, "hello")
+{:ok, "hello"} = OMQ.recv_string(pull, 1000)
+```
+
+Development commands live in the parent OMQ.beam package.

--- a/bindings/beam/elixir/mix.exs
+++ b/bindings/beam/elixir/mix.exs
@@ -6,6 +6,9 @@ defmodule Omq.MixProject do
       app: :omq_elixir,
       version: "0.1.0",
       elixir: "~> 1.16",
+      description: description(),
+      package: package(),
+      source_url: "https://github.com/paddor/omq.rs",
       deps: deps()
     ]
   end
@@ -15,6 +18,21 @@ defmodule Omq.MixProject do
   end
 
   defp deps do
-    []
+    [{:omq, "~> 0.1"}]
+  end
+
+  defp description do
+    "Elixir wrapper for OMQ.beam, backed by the Erlang OMQ NIF package."
+  end
+
+  defp package do
+    [
+      licenses: ["ISC"],
+      links: %{
+        "GitHub" => "https://github.com/paddor/omq.rs",
+        "OMQ.beam" => "https://github.com/paddor/omq.rs/tree/main/bindings/beam"
+      },
+      files: ~w(lib mix.exs README.md)
+    ]
   end
 end

--- a/bindings/beam/gleam/README.md
+++ b/bindings/beam/gleam/README.md
@@ -1,0 +1,24 @@
+# OMQ Gleam
+
+Gleam wrapper for OMQ.beam.
+
+This package depends on the Erlang `omq` package, which owns the Rust NIF and
+native OMQ runtime. The Gleam module exposes typed handles and `Result`
+return values around the Erlang API.
+
+```gleam
+import omq_gleam as omq
+
+pub fn example() {
+  let assert Ok(ctx) = omq.context()
+  let assert Ok(pull) = omq.socket(ctx, omq.pull())
+  let assert Ok(push) = omq.socket(ctx, omq.push())
+  let assert Ok(endpoint) = omq.bind(pull, <<"tcp://127.0.0.1:0">>)
+  let assert Ok(Nil) = omq.connect(push, endpoint)
+  let assert Ok(Nil) = omq.send_string(push, "hello")
+  let assert Ok("hello") = omq.recv_string_timeout(pull, 1000)
+  Nil
+}
+```
+
+Development commands live in the parent OMQ.beam package.

--- a/bindings/beam/gleam/gleam.toml
+++ b/bindings/beam/gleam/gleam.toml
@@ -1,8 +1,18 @@
 name = "omq_gleam"
 version = "0.1.0"
+description = "Gleam wrapper for OMQ.beam, backed by the Erlang OMQ NIF package."
+licences = ["ISC"]
 target = "erlang"
 
+[repository]
+type = "github"
+user = "paddor"
+repo = "omq.rs"
+path = "bindings/beam/gleam"
+tag-prefix = "bindings/beam/gleam/v"
+
 [dependencies]
+omq = ">= 0.1.0 and < 1.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 
 [dev-dependencies]

--- a/bindings/beam/native/.cargo/config.toml
+++ b/bindings/beam/native/.cargo/config.toml
@@ -1,0 +1,4 @@
+[patch.crates-io]
+omq-proto = { path = "../../../omq-proto" }
+omq-tokio = { path = "../../../omq-tokio" }
+yring = { path = "../../../yring" }

--- a/bindings/beam/native/Cargo.toml
+++ b/bindings/beam/native/Cargo.toml
@@ -23,5 +23,5 @@ ws = ["omq-tokio/ws"]
 
 [dependencies]
 bytes = "1.12.0"
-omq-tokio = { path = "../../../omq-tokio", default-features = false }
+omq-tokio = { version = "0.21.4", default-features = false }
 rustler = "0.38.0"

--- a/bindings/beam/src/omq.app.src
+++ b/bindings/beam/src/omq.app.src
@@ -1,9 +1,22 @@
 {application, omq, [
-    {description, "OMQ BEAM bindings"},
+    {description, "Erlang bindings for OMQ, a Rust ZeroMQ-compatible messaging stack"},
     {vsn, "0.1.0"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {modules, [omq, omq_nif]},
     {licenses, ["ISC"]},
-    {links, [{"GitHub", "https://github.com/paddor/omq.rs"}]}
+    {links, [
+        {"GitHub", "https://github.com/paddor/omq.rs"},
+        {"OMQ.beam", "https://github.com/paddor/omq.rs/tree/main/bindings/beam"}
+    ]},
+    {files, [
+        "src",
+        "native/Cargo.toml",
+        "native/src",
+        "rebar.config",
+        "rebar.lock",
+        "README.md",
+        "DEVELOPMENT.md",
+        "doc/architecture.md"
+    ]}
 ]}.


### PR DESCRIPTION
- Add Hex package metadata for the Erlang `omq` base package.
- Add release docs for publishing `omq`, `omq_elixir`, and `omq_gleam` in dependency order.
- Add install docs for Erlang, Elixir, and Gleam users.
- Add wrapper package metadata and README files for `omq_elixir` and `omq_gleam`.
- Use crates.io `omq-tokio` in packaged NIF builds while keeping local workspace patch config for development.