### PR TITLE
Fix Node release packaging and prepare 0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       run_lua: ${{ steps.scope.outputs.lua }}
       run_dotnet: ${{ steps.scope.outputs.dotnet }}
       run_ruby: ${{ steps.scope.outputs.ruby }}
+      run_node: ${{ steps.scope.outputs.node }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v3
@@ -103,6 +104,10 @@ jobs:
               - 'Cargo.lock'
               - '.cargo/**'
               - '.github/workflows/ci.yml'
+            node:
+              - 'bindings/node/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-node.yml'
       - id: matrix
         run: |
           echo 'test_matrix={"include":[{"toolchain":"1.93","os":"ubuntu-latest"},{"toolchain":"stable","os":"macos-15"},{"toolchain":"stable","os":"windows-latest","target":"x86_64-pc-windows-msvc"}]}' >> "$GITHUB_OUTPUT"
@@ -160,6 +165,30 @@ jobs:
           dotnet-version: '10.0.x'
       - name: verify formatting
         run: dotnet format bindings/dotnet/Omq.Net.csproj --verify-no-changes --verbosity minimal
+
+  node-package:
+    name: node package metadata
+    needs: [changes]
+    if: needs.changes.outputs.run_node == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: bindings/node/package-lock.json
+      - name: install dependencies
+        working-directory: bindings/node
+        run: npm ci
+      - name: validate package metadata
+        working-directory: bindings/node
+        run: |
+          npm run build:ts
+          node --check scripts/prepare-release.js
+          version="$(node -p 'require("./package.json").version')"
+          npm run release:prepare -- "$version" --dry-run
 
   go-test:
     name: go test
@@ -866,6 +895,7 @@ jobs:
         ruby-test,
         dotnet-lint,
         dotnet,
+        node-package,
       ]
     runs-on: ubuntu-latest
     if: always()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -399,6 +399,17 @@ GitHub releases. Configuration lives in `release-plz.toml`.
 
 ### Binding Releases
 
+Push binding tags one at a time with `push.followTags` disabled. GitHub does
+not create push events when one push creates more than three tags, and a local
+`push.followTags=true` setting can silently add other annotated tags.
+
+For workflow-backed releases, find and watch the run created for the tag:
+
+```sh
+gh run list --repo paddor/omq.rs --workflow WORKFLOW --branch TAG --limit 1
+gh run watch RUN_ID --repo paddor/omq.rs --exit-status
+```
+
 `pyomq` publishes to PyPI from `.github/workflows/release-pyomq.yml`.
 Prepare a release by bumping `bindings/pyomq/Cargo.toml` and
 `bindings/pyomq/pyproject.toml`, running `cargo update -p pyomq` inside
@@ -407,8 +418,7 @@ the PR is merged, push a tag:
 
 ```sh
 git tag -a pyomq-v0.21.0 -m "pyomq 0.21.0"
-git push origin pyomq-v0.21.0
-gh run watch --repo paddor/omq.rs --exit-status
+git -c push.followTags=false push origin pyomq-v0.21.0
 ```
 
 `omq-rs` publishes to RubyGems from
@@ -420,8 +430,7 @@ versions before pushing the Ruby tag. After the PR is merged, push a tag:
 
 ```sh
 git tag -a ruby-v0.2.0 -m "omq-rs 0.2.0"
-git push origin ruby-v0.2.0
-gh run watch --repo paddor/omq.rs --exit-status
+git -c push.followTags=false push origin ruby-v0.2.0
 ```
 
 `OMQ.java` publishes to Maven Central from
@@ -434,8 +443,7 @@ After the PR is merged, push a tag:
 
 ```sh
 git tag -a omq-java-v0.3.4 -m "OMQ.java 0.3.4"
-git push origin omq-java-v0.3.4
-gh run watch --repo paddor/omq.rs --exit-status
+git -c push.followTags=false push origin omq-java-v0.3.4
 ```
 
 The workflow publishes with `central.autoPublish=true` and waits until Central
@@ -447,19 +455,30 @@ module tag from `main`:
 
 ```sh
 git tag -a bindings/go/v0.1.2 -m "OMQ.go 0.1.2"
-git push origin bindings/go/v0.1.2
+git -c push.followTags=false push origin bindings/go/v0.1.2
 go list -m github.com/paddor/omq.rs/bindings/go@v0.1.2
 ```
 
 The public Go module proxy discovers the version from that tag.
 
 `OMQ.node` publishes to npm from `.github/workflows/release-node.yml`.
-Prepare a release by checking `bindings/node/package.json`,
-`bindings/node/npm/*/package.json`, and
-`bindings/node/scripts/prepare-release.js`. The workflow version comes from
-the tag or manual `workflow_dispatch` input, builds all platform native
-addons, packs platform packages, smoke-tests host tarballs, publishes
-platform packages first, then publishes the root package.
+Prepare a release by bumping `bindings/node/Cargo.toml`, its local package in
+`bindings/node/Cargo.lock`, the root `package.json` version, both root
+`package-lock.json` package versions, every `bindings/node/npm/*/package.json`
+version, and the changelog. Do not check root `optionalDependencies` into
+`package.json` or `package-lock.json`.
+`scripts/prepare-release.js` adds them after `npm ci` and after every platform
+package has been built. Validate the prepared tree with:
+
+```sh
+(cd bindings/node && npm ci)
+(cd bindings/node && npm run release:prepare -- VERSION --dry-run)
+```
+
+The workflow version comes from the tag or manual `workflow_dispatch` input.
+It builds all platform native addons, packs platform packages, smoke-tests
+host tarballs, publishes platform packages first, then publishes the root
+package.
 
 Publishing uses npm trusted publishing with GitHub Actions OIDC. No npm token
 secret is required by the workflow. In npm, configure a trusted publisher for
@@ -494,9 +513,8 @@ release. After the PR is merged and trusted publishers are configured, push a
 tag:
 
 ```sh
-git tag -a omq-node-v0.2.0 -m "OMQ.node 0.2.0"
-git push origin omq-node-v0.2.0
-gh run watch --repo paddor/omq.rs --exit-status
+git tag -a omq-node-v0.2.1 -m "OMQ.node 0.2.1"
+git -c push.followTags=false push origin omq-node-v0.2.1
 ```
 
 `OMQ.Net` publishes to NuGet from `.github/workflows/release-dotnet.yml`.
@@ -505,8 +523,7 @@ Prepare a release by bumping `bindings/dotnet/Omq.Net.csproj` and adding a
 
 ```sh
 git tag -a omq-dotnet-v0.2.0 -m "OMQ.Net 0.2.0"
-git push origin omq-dotnet-v0.2.0
-gh run watch --repo paddor/omq.rs --exit-status
+git -c push.followTags=false push origin omq-dotnet-v0.2.0
 ```
 
 `OMQ.lua` publishes to LuaRocks. Prepare a release by adding a versioned
@@ -515,7 +532,7 @@ same commit before uploading the rockspec:
 
 ```sh
 git tag -a omq-lua-v0.2.2 -m "OMQ.lua 0.2.2"
-git push origin omq-lua-v0.2.2
+git -c push.followTags=false push origin omq-lua-v0.2.2
 luarocks upload bindings/lua/omq-0.2.2-1.rockspec
 ```
 
@@ -531,7 +548,7 @@ merged, push a tag:
 
 ```sh
 git tag -a omq-zig-v0.1.0 -m "OMQ.zig 0.1.0"
-git push origin omq-zig-v0.1.0
+git -c push.followTags=false push origin omq-zig-v0.1.0
 ```
 
 ### Crates To Check

--- a/bindings/beam/.gitignore
+++ b/bindings/beam/.gitignore
@@ -1,4 +1,7 @@
 /_build/
+/doc/.build*
+/doc/dist/
+/doc/*.epub
 /elixir/_build/
 /priv/omq_beam_native.so
 /gleam/build/

--- a/bindings/node/CHANGELOG.md
+++ b/bindings/node/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
+- Keep generated platform package dependencies out of the checked-in root
+  manifest and lockfile so release jobs can run `npm ci` before packaging.
+
 ## [0.2.0] - 2026-09-04
 
 - Preserve SERVER routing IDs across receive and send operations.

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "omq-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "napi",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omq-node"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.93"
 publish = false

--- a/bindings/node/DEVELOPMENT.md
+++ b/bindings/node/DEVELOPMENT.md
@@ -133,10 +133,15 @@ Allowed action: npm publish
 Trigger CI release with a tag:
 
 ```sh
-git tag omq-node-v0.2.0
+git tag -a omq-node-v0.2.1 -m "OMQ.node 0.2.1"
+git -c push.followTags=false push origin omq-node-v0.2.1
 ```
 
-Or run `.github/workflows/release-node.yml` with `version=0.2.0`.
+Or run `.github/workflows/release-node.yml` with `version=0.2.1`.
+
+Keep root `optionalDependencies` out of the checked-in `package.json` and
+`package-lock.json`. The release preparation script adds them after `npm ci`
+and after the platform packages exist.
 
 Native jobs build platform addons named `omq_node.<platform>.node`.
 Package job copies them into `npm/<platform>/`, writes root
@@ -152,7 +157,7 @@ cp omq_node.linux-x64-gnu.node npm/linux-x64-gnu/
 npm pack ./npm/linux-x64-gnu --dry-run
 ```
 
-Use `npm run release:prepare -- 0.2.0 --dry-run` to validate metadata without
+Use `npm run release:prepare -- 0.2.1 --dry-run` to validate metadata without
 rewriting manifests.
 
 `npm run artifacts` expects every configured platform addon under `artifacts/`.

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-arm64-musl/package.json
+++ b/bindings/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-arm64-musl",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/linux-x64-musl/package.json
+++ b/bindings/node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-linux-x64-musl",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-arm64-msvc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "arm64"
   ],

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node-win32-x64-msvc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "cpu": [
     "x64"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paddor/omq-node",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "devDependencies": {
         "@napi-rs/cli": "^3.3.4",
@@ -16,16 +16,6 @@
       },
       "engines": {
         "node": ">=24.11.0"
-      },
-      "optionalDependencies": {
-        "@paddor/omq-node-darwin-arm64": "0.2.0",
-        "@paddor/omq-node-darwin-x64": "0.2.0",
-        "@paddor/omq-node-linux-arm64-gnu": "0.2.0",
-        "@paddor/omq-node-linux-arm64-musl": "0.2.0",
-        "@paddor/omq-node-linux-x64-gnu": "0.2.0",
-        "@paddor/omq-node-linux-x64-musl": "0.2.0",
-        "@paddor/omq-node-win32-arm64-msvc": "0.2.0",
-        "@paddor/omq-node-win32-x64-msvc": "0.2.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddor/omq-node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native Node.js binding for OMQ.rs",
   "license": "ISC",
   "type": "commonjs",
@@ -56,15 +56,5 @@
     "@types/node": "^24.10.0",
     "typescript": "^5.9.3",
     "zeromq": "^6.5.0"
-  },
-  "optionalDependencies": {
-    "@paddor/omq-node-linux-x64-gnu": "0.2.0",
-    "@paddor/omq-node-linux-x64-musl": "0.2.0",
-    "@paddor/omq-node-linux-arm64-gnu": "0.2.0",
-    "@paddor/omq-node-linux-arm64-musl": "0.2.0",
-    "@paddor/omq-node-darwin-x64": "0.2.0",
-    "@paddor/omq-node-darwin-arm64": "0.2.0",
-    "@paddor/omq-node-win32-x64-msvc": "0.2.0",
-    "@paddor/omq-node-win32-arm64-msvc": "0.2.0"
   }
 }


### PR DESCRIPTION
- Remove generated platform `optionalDependencies` from checked-in Node package metadata so `npm ci` runs before package publication.
- Bump `OMQ.node` and all platform packages to 0.2.1.
- Add Node package metadata validation to PR CI.
- Correct binding tag push and workflow watch instructions in `DEVELOPMENT.md`.
- Ignore generated BEAM Hex documentation artifacts.