### PR TITLE
perf(yring): inline ring pop to eliminate intermediate copies

### DIFF
--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Always inline the internal ring pop helper so callers can eliminate
+  intermediate payload-sized return buffers.
+
 ## [0.3.14] - 2026-08-16
 
 ### Added

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -158,7 +158,13 @@ impl<T> Ring<T> {
         cursor == self.head.0.load(Ordering::Acquire)
     }
 
-    #[inline]
+    // Fold the Option into the caller's return value instead of copying a
+    // payload-sized return buffer through this internal helper.
+    #[expect(
+        clippy::inline_always,
+        reason = "profiling shows payload copies through out-of-line pop returns"
+    )]
+    #[inline(always)]
     pub(crate) fn pop(&self, head: &mut Cursor, cached_tail: Cursor) -> Option<T> {
         if *head == cached_tail {
             return None;


### PR DESCRIPTION
- Mark internal `Ring::pop` `#[inline(always)]` so downstream callers can eliminate payload-sized `Option<T>` return copies.
- Preserve ownership behavior and atomic ordering.
- Record multi-producer gains and single-producer 64-byte regression in commit context.
- Add `yring` changelog entry.