### PR TITLE
Name OMQ background threads

### DIFF
--- a/omq-libzmq/doc/compatibility.md
+++ b/omq-libzmq/doc/compatibility.md
@@ -59,6 +59,11 @@ currently wired into backend behavior.
 `ZMQ_THREAD_SAFE` returns 0. Match libzmq discipline: one application thread per
 socket.
 
+Unnamed contexts use background thread names such as `OMQ0/IO/0`. Contexts
+configured with more than one IO thread also have an `OMQ0/Control` thread.
+`ZMQ_THREAD_NAME_PREFIX` replaces the generated `OMQ0` context name and must be
+set before creating a socket.
+
 ## OMQ extension API
 
 `libomq_zmq.so` also exports a small `omq_*` extension surface. These symbols

--- a/omq-libzmq/src/context.rs
+++ b/omq-libzmq/src/context.rs
@@ -26,6 +26,7 @@ pub(crate) struct OmqContext {
     pub ipv6: AtomicBool,
     pub blocky: AtomicBool,
     pub zero_copy_recv: AtomicBool,
+    thread_name_prefix: Mutex<Option<String>>,
     /// Zmq-layer inproc registry. Maps inproc name to the bound `OmqSocket`.
     pub(crate) inproc_binds: Mutex<FxHashMap<String, std::sync::Weak<crate::socket::OmqSocket>>>,
     /// Pending inproc connect requests waiting for a bind.
@@ -73,6 +74,7 @@ impl OmqContext {
             ipv6: AtomicBool::new(false),
             blocky: AtomicBool::new(true),
             zero_copy_recv: AtomicBool::new(true),
+            thread_name_prefix: Mutex::new(None),
             inproc_binds: Mutex::new(FxHashMap::default()),
             inproc_waiting: Mutex::new(FxHashMap::default()),
             zap: Arc::new(crate::zap::ZapService::default()),
@@ -94,6 +96,7 @@ impl OmqContext {
             ipv6: AtomicBool::new(false),
             blocky: AtomicBool::new(true),
             zero_copy_recv: AtomicBool::new(true),
+            thread_name_prefix: Mutex::new(None),
             inproc_binds: Mutex::new(FxHashMap::default()),
             inproc_waiting: Mutex::new(FxHashMap::default()),
             zap: Arc::new(crate::zap::ZapService::default()),
@@ -120,12 +123,40 @@ impl OmqContext {
         if n <= 0 {
             return None;
         }
+        let thread_name_prefix = self
+            .thread_name_prefix
+            .lock()
+            .expect("thread name prefix poisoned");
         let ctx = self.ctx.get_or_init(|| {
-            omq_tokio::Context::with_config(omq_tokio::ContextConfig {
+            let config = omq_tokio::ContextConfig {
                 io_threads: n as usize,
-            })
+            };
+            match thread_name_prefix.as_deref() {
+                Some(prefix) => omq_tokio::Context::with_config_and_name(config, prefix),
+                None => omq_tokio::Context::with_config(config),
+            }
         });
         (!ctx.is_terminated()).then_some(ctx)
+    }
+
+    fn set_thread_name_prefix(&self, prefix: String) -> Result<(), ()> {
+        let mut stored = self
+            .thread_name_prefix
+            .lock()
+            .expect("thread name prefix poisoned");
+        if self.socket_count.load(Ordering::Acquire) != 0 || self.ctx.get().is_some() {
+            return Err(());
+        }
+        *stored = Some(prefix);
+        Ok(())
+    }
+
+    fn thread_name_prefix(&self) -> String {
+        self.thread_name_prefix
+            .lock()
+            .expect("thread name prefix poisoned")
+            .clone()
+            .unwrap_or_default()
     }
 
     pub(crate) fn is_effectively_terminated(&self) -> bool {
@@ -365,6 +396,11 @@ pub extern "C" fn zmq_ctx_set(ctx_ptr: *mut libc::c_void, option: c_int, value: 
         ZMQ_ZERO_COPY_RECV => {
             ctx.zero_copy_recv.store(value != 0, Ordering::Release);
         }
+        ZMQ_THREAD_NAME_PREFIX => {
+            if ctx.set_thread_name_prefix(value.to_string()).is_err() {
+                return crate::error::fail(libc::EINVAL);
+            }
+        }
         ZMQ_SOCKET_LIMIT => {}
         _ => return crate::error::fail(libc::EINVAL),
     }
@@ -384,6 +420,7 @@ pub extern "C" fn zmq_ctx_get(ctx_ptr: *mut libc::c_void, option: c_int) -> c_in
         ZMQ_MAX_MSGSZ => ctx.max_msg_size.load(Ordering::Relaxed) as c_int,
         ZMQ_MSG_T_SIZE => c_int::try_from(crate::msg::ZMQ_MSG_T_SIZE).unwrap_or(c_int::MAX),
         ZMQ_ZERO_COPY_RECV => c_int::from(ctx.zero_copy_recv.load(Ordering::Acquire)),
+        ZMQ_THREAD_NAME_PREFIX => ctx.thread_name_prefix().parse().unwrap_or(0),
         ZMQ_IPV6_CTX => c_int::from(ctx.ipv6.load(Ordering::Acquire)),
         ZMQ_BLOCKY => c_int::from(ctx.blocky.load(Ordering::Acquire)),
         _ => crate::error::fail(libc::EINVAL),
@@ -397,11 +434,31 @@ pub extern "C" fn zmq_ctx_set_ext(
     optval: *const c_void,
     optvallen: usize,
 ) -> c_int {
+    if ctx_ptr.is_null() {
+        return crate::error::fail(libc::EFAULT);
+    }
     if option == ZMQ_THREAD_NAME_PREFIX {
-        if optval.is_null() && optvallen > 0 {
+        if optval.is_null() {
             return crate::error::fail(libc::EFAULT);
         }
-        return 0;
+        if optvallen == 0 || optvallen > 16 {
+            return crate::error::fail(libc::EINVAL);
+        }
+        // SAFETY: optval is non-null and optvallen describes the input bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(optval.cast::<u8>(), optvallen) };
+        let bytes = bytes.strip_suffix(&[0]).unwrap_or(bytes);
+        if bytes.is_empty() || bytes.contains(&0) {
+            return crate::error::fail(libc::EINVAL);
+        }
+        let Ok(prefix) = std::str::from_utf8(bytes) else {
+            return crate::error::fail(libc::EINVAL);
+        };
+        // SAFETY: ctx_ptr was checked above and belongs to this API.
+        let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
+        return match ctx.set_thread_name_prefix(prefix.to_owned()) {
+            Ok(()) => 0,
+            Err(()) => crate::error::fail(libc::EINVAL),
+        };
     }
     if optval.is_null() || optvallen < std::mem::size_of::<c_int>() {
         return crate::error::fail(libc::EINVAL);
@@ -418,8 +475,13 @@ pub extern "C" fn zmq_ctx_get_ext(
     optval: *mut c_void,
     optvallen: *mut usize,
 ) -> c_int {
+    if ctx_ptr.is_null() {
+        return crate::error::fail(libc::EFAULT);
+    }
     if option == ZMQ_THREAD_NAME_PREFIX {
-        return write_bytes(optval, optvallen, b"");
+        // SAFETY: ctx_ptr was checked above and belongs to this API.
+        let ctx = unsafe { &*(ctx_ptr.cast::<Arc<OmqContext>>()) };
+        return write_bytes(optval, optvallen, ctx.thread_name_prefix().as_bytes());
     }
     let value = zmq_ctx_get(ctx_ptr, option);
     if value == -1 && option != ZMQ_MAX_MSGSZ {

--- a/omq-libzmq/tests/ctx.rs
+++ b/omq-libzmq/tests/ctx.rs
@@ -153,7 +153,7 @@ fn ctx_ext_int_options_roundtrip() {
 }
 
 #[test]
-fn ctx_ext_thread_name_prefix_is_accepted_noop() {
+fn ctx_ext_thread_name_prefix_roundtrips() {
     let ctx = zmq_ctx_new();
     let prefix = CString::new("omq").unwrap();
     assert_eq!(
@@ -177,9 +177,52 @@ fn ctx_ext_thread_name_prefix_is_accepted_noop() {
         ),
         0
     );
-    assert_eq!(len, 1);
-    assert_eq!(buf[0], 0);
+    assert_eq!(len, 4);
+    assert_eq!(&buf, b"omq\0");
 
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_int_thread_name_prefix_roundtrips() {
+    let ctx = zmq_ctx_new();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_THREAD_NAME_PREFIX, 42), 0);
+    assert_eq!(zmq_ctx_get(ctx, ZMQ_THREAD_NAME_PREFIX), 42);
+
+    zmq_ctx_term(ctx);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn ctx_thread_name_prefix_names_background_threads() {
+    let ctx = zmq_ctx_new();
+    let name = CString::new("threads").unwrap();
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, 2), 0);
+    assert_eq!(
+        zmq_ctx_set_ext(
+            ctx,
+            ZMQ_THREAD_NAME_PREFIX,
+            name.as_ptr().cast(),
+            name.as_bytes_with_nul().len(),
+        ),
+        0
+    );
+    let sock = zmq_socket(ctx, ZMQ_PUSH);
+    assert!(!sock.is_null());
+    let endpoint = CString::new("inproc://thread-name-test").unwrap();
+    assert_eq!(zmq_bind(sock, endpoint.as_ptr()), 0);
+
+    let names = std::fs::read_dir("/proc/self/task")
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter_map(|entry| std::fs::read_to_string(entry.path().join("comm")).ok())
+        .map(|name| name.trim().to_owned())
+        .collect::<Vec<_>>();
+    assert!(names.iter().any(|name| name == "threads/Control"));
+    assert!(names.iter().any(|name| name == "threads/IO/0"));
+    assert!(names.iter().any(|name| name == "threads/IO/1"));
+
+    zmq_close(sock);
     zmq_ctx_term(ctx);
 }
 
@@ -193,7 +236,44 @@ fn ctx_set_io_threads_rejects_negative_and_late_changes() {
     assert!(!sock.is_null());
     assert_eq!(zmq_ctx_set(ctx, ZMQ_IO_THREADS, 2), -1);
     assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+    assert_eq!(zmq_ctx_set(ctx, ZMQ_THREAD_NAME_PREFIX, 2), -1);
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
     zmq_close(sock);
+    zmq_ctx_term(ctx);
+}
+
+#[test]
+fn ctx_ext_thread_name_prefix_validates_input() {
+    let ctx = zmq_ctx_new();
+    let too_long = [b'x'; 17];
+    assert_eq!(
+        zmq_ctx_set_ext(
+            ctx,
+            ZMQ_THREAD_NAME_PREFIX,
+            too_long.as_ptr().cast(),
+            too_long.len(),
+        ),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    let embedded_nul = b"bad\0name";
+    assert_eq!(
+        zmq_ctx_set_ext(
+            ctx,
+            ZMQ_THREAD_NAME_PREFIX,
+            embedded_nul.as_ptr().cast(),
+            embedded_nul.len(),
+        ),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EINVAL);
+
+    assert_eq!(
+        zmq_ctx_set_ext(ctx, ZMQ_THREAD_NAME_PREFIX, std::ptr::null(), 0),
+        -1
+    );
+    assert_eq!(omq_zmq::zmq_errno(), libc::EFAULT);
     zmq_ctx_term(ctx);
 }
 

--- a/omq-tokio/src/context.rs
+++ b/omq-tokio/src/context.rs
@@ -18,6 +18,8 @@ use crate::Socket;
 
 type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
+static NEXT_CONTEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+
 /// Configuration for a [`Context`] that owns its own tokio runtime.
 ///
 /// ```
@@ -82,12 +84,17 @@ struct IoThreadPool {
 }
 
 impl IoThreadPool {
-    fn new(n: usize) -> Arc<Self> {
+    fn new_with_context_name(n: usize, context_name: Option<String>) -> Arc<Self> {
         assert!(n >= 1);
         let cancel = CancellationToken::new();
+        let id = NEXT_CONTEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+        let context_name = context_name
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| format!("OMQ{id}"));
         // Multi-IO contexts reserve runtime 0 for socket actors and blocking
         // control calls. The configured count applies to data runtimes.
         let runtime_count = if n > 1 { n + 1 } else { 1 };
+        let context_name = fit_context_name(&context_name, n);
         let mut threads = Vec::with_capacity(runtime_count);
         let mut joins = Vec::with_capacity(runtime_count);
         let mut primary_job_tx = None;
@@ -95,12 +102,13 @@ impl IoThreadPool {
         for i in 0..runtime_count {
             let (handle_tx, handle_rx) = mpsc::channel::<Handle>();
             let cancel_i = cancel.clone();
+            let thread_name = background_thread_name(context_name, runtime_count, i);
 
             let join = if i == 0 {
                 let (job_tx, mut job_rx) = tokio::sync::mpsc::unbounded_channel::<BoxFuture>();
                 primary_job_tx = Some(job_tx);
                 thread::Builder::new()
-                    .name("omq-io-0".into())
+                    .name(thread_name)
                     .spawn(move || {
                         let rt = build_current_thread_runtime();
                         let _ = handle_tx.send(rt.handle().clone());
@@ -124,9 +132,8 @@ impl IoThreadPool {
                     })
                     .expect("omq: failed to spawn primary IO thread")
             } else {
-                let name = format!("omq-io-{i}");
                 thread::Builder::new()
-                    .name(name)
+                    .name(thread_name)
                     .spawn(move || {
                         let rt = build_current_thread_runtime();
                         let _ = handle_tx.send(rt.handle().clone());
@@ -197,6 +204,38 @@ impl IoThreadPool {
             }
         }
     }
+}
+
+fn background_thread_name(prefix: &str, runtime_count: usize, index: usize) -> String {
+    if runtime_count > 1 && index == 0 {
+        format!("{prefix}/Control")
+    } else {
+        let io_index = index.saturating_sub(usize::from(runtime_count > 1));
+        format!("{prefix}/IO/{io_index}")
+    }
+}
+
+fn fit_context_name(name: &str, io_threads: usize) -> &str {
+    let max_io_suffix = format!("/IO/{}", io_threads - 1).len();
+    let max_suffix = if io_threads > 1 {
+        max_io_suffix.max("/Control".len())
+    } else {
+        max_io_suffix
+    };
+    truncate_utf8(name, 15usize.saturating_sub(max_suffix))
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let end = value
+        .char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    &value[..end]
 }
 
 impl std::fmt::Debug for IoThreadPool {
@@ -442,11 +481,43 @@ impl Context {
     /// IO threads, this is equivalent to [`Context::current`] and requires an
     /// active tokio runtime.
     pub fn with_config(config: ContextConfig) -> Self {
+        Self::with_config_inner(config, None)
+    }
+
+    /// Create a context with one IO thread and a custom context name.
+    ///
+    /// For example, the name `orders` produces the background thread name
+    /// `orders/IO/0`.
+    pub fn with_name(name: impl Into<String>) -> Self {
+        Self::with_config_and_name(ContextConfig::default(), name)
+    }
+
+    /// Create a context with custom configuration and a custom context name.
+    ///
+    /// Data thread names use `<name>/IO/<index>`. Multi-IO contexts also use
+    /// `<name>/Control` for the internal control runtime. Without an explicit
+    /// name, contexts receive process-local names such as `OMQ0` and `OMQ1`.
+    /// Names are shortened at UTF-8 boundaries to fit Linux's 15-byte thread
+    /// name limit while retaining the role and IO index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty or contains a NUL byte.
+    pub fn with_config_and_name(config: ContextConfig, name: impl Into<String>) -> Self {
+        let name = name.into();
+        assert!(
+            !name.is_empty() && !name.contains('\0'),
+            "context name must be non-empty and contain no NUL byte"
+        );
+        Self::with_config_inner(config, Some(name))
+    }
+
+    fn with_config_inner(config: ContextConfig, context_name: Option<String>) -> Self {
         if config.io_threads == 0 {
             return Self::current();
         }
         let io_threads = config.io_threads;
-        let pool = IoThreadPool::new(io_threads);
+        let pool = IoThreadPool::new_with_context_name(io_threads, context_name);
         Self {
             inner: ContextCore::new(RuntimeOwnership::Owned { pool }, io_threads),
         }
@@ -680,25 +751,76 @@ fn build_current_thread_runtime() -> tokio::runtime::Runtime {
 
 #[cfg(test)]
 mod tests {
-    use super::IoThreadPool;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::{IoThreadPool, fit_context_name};
+
+    fn thread_name(pool: &IoThreadPool, index: usize) -> String {
+        let (name_tx, name_rx) = mpsc::channel();
+        drop(pool.threads[index].handle.spawn(async move {
+            name_tx
+                .send(thread::current().name().unwrap().to_owned())
+                .unwrap();
+        }));
+        name_rx.recv_timeout(Duration::from_secs(1)).unwrap()
+    }
 
     #[test]
     fn single_io_thread_shares_control_runtime() {
-        let pool = IoThreadPool::new(1);
+        let pool = IoThreadPool::new_with_context_name(1, Some("single".to_owned()));
         assert_eq!(pool.threads.len(), 1);
         assert_eq!(pool.thread_count(), 1);
         assert_eq!(pool.assign_thread(), 0);
+        assert_eq!(thread_name(&pool, 0), "single/IO/0");
         pool.shutdown();
     }
 
     #[test]
     fn configured_count_excludes_control_runtime() {
-        let pool = IoThreadPool::new(3);
+        let pool = IoThreadPool::new_with_context_name(3, Some("multi".to_owned()));
         assert_eq!(pool.threads.len(), 4);
         assert_eq!(pool.thread_count(), 3);
         assert_eq!(pool.assign_thread(), 0);
         assert_eq!(pool.assign_thread(), 1);
         assert_eq!(pool.assign_thread(), 2);
+        assert_eq!(thread_name(&pool, 0), "multi/Control");
+        assert_eq!(thread_name(&pool, 1), "multi/IO/0");
+        assert_eq!(thread_name(&pool, 2), "multi/IO/1");
+        assert_eq!(thread_name(&pool, 3), "multi/IO/2");
         pool.shutdown();
+    }
+
+    #[test]
+    fn contexts_get_distinct_default_thread_names() {
+        let first = IoThreadPool::new_with_context_name(1, None);
+        let second = IoThreadPool::new_with_context_name(1, None);
+        assert_ne!(thread_name(&first, 0), thread_name(&second, 0));
+        assert!(thread_name(&first, 0).starts_with("OMQ"));
+        assert!(thread_name(&first, 0).ends_with("/IO/0"));
+        assert!(thread_name(&second, 0).starts_with("OMQ"));
+        assert!(thread_name(&second, 0).ends_with("/IO/0"));
+        first.shutdown();
+        second.shutdown();
+    }
+
+    #[test]
+    fn long_context_names_preserve_thread_role() {
+        let pool = IoThreadPool::new_with_context_name(3, Some("orders-service".to_owned()));
+        assert_eq!(fit_context_name("orders-service", 3), "orders-");
+        assert_eq!(thread_name(&pool, 0), "orders-/Control");
+        assert_eq!(thread_name(&pool, 1), "orders-/IO/0");
+        assert_eq!(thread_name(&pool, 3), "orders-/IO/2");
+        pool.shutdown();
+    }
+
+    #[test]
+    #[should_panic(expected = "context name must be non-empty and contain no NUL byte")]
+    fn explicit_context_name_rejects_nul() {
+        let _ = super::Context::with_config_and_name(
+            super::ContextConfig { io_threads: 1 },
+            "bad\0prefix",
+        );
     }
 }


### PR DESCRIPTION
- Name owned-context threads as `OMQ<N>/IO/0` or `OMQ<N>/Control` plus `OMQ<N>/IO/<n>`
- Add named Rust context constructors with UTF-8-safe platform truncation
- Implement `ZMQ_THREAD_NAME_PREFIX` for the libzmq compatibility API
- Add core and libzmq coverage for naming, validation, truncation, and option round trips