### PR TITLE
chore(pyomq): prepare 0.20.3 release

### DIFF
--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3] - 2026-09-02
+
+### Added
+
+- Include the `py.typed` marker so downstream type checkers recognize pyomq
+  as typed.
+
 ## [0.20.2] - 2026-09-01
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "pyomq"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "bytes",
  "flume",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyomq"
-version = "0.20.2"
+version = "0.20.3"
 edition = "2024"
 rust-version = "1.93"
 license = "ISC"

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyomq"
-version = "0.20.2"
+version = "0.20.3"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }


### PR DESCRIPTION
- Bump `pyomq` metadata from `0.20.2` to `0.20.3`.
- Update `bindings/pyomq/Cargo.lock` for the new package version.
- Add the `0.20.3` changelog entry for the `py.typed` marker.
- Leave the existing `omq-rs` Ruby `0.1.2` release prep on `main` unchanged.