### PR TITLE
fix(pyomq): guard canceled receive fd cleanup

### DIFF
--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -142,6 +142,8 @@ class _RecvFuture:
         try_fn = self._try_fn
 
         def _on_readable() -> None:
+            # Check fut.done() before closing. After cancellation,
+            # _on_cancel owns the descriptor.
             try:
                 os.read(fd, 8)
             except OSError:
@@ -149,20 +151,22 @@ class _RecvFuture:
             try:
                 r = try_fn()
             except Exception as e:
+                if fut.done():
+                    return
                 loop.remove_reader(fd)
                 os.close(fd)
-                if not fut.done():
-                    fut.set_exception(e)
+                fut.set_exception(e)
                 return
             if r is not None:
                 try:
                     os.write(fd, b"\x01\x00\x00\x00\x00\x00\x00\x00")
                 except OSError:
                     pass
+                if fut.done():
+                    return
                 loop.remove_reader(fd)
                 os.close(fd)
-                if not fut.done():
-                    fut.set_result(r)
+                fut.set_result(r)
 
         def _on_cancel(f: asyncio.Future[Any]) -> None:
             if f.cancelled():

--- a/bindings/pyomq/tests/test_recv_future.py
+++ b/bindings/pyomq/tests/test_recv_future.py
@@ -1,12 +1,21 @@
 """_RecvFuture: both await and blocking .result() paths."""
 
 import asyncio
+import os
+import select
+import sys
 import threading
+import types
+from typing import Any
 
 import pytest
 
 import pyomq
 import pyomq.asyncio as zmq_async
+
+
+async def _await(value):
+    return await value
 
 
 @pytest.mark.asyncio
@@ -58,6 +67,56 @@ async def test_recv_future_done_transitions(tcp_endpoint):
         push.send(b"done-test")
         msg = await fut
         assert msg == b"done-test"
+    finally:
+        push.close()
+        pull.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix fd readiness path only")
+@pytest.mark.asyncio
+async def test_cancelled_read_does_not_close_reused_fd(tcp_endpoint, monkeypatch):
+    ctx = zmq_async.Context()
+    push = ctx.socket(pyomq.PUSH)
+    pull = ctx.socket(pyomq.PULL)
+    try:
+        ep = pull.bind(tcp_endpoint)
+        push.connect(ep)
+
+        pending: Any = pull.recv_multipart()
+        old_fd = pending._fd
+        pending_task = asyncio.create_task(_await(pending))
+        await asyncio.sleep(0)
+
+        push.send_multipart([b"raced"])
+        ready, _, _ = select.select([old_fd], [], [], 5.0)
+        assert ready
+
+        replacement: list[Any] = []
+        replacement_created = asyncio.Event()
+        real_os = zmq_async.os
+        os_proxy = types.ModuleType("os")
+        os_proxy.__dict__.update(vars(real_os))
+
+        def close_and_reuse(fd: int) -> None:
+            os.close(fd)
+            if fd == old_fd and not replacement:
+                replacement.append(pull.recv_multipart())
+                replacement_created.set()
+
+        setattr(os_proxy, "close", close_and_reuse)
+        monkeypatch.setattr(zmq_async, "os", os_proxy)
+
+        asyncio.get_running_loop().call_soon(pending_task.cancel)
+        await replacement_created.wait()
+        assert replacement[0]._fd == old_fd
+
+        replacement_task = asyncio.create_task(_await(replacement[0]))
+        await asyncio.sleep(0)
+        push.send_multipart([b"replacement"])
+        assert await asyncio.wait_for(replacement_task, timeout=5.0) == [b"replacement"]
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending_task
     finally:
         push.close()
         pull.close()


### PR DESCRIPTION
- Prevent stale `asyncio` receive callbacks from closing FDs reused by replacement reads after cancellation.
- Make cancellation own descriptor cleanup once its future is already done, without adding normal receive hot-path work.
- Add deterministic Unix regression coverage for cancellation racing with readability and FD reuse.
- Fixes #328.