### PR TITLE
Split other protocol comparison charts

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -5,3 +5,6 @@ General cross-implementation benchmark charts live in
 
 Compression transport benchmarks live in
 [BENCHMARKS_COMPRESSION.md](BENCHMARKS_COMPRESSION.md).
+
+Other messaging and RPC protocol comparison charts live in
+[PROTOCOL_COMPARISONS.md](PROTOCOL_COMPARISONS.md).

--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -1,8 +1,11 @@
 # Comparisons
 
-These charts compare OMQ with `libzmq`, `tmq`, `zmq.rs`, `rzmq`, gRPC, and
-brokered messaging systems. The benchmark runner records throughput,
-latency, CPU time, and peer fairness where the pattern has multiple peers.
+These charts compare OMQ with `libzmq`, `tmq`, `zmq.rs`, and `rzmq`. The
+benchmark runner records throughput, latency, CPU time, and peer fairness where
+the pattern has multiple peers.
+
+Comparisons with other messaging and RPC protocols live in
+[PROTOCOL_COMPARISONS.md](PROTOCOL_COMPARISONS.md).
 
 ## Setup
 
@@ -11,8 +14,6 @@ latency, CPU time, and peer fairness where the pattern has multiple peers.
 - `zeromq v0.6.0`
 - `rzmq v0.5.24` in its normal and io_uring modes
 - OMQ from this repository
-- Rust gRPC over plaintext TCP, with opaque blob payloads and no QoS
-- RabbitMQ, Redpanda, NATS, and Redis over loopback TCP using Rust clients
 
 ## Methodology
 
@@ -120,14 +121,4 @@ N-to-1 PUSH/PULL over TCP.
 
 <p align="center">
   <img src="doc/charts/pubsub/curve_tcp.svg" alt="CURVE PUB/SUB throughput: TCP" width="850">
-</p>
-
-## Producer/Consumer Throughput
-
-Direct ZMTP, gRPC streaming over HTTP/2, brokered queues, and persistent
-stream/log systems over loopback TCP. Kafka and Redis Streams are included
-for context, but they are not transparent ZMQ-style PUSH/PULL sockets.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/paddor/omq.rs/other-moms/doc/charts/main_mom_tcp.svg" alt="Producer/consumer throughput: direct, RPC, and brokered messaging" width="950">
 </p>

--- a/PROTOCOL_COMPARISONS.md
+++ b/PROTOCOL_COMPARISONS.md
@@ -1,0 +1,32 @@
+# Other Protocol Comparisons
+
+These charts compare OMQ/ZMTP with other messaging and RPC protocols over TCP
+loopback. They measure one flow, not horizontal scaling.
+
+## Setup
+
+- OMQ/ZMTP and plaintext gRPC are direct process-to-process baselines.
+- NATS uses transient NATS Core messaging.
+- RabbitMQ uses nonpersistent AMQP 0-9-1 messages, auto-delete queues, and
+  automatic consumer acknowledgments.
+- Kafka runs against Redpanda.
+- Redis uses Redis Streams.
+- Iggy uses Apache Iggy streams and topics.
+
+Each data point uses an opaque byte payload. Throughput uses one sender, one
+receiver, and one connection, queue, topic, or partition. Latency sends one
+request at a time and measures requester-observed round-trip time. Delivery
+and persistence semantics differ. The charts compare these concrete
+low-overhead configurations, not equal durability guarantees.
+
+## Producer/Consumer Throughput
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/other-moms/doc/charts/main_mom_tcp.svg" alt="Producer/consumer throughput: direct, RPC, and brokered messaging" width="950">
+</p>
+
+## Request/Reply-Like Latency
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/paddor/omq.rs/other-moms/doc/charts/main_mom_latency_tcp.svg" alt="Sequential request/reply-like latency: direct, RPC, and brokered messaging" width="850">
+</p>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ not depend on libzmq, libsodium, or a C compiler.
 [Full compression transport benchmarks (LZ4 and Zstd)](BENCHMARKS_COMPRESSION.md)
 </details>
 
-[Full comparison charts](COMPARISONS.md)
+[Full comparison charts](COMPARISONS.md) |
+[Other protocol comparisons](PROTOCOL_COMPARISONS.md)
 
 ## The hard parts
 
@@ -201,6 +202,8 @@ OMQ_SOAK_DURATION_SECS=600 cargo test -p omq-tokio \
 ## Further reading
 
 - [COMPARISONS.md](COMPARISONS.md): cross-implementation comparison charts.
+- [PROTOCOL_COMPARISONS.md](PROTOCOL_COMPARISONS.md): throughput and
+  request/reply-like latency against other messaging and RPC protocols.
 - [BENCHMARKS_COMPRESSION.md](BENCHMARKS_COMPRESSION.md): lz4+tcp
   throughput on bandwidth-limited links.
 - [doc/architecture.md](doc/architecture.md): architecture and tokio


### PR DESCRIPTION
- Move non-ZMTP comparisons into `PROTOCOL_COMPARISONS.md`.
- Show producer/consumer throughput and request/reply-like latency charts.
- Keep `COMPARISONS.md` focused on ZMTP implementations and link the new page from benchmark docs.