### PR TITLE
docs(beam): add API docs

### DIFF
--- a/bindings/beam/elixir/lib/omq.ex
+++ b/bindings/beam/elixir/lib/omq.ex
@@ -1,10 +1,51 @@
 defmodule OMQ do
   @moduledoc """
-  Thin Elixir wrapper over the Erlang `:omq` module.
+  Elixir API for OMQ.
 
-  Functions return Erlang result shapes unchanged: `:ok`, `{:ok, value}`, or
+  OMQ sockets are ZeroMQ-compatible message queues backed by the Rust
+  `omq-tokio` runtime. Create a context with `context/0` or reuse the
+  process-wide singleton with `context_instance/0`, then create sockets with
+  `socket/2`.
+
+  Endpoints are binaries or strings such as `"tcp://127.0.0.1:5555"`,
+  `"ipc:///tmp/omq.sock"`, `"inproc://queue"`, `"lz4+tcp://127.0.0.1:5555"`,
+  and `"zstd+tcp://127.0.0.1:5555"`.
+
+  Functions return Erlang result shapes unchanged: `:ok`, `{:ok, value}`,
+  `{:ok, value, metadata}` where documented by Erlang, or
   `{:error, class, reason}`.
+
+  `send/3` accepts either an integer flags mask or an option list. Supported
+  options are `:sndmore`, `:noblock`, `:dontwait`, `{:flags, flags}`, and
+  `{:routing_id, id}`. `recv/1` and `recv/2` return either `{:ok, data}` or
+  routing metadata maps for ROUTER/SERVER-style sockets.
   """
+
+  @typedoc "Native OMQ context resource."
+  @type context :: term()
+
+  @typedoc "Native OMQ socket resource."
+  @type socket :: term()
+
+  @typedoc "Socket monitor event stream resource."
+  @type monitor :: term()
+
+  @typedoc "Common OMQ result shape."
+  @type result(value) :: :ok | {:ok, value} | {:error, atom(), binary() | String.t()}
+
+  @typedoc "Endpoint URI accepted by bind/connect."
+  @type endpoint :: binary() | String.t()
+
+  @typedoc "Send flags or option list."
+  @type send_opts ::
+          integer()
+          | [
+              :sndmore
+              | :noblock
+              | :dontwait
+              | {:flags, integer()}
+              | {:routing_id, non_neg_integer()}
+            ]
 
   @doc "Create a context with one IO thread."
   def context, do: call(:context, [])

--- a/bindings/beam/elixir/mix.exs
+++ b/bindings/beam/elixir/mix.exs
@@ -9,6 +9,7 @@ defmodule Omq.MixProject do
       description: description(),
       package: package(),
       source_url: "https://github.com/paddor/omq.rs",
+      docs: docs(),
       deps: deps()
     ]
   end
@@ -18,7 +19,10 @@ defmodule Omq.MixProject do
   end
 
   defp deps do
-    [{:omq, "~> 0.1"}]
+    [
+      {:omq, "~> 0.1"},
+      {:ex_doc, "~> 0.40", only: :dev, runtime: false}
+    ]
   end
 
   defp description do
@@ -33,6 +37,15 @@ defmodule Omq.MixProject do
         "OMQ.beam" => "https://github.com/paddor/omq.rs/tree/main/bindings/beam"
       },
       files: ~w(lib mix.exs README.md)
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      extras: ["README.md"],
+      source_ref: "main",
+      source_url: "https://github.com/paddor/omq.rs"
     ]
   end
 end

--- a/bindings/beam/gleam/manifest.toml
+++ b/bindings/beam/gleam/manifest.toml
@@ -4,8 +4,10 @@
 packages = [
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
+  { name = "omq", version = "0.1.0", build_tools = ["rebar3"], requirements = [], otp_app = "omq", source = "hex", outer_checksum = "9AC2CA520467BE8B0C45ABF2EA3E245003669B9B381BC24A497DF12C3026094E" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.11.0 and < 2.0.0" }
+omq = { version = ">= 0.1.0 and < 1.0.0" }

--- a/bindings/beam/gleam/src/omq_gleam.gleam
+++ b/bindings/beam/gleam/src/omq_gleam.gleam
@@ -1,3 +1,20 @@
+//// Gleam API for OMQ.
+////
+//// OMQ sockets are ZeroMQ-compatible message queues backed by the Rust
+//// `omq-tokio` runtime. Create a context with `context` or reuse the
+//// process-wide singleton with `context_instance`, then create sockets with
+//// `socket`.
+////
+//// Endpoints are UTF-8 bit arrays such as <<"tcp://127.0.0.1:5555":utf8>>,
+//// <<"ipc:///tmp/omq.sock":utf8>>, <<"inproc://queue":utf8>>,
+//// <<"lz4+tcp://127.0.0.1:5555":utf8>>, and
+//// <<"zstd+tcp://127.0.0.1:5555":utf8>>.
+////
+//// Functions return `Ok(value)` or `Error(#(class, reason))` unless they are
+//// pure constants or feature checks. `send` and `recv` move binary frames;
+//// string, JSON, term, multipart, pub/sub, RADIO/DISH, and socket option
+//// helpers wrap the Erlang base package.
+
 import gleam/dynamic.{type Dynamic}
 
 /// Native OMQ context resource.

--- a/bindings/beam/rebar.config
+++ b/bindings/beam/rebar.config
@@ -1,6 +1,21 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 {deps, []}.
 
+{project_plugins, [rebar3_ex_doc]}.
+
+{hex, [{doc, #{provider => ex_doc}}]}.
+
+{ex_doc, [
+    {source_url, <<"https://github.com/paddor/omq.rs">>},
+    {extras, [<<"README.md">>, <<"DEVELOPMENT.md">>, <<"doc/architecture.md">>]},
+    {main, <<"readme">>},
+    {skip_undefined_reference_warnings_on, [
+        <<"README.md">>,
+        <<"DEVELOPMENT.md">>,
+        <<"doc/architecture.md">>
+    ]}
+]}.
+
 {post_hooks, [
     {compile, "sh -c 'cd native && cargo build'"},
     {compile, "sh -c 'mkdir -p priv && cp native/target/debug/libomq_beam_native.so priv/omq_beam_native.so'"}

--- a/bindings/beam/src/omq.erl
+++ b/bindings/beam/src/omq.erl
@@ -1,3 +1,23 @@
+%% @doc Erlang API for OMQ.
+%%
+%% OMQ sockets are ZeroMQ-compatible message queues backed by the Rust
+%% omq-tokio runtime. Create a context with context/0 or reuse the
+%% process-wide singleton with context_instance/0, then create sockets with
+%% socket/2.
+%%
+%% Endpoints are binaries or iodata URI strings such as
+%% tcp://127.0.0.1:5555, ipc:///tmp/omq.sock, inproc://queue,
+%% lz4+tcp://127.0.0.1:5555, and zstd+tcp://127.0.0.1:5555.
+%%
+%% Most calls return ok, {ok, Value}, or {error, Class, Reason}.
+%% send/3 accepts an integer flags mask or an option list. Supported option
+%% entries are sndmore, noblock, dontwait, {flags, Flags}, and
+%% {routing_id, Id}. recv/1,2 returns either {ok, Data} or routing
+%% metadata maps for ROUTER/SERVER-style sockets.
+%%
+%% Socket type constants match libzmq values where libzmq defines one. Socket
+%% options can be passed by atom or integer option ID.
+%% @end
 -module(omq).
 
 -export([
@@ -123,7 +143,7 @@
     forwarder/0, queue/0, streamer/0, null/0, plain/0, curve/0
 ]).
 
-%% @doc Create a context. `context/0` uses one IO thread.
+%% @doc Create a context. context/0 uses one IO thread.
 context() ->
     context(1).
 
@@ -148,7 +168,7 @@ context_instance(IoThreads) ->
         end
     end).
 
-%% @doc Return process-wide singleton context. Alias for `context_instance/0,1`.
+%% @doc Return process-wide singleton context. Alias for context_instance/0,1.
 instance() ->
     context_instance().
 
@@ -162,7 +182,7 @@ term(Context) ->
         omq_nif:context_term(Context)
     end).
 
-%% @doc Terminate a context. Alias for `term/1`.
+%% @doc Terminate a context. Alias for term/1.
 destroy(Context) ->
     term(Context).
 
@@ -186,11 +206,11 @@ backend_name() ->
 version() ->
     omq_nif:version().
 
-%% @doc Return native binding version. Alias for `version/0`.
+%% @doc Return native binding version. Alias for version/0.
 omq_version() ->
     version().
 
-%% @doc Return native binding version as `{Major, Minor, Patch}`.
+%% @doc Return native binding version as {Major, Minor, Patch}.
 omq_version_info() ->
     case version() of
         {ok, Version} -> {ok, version_info_tuple(Version)};
@@ -293,7 +313,7 @@ send_string(Socket, Text, Opts) ->
 send_string(Socket, Text, Encoding, Opts) ->
     send(Socket, unicode:characters_to_binary(Text, utf8, Encoding), Opts).
 
-%% @doc Send one JSON value encoded with OTP `json`.
+%% @doc Send one JSON value encoded with OTP json.
 send_json(Socket, Value) ->
     send_json(Socket, Value, []).
 
@@ -359,7 +379,7 @@ recv_string(Socket, Timeout, Encoding) ->
             Other
     end.
 
-%% @doc Receive one JSON value decoded by OTP `json`.
+%% @doc Receive one JSON value decoded by OTP json.
 recv_json(Socket) ->
     recv_json(Socket, infinity).
 
@@ -370,7 +390,7 @@ recv_json(Socket, Timeout) ->
 try_recv_json(Socket) ->
     decode_json_result(try_recv(Socket)).
 
-%% @doc Receive one Erlang term encoded by `send_term/2,3`.
+%% @doc Receive one Erlang term encoded by send_term/2,3.
 recv_term(Socket) ->
     recv_term(Socket, infinity).
 
@@ -537,11 +557,11 @@ wait_connected(Socket, MinPeers, Timeout) ->
 wait_subscribed(Socket, MinSubscriptions, Timeout) ->
     omq_nif:wait_subscribed(Socket, MinSubscriptions, timeout_ms(Timeout)).
 
-%% @doc Set socket option. Alias for `setsockopt/3`.
+%% @doc Set socket option. Alias for setsockopt/3.
 set(Socket, Option, Value) ->
     setsockopt(Socket, Option, Value).
 
-%% @doc Get socket option. Alias for `getsockopt/2`.
+%% @doc Get socket option. Alias for getsockopt/2.
 get(Socket, Option) ->
     getsockopt(Socket, Option).
 


### PR DESCRIPTION
- Add Hex docs generation config for the Erlang `omq` package with `rebar3_ex_doc`.
- Add ExDoc config and dev dependency for the `omq_elixir` wrapper.
- Expand Erlang, Elixir, and Gleam module docs with endpoints, result shapes, send options, and routed receive behavior.
- Commit the resolved Gleam manifest entry for the published `omq` Hex package.
