### PR TITLE
Fix yring wakeup races and local performance measurements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,10 +72,14 @@ OMQ_SKIP_PERF=1 ./scripts/test-all.sh
 OMQ_LOOM=1 ./scripts/test-all.sh
 ```
 
-The full sweep runs `omq_perf_verify` locally. With `.perf_hw` present,
-it uses machine-specific hardware thresholds. Without `.perf_hw`, it
-runs a smaller smoke gate for obvious TCP/inproc regressions. The perf
-gate skips when `CI` or `GITHUB_ACTIONS` is set.
+The full sweep runs `omq_perf_verify` locally. `.perf_hw` supplies hardware
+thresholds; if absent, a smaller smoke gate runs. CI skips the gate.
+
+Use `--list`, `--case NAME`, `--repeat N`, or `--measure-only` for focused checks.
+`OMQ_PERF_WARMUP_MS` and `OMQ_PERF_MEASURE_MS` set durations;
+`OMQ_PERF_CPUS` sets an ordered Linux CPU list. The verifier excludes warmup,
+times bounded batches, and reports rates using actual elapsed time.
+See [performance verification](doc/perf-verification.md) for threshold settings.
 
 GitHub CI runs `cargo fmt` and clippy on Linux, macOS Intel, macOS
 ARM64, and Windows. It runs workspace tests on Linux x86_64 with MSRV
@@ -202,6 +206,15 @@ unless `OMQ_BENCH_NO_WRITE=1`.
 
 Unless stated otherwise, user ensures system is NOT noisy during benchmarks. So
 when a measured cell looks bad, don't hand-wave it as noise.
+
+- Throughput: no per-message clocks, logging, or shared measurement counters.
+  Use bounded message/byte batches; check deadlines while blocked.
+- Exclude warmup and boundary-crossing batches; use actual elapsed time.
+  Test clock-read bounds and window boundaries. Per-operation timing is for latency.
+- Profile instrumentation and library code. Compare revisions with identical
+  harness, flags, workload, warmup, duration, and CPU placement. Measure harness
+  changes against the same library.
+- Use `--measure-only` for diagnosis; do not lower thresholds to pass a regression.
 
 ### Cross-implementation Comparison Benchmarks
 

--- a/omq-tokio/CHANGELOG.md
+++ b/omq-tokio/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct the local performance gate's warmup accounting and measurement
+  windows; bound receive drains and send retries, and stop on the first
+  failed gate. Add explicit Linux CPU placement and repeatable case selection
+  with sample ranges and median results.
+
 ## [0.22.1] - 2026-09-05
 
 ### Changed

--- a/omq-tokio/src/bin/perf_verify.rs
+++ b/omq-tokio/src/bin/perf_verify.rs
@@ -5,14 +5,55 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
-use std::process::{Command, Stdio};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier, LazyLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use omq_proto::flow::DrainBudget;
 use omq_tokio::{Context, ContextConfig, Endpoint, Message, Options, SocketType};
+
+#[path = "perf_verify/affinity.rs"]
+mod affinity;
+#[path = "perf_verify/measurement.rs"]
+mod measurement;
+
+use affinity::{Affinity, Side};
+use measurement::{Counter, DrainResult, MEASURED_TAG, Received, Window, drain_ready};
+
+struct Settings {
+    affinity: Affinity,
+    warmup: Duration,
+    measure: Duration,
+}
+
+static SETTINGS: LazyLock<Settings> = LazyLock::new(|| Settings {
+    affinity: Affinity::from_env(),
+    warmup: duration_env("OMQ_PERF_WARMUP_MS", WARMUP),
+    measure: duration_env("OMQ_PERF_MEASURE_MS", MEASURE),
+});
+
+fn duration_env(name: &str, default: Duration) -> Duration {
+    std::env::var(name).map_or(default, |value| {
+        let millis = value
+            .parse()
+            .expect("benchmark duration must be milliseconds");
+        assert!(millis > 0, "benchmark duration must be positive");
+        Duration::from_millis(millis)
+    })
+}
+
+fn context(io_threads: usize, side: Side) -> Context {
+    let name = match side {
+        Side::Sender => "perf-tx",
+        Side::Receiver => "perf-rx",
+    };
+    let ctx = Context::with_config_and_name(ContextConfig { io_threads }, name);
+    SETTINGS.affinity.pin_context(name, io_threads, side);
+    ctx
+}
 
 const WARMUP: Duration = Duration::from_millis(100);
 const MEASURE: Duration = Duration::from_millis(750);
@@ -39,7 +80,11 @@ struct ThresholdConfig {
 }
 
 fn payload(size: usize) -> Message {
-    let bytes = vec![0x5a; size];
+    tagged_payload(size, MEASURED_TAG)
+}
+
+fn tagged_payload(size: usize, tag: u8) -> Message {
+    let bytes = vec![tag; size];
     if size <= omq_tokio::message::MAX_INLINE_MESSAGE {
         Message::from_slice(&bytes)
     } else {
@@ -65,12 +110,17 @@ fn smoke_thresholds() -> HashMap<String, f64> {
 }
 
 fn read_thresholds() -> ThresholdConfig {
-    let Ok(contents) = std::fs::read_to_string(".perf_hw") else {
-        return ThresholdConfig {
-            mode: ThresholdMode::Smoke,
-            values: smoke_thresholds(),
-        };
+    let contents = match std::fs::read_to_string(".perf_hw") {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ThresholdConfig {
+                mode: ThresholdMode::Smoke,
+                values: smoke_thresholds(),
+            };
+        }
+        Err(error) => panic!("cannot read .perf_hw: {error}"),
     };
+    println!("threshold file: .perf_hw");
     let mut section = String::new();
     let mut thresholds = HashMap::new();
     for line in contents.lines() {
@@ -117,65 +167,177 @@ async fn reqrep_latency() -> f64 {
         }
     });
     let msg = payload(256);
-    for _ in 0..100 {
-        req.send(msg.clone()).await.expect("REQ warmup send");
-        req.recv().await.expect("REQ warmup recv");
+    let warmup_end = Instant::now() + SETTINGS.warmup;
+    while Instant::now() < warmup_end {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            req.send(msg.clone()).await.expect("REQ warmup send");
+            req.recv().await.expect("REQ warmup recv");
+        })
+        .await
+        .expect("REQ warmup timeout");
     }
     let mut samples = Vec::with_capacity(500);
     for _ in 0..500 {
         let start = Instant::now();
-        req.send(msg.clone()).await.expect("REQ send");
-        req.recv().await.expect("REQ recv");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            req.send(msg.clone()).await.expect("REQ send");
+            req.recv().await.expect("REQ recv");
+        })
+        .await
+        .expect("REQ measurement timeout");
         samples.push(start.elapsed().as_secs_f64() * 1_000_000.0);
     }
     echo.abort();
+    let _ = echo.await;
     samples.sort_by(f64::total_cmp);
     samples[samples.len() / 2]
 }
 
-async fn try_send_until(sock: &omq_tokio::Socket, mut msg: Message, deadline: Instant) -> bool {
+async fn send_batch_until(sock: &omq_tokio::Socket, message: &Message, deadline: Instant) -> bool {
+    if Instant::now() >= deadline {
+        return false;
+    }
+    let mut budget = DrainBudget::WORKER;
+    let bytes = message.byte_len();
     loop {
-        match sock.try_send(msg) {
-            Ok(()) => return true,
-            Err(omq_tokio::TrySendError::Full(returned)) => {
-                msg = returned;
-                if Instant::now() >= deadline {
-                    return false;
+        let mut msg = message.clone();
+        loop {
+            match sock.try_send(msg) {
+                Ok(()) => break,
+                Err(omq_tokio::TrySendError::Full(returned)) => {
+                    if Instant::now() >= deadline {
+                        return false;
+                    }
+                    msg = returned;
+                    tokio::task::yield_now().await;
                 }
-                tokio::task::yield_now().await;
+                Err(error) => panic!("perf send failed: {error}"),
             }
-            Err(error) => panic!("perf send failed: {error}"),
+        }
+        if !budget.account(bytes) {
+            return true;
         }
     }
 }
 
-async fn count_messages(sock: omq_tokio::Socket, deadline: Instant) -> u64 {
-    let mut count = 0_u64;
-    while Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if !matches!(
-            tokio::time::timeout(remaining, sock.recv()).await,
-            Ok(Ok(_))
-        ) {
-            break;
+fn send_blocking_batch_until(
+    sock: &omq_tokio::blocking::Socket,
+    message: &Message,
+    deadline: Instant,
+) -> bool {
+    if Instant::now() >= deadline {
+        return false;
+    }
+    let mut budget = DrainBudget::WORKER;
+    let bytes = message.byte_len();
+    loop {
+        let mut msg = message.clone();
+        loop {
+            match sock.try_send(msg) {
+                Ok(()) => break,
+                Err(omq_tokio::TrySendError::Full(returned)) => {
+                    if Instant::now() >= deadline {
+                        return false;
+                    }
+                    msg = returned;
+                    thread::yield_now();
+                }
+                Err(error) => panic!("perf send failed: {error}"),
+            }
         }
-        count += 1;
-        while sock.try_recv().is_ok() {
-            count += 1;
+        if !budget.account(bytes) {
+            return true;
+        }
+    }
+}
+
+async fn count_messages(sock: omq_tokio::Socket, window: Window) -> Received {
+    let mut counter = Counter::new(window);
+    loop {
+        let mut budget = DrainBudget::WORKER;
+        match drain_ready(
+            || sock.try_recv(),
+            &mut counter,
+            window,
+            &mut budget,
+            Instant::now,
+        ) {
+            DrainResult::Deadline => break,
+            DrainResult::Budget => {}
+            DrainResult::Empty => {
+                match tokio::time::timeout_at(window.end.into(), sock.recv()).await {
+                    Ok(Ok(message)) => {
+                        counter.record(&message, Instant::now());
+                        let _ = budget.account(message.byte_len());
+                    }
+                    Ok(Err(error)) => panic!("perf recv failed: {error}"),
+                    Err(_) => break, // Normal end of this measurement window.
+                }
+            }
         }
         tokio::task::yield_now().await;
     }
-    count
+    counter.finish(Instant::now())
+}
+
+fn count_blocking(sock: &omq_tokio::blocking::Socket, window: Window) -> Received {
+    let mut counter = Counter::new(window);
+    loop {
+        let mut budget = DrainBudget::WORKER;
+        if drain_ready(
+            || sock.try_recv(),
+            &mut counter,
+            window,
+            &mut budget,
+            Instant::now,
+        ) == DrainResult::Deadline
+        {
+            break;
+        }
+        thread::yield_now();
+    }
+    counter.finish(Instant::now())
+}
+
+fn transfer_blocking(
+    sender: &omq_tokio::blocking::Socket,
+    receiver: omq_tokio::blocking::Socket,
+    size: usize,
+) -> f64 {
+    let (window_tx, window_rx) = mpsc::channel();
+    let ready = Arc::new(Barrier::new(2));
+    let receiver_ready = ready.clone();
+    let handle = thread::spawn(move || {
+        SETTINGS.affinity.pin(5);
+        receiver_ready.wait();
+        count_blocking(
+            &receiver,
+            window_rx.recv().expect("receive benchmark window"),
+        )
+    });
+    ready.wait();
+    let window = Window::new(Instant::now(), SETTINGS.warmup, SETTINGS.measure);
+    window_tx.send(window).expect("send benchmark window");
+    // Warm the actual data path while the receiver drains. Tags exclude any
+    // warmup backlog still in flight when measurement starts.
+    for (message, deadline) in [
+        (tagged_payload(size, 0), window.start),
+        (payload(size), window.end),
+    ] {
+        while send_blocking_batch_until(sender, &message, deadline) {}
+    }
+    handle.join().expect("receiver thread").rate()
 }
 
 async fn pushpull(size: usize, io_threads: usize, endpoint: Endpoint) -> f64 {
     tokio::task::spawn_blocking(move || {
+        SETTINGS.affinity.pin(0);
         let is_inproc = matches!(endpoint, Endpoint::Inproc { .. });
-        let pull_ctx = Context::with_config(ContextConfig { io_threads });
+        let pull_ctx = context(io_threads, Side::Receiver);
         let push_ctx = if is_inproc {
             pull_ctx.clone()
         } else {
-            Context::with_config(ContextConfig { io_threads })
+            context(io_threads, Side::Sender)
         };
         let pull = pull_ctx.blocking_socket(SocketType::Pull, Options::default());
         let push = push_ctx.blocking_socket(SocketType::Push, Options::default());
@@ -183,49 +345,10 @@ async fn pushpull(size: usize, io_threads: usize, endpoint: Endpoint) -> f64 {
         push.connect(endpoint).expect("PUSH connect");
         pull.wait_connected(1, Duration::from_secs(1))
             .expect("PULL connect timeout");
-
-        let done = Arc::new(AtomicBool::new(false));
-        let receiver_done = done.clone();
-        let receiver = thread::spawn(move || {
-            thread::sleep(WARMUP);
-            let mut count = 0_u64;
-            loop {
-                match pull.try_recv() {
-                    Ok(_) => {
-                        count += 1;
-                        while pull.try_recv().is_ok() {
-                            count += 1;
-                        }
-                    }
-                    Err(_) if receiver_done.load(Ordering::Acquire) => break,
-                    Err(_) => thread::yield_now(),
-                }
-            }
-            count
-        });
-
-        thread::sleep(WARMUP);
-        let msg = payload(size);
-        let deadline = Instant::now() + MEASURE;
-        while Instant::now() < deadline {
-            let mut pending = msg.clone();
-            loop {
-                match push.try_send(pending) {
-                    Ok(()) => break,
-                    Err(omq_tokio::TrySendError::Full(returned)) => {
-                        pending = returned;
-                        thread::yield_now();
-                    }
-                    Err(error) => panic!("PUSH send failed: {error}"),
-                }
-            }
-        }
-        push.send(msg).expect("PUSH wakeup send");
-        done.store(true, Ordering::Release);
-        let count = receiver.join().expect("PULL thread");
+        let rate = transfer_blocking(&push, pull, size);
         push_ctx.term();
         pull_ctx.term();
-        count as f64 / MEASURE.as_secs_f64()
+        rate
     })
     .await
     .expect("PUSH/PULL task")
@@ -238,8 +361,9 @@ async fn fanin(
     sender_type: SocketType,
 ) -> f64 {
     tokio::task::spawn_blocking(move || {
-        let receiver_ctx = Context::with_config(ContextConfig { io_threads });
-        let sender_ctx = Context::with_config(ContextConfig { io_threads });
+        SETTINGS.affinity.pin(0);
+        let receiver_ctx = context(io_threads, Side::Receiver);
+        let sender_ctx = context(io_threads, Side::Sender);
         let receiver = receiver_ctx.blocking_socket(receiver_type, Options::default());
         let sender = sender_ctx.blocking_socket(
             sender_type,
@@ -250,49 +374,10 @@ async fn fanin(
         receiver
             .wait_connected(1, Duration::from_secs(1))
             .expect("receiver connect timeout");
-
-        let done = Arc::new(AtomicBool::new(false));
-        let receiver_done = done.clone();
-        let receiver_thread = thread::spawn(move || {
-            thread::sleep(WARMUP);
-            let mut count = 0_u64;
-            loop {
-                match receiver.try_recv() {
-                    Ok(_) => {
-                        count += 1;
-                        while receiver.try_recv().is_ok() {
-                            count += 1;
-                        }
-                    }
-                    Err(_) if receiver_done.load(Ordering::Acquire) => break,
-                    Err(_) => thread::yield_now(),
-                }
-            }
-            count
-        });
-
-        thread::sleep(WARMUP);
-        let msg = payload(size);
-        let deadline = Instant::now() + MEASURE;
-        while Instant::now() < deadline {
-            let mut pending = msg.clone();
-            loop {
-                match sender.try_send(pending) {
-                    Ok(()) => break,
-                    Err(omq_tokio::TrySendError::Full(returned)) => {
-                        pending = returned;
-                        thread::yield_now();
-                    }
-                    Err(error) => panic!("sender failed: {error}"),
-                }
-            }
-        }
-        sender.send(msg).expect("wakeup send");
-        done.store(true, Ordering::Release);
-        let count = receiver_thread.join().expect("receiver thread");
+        let rate = transfer_blocking(&sender, receiver, size);
         sender_ctx.term();
         receiver_ctx.term();
-        count as f64 / MEASURE.as_secs_f64()
+        rate
     })
     .await
     .expect("fan-in task")
@@ -329,11 +414,13 @@ async fn compare_fanin() {
 }
 
 async fn pubsub(size: usize, io_threads: usize, peers: usize) -> f64 {
-    let pub_ctx = Context::with_config(ContextConfig { io_threads });
-    let sub_ctx = Context::with_config(ContextConfig { io_threads });
+    let pub_ctx = context(io_threads, Side::Sender);
+    let sub_ctx = context(io_threads, Side::Receiver);
     let publisher = pub_ctx.socket(SocketType::Pub, Options::default());
     let endpoint = publisher.bind(tcp_zero()).await.expect("PUB bind");
-    let mut subscribers = Vec::with_capacity(peers);
+    let ready = Arc::new(tokio::sync::Barrier::new(peers + 1));
+    let mut receivers = Vec::with_capacity(peers);
+    let mut windows = Vec::with_capacity(peers);
     for _ in 0..peers {
         let subscriber = sub_ctx.socket(SocketType::Sub, Options::default());
         subscriber
@@ -344,69 +431,46 @@ async fn pubsub(size: usize, io_threads: usize, peers: usize) -> f64 {
             .subscribe(Bytes::new())
             .await
             .expect("SUB subscribe");
-        subscribers.push(subscriber);
+        let ready = ready.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        windows.push(tx);
+        receivers.push(tokio::spawn(async move {
+            ready.wait().await;
+            count_messages(subscriber, rx.await.expect("receive benchmark window")).await
+        }));
     }
     publisher
         .wait_subscribed(peers as u64, Duration::from_secs(1))
         .await
         .expect("SUB subscribe timeout");
-
-    let mut receivers = Vec::with_capacity(peers);
-    for subscriber in subscribers {
-        receivers.push(tokio::spawn(count_messages(
-            subscriber,
-            Instant::now() + WARMUP + MEASURE,
-        )));
+    ready.wait().await;
+    let window = Window::new(Instant::now(), SETTINGS.warmup, SETTINGS.measure);
+    for tx in windows {
+        tx.send(window).expect("send benchmark window");
     }
-    let msg = payload(size);
-    let warmup_deadline = Instant::now() + WARMUP;
-    'warmup: loop {
-        for _ in 0..256 {
-            if !try_send_until(&publisher, msg.clone(), warmup_deadline).await {
-                break 'warmup;
-            }
+    for (message, deadline) in [
+        (tagged_payload(size, 0), window.start),
+        (payload(size), window.end),
+    ] {
+        while send_batch_until(&publisher, &message, deadline).await {
+            tokio::task::yield_now().await;
         }
-        if Instant::now() >= warmup_deadline {
-            break;
-        }
-        tokio::task::yield_now().await;
     }
-    let deadline = Instant::now() + MEASURE;
-    'measure: loop {
-        for _ in 0..256 {
-            if !try_send_until(&publisher, msg.clone(), deadline).await {
-                break 'measure;
-            }
-        }
-        if Instant::now() >= deadline {
-            break;
-        }
-        tokio::task::yield_now().await;
-    }
-    let mut rx_count = 0;
+    let mut received = Received {
+        count: 0,
+        elapsed: SETTINGS.measure,
+    };
     for receiver in receivers {
-        rx_count += receiver.await.expect("SUB task");
+        received = received.combine(receiver.await.expect("SUB task"));
     }
     pub_ctx.term();
     sub_ctx.term();
-    rx_count as f64 / MEASURE.as_secs_f64()
-}
-
-fn send_blocking_retry(sock: &omq_tokio::blocking::Socket, mut msg: Message) {
-    loop {
-        match sock.try_send(msg) {
-            Ok(()) => return,
-            Err(omq_tokio::TrySendError::Full(returned)) => {
-                msg = returned;
-                thread::yield_now();
-            }
-            Err(error) => panic!("PUB send failed: {error}"),
-        }
-    }
+    received.rate()
 }
 
 fn run_pubsub_pub_child(size: usize, io_threads: usize, peers: usize) {
-    let ctx = Context::with_config(ContextConfig { io_threads });
+    SETTINGS.affinity.pin(0);
+    let ctx = context(io_threads, Side::Sender);
     let options = Options {
         xpub_nodrop: true,
         ..Options::default()
@@ -418,98 +482,147 @@ fn run_pubsub_pub_child(size: usize, io_threads: usize, peers: usize) {
     publisher
         .wait_subscribed(peers as u64, Duration::from_secs(10))
         .expect("SUB subscribe timeout");
-    let msg = payload(size);
-    loop {
-        send_blocking_retry(&publisher, msg.clone());
+    let measured = Arc::new(AtomicBool::new(false));
+    let measured_reader = measured.clone();
+    thread::spawn(move || {
+        let mut command = String::new();
+        std::io::stdin()
+            .read_line(&mut command)
+            .expect("read measurement command");
+        assert_eq!(command.trim(), "MEASURE");
+        measured_reader.store(true, Ordering::Release);
+    });
+    let warmup = tagged_payload(size, 0);
+    let message = payload(size);
+    let deadline = Instant::now() + SETTINGS.warmup + SETTINGS.measure + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        let value = if measured.load(Ordering::Acquire) {
+            &message
+        } else {
+            &warmup
+        };
+        if !send_blocking_batch_until(&publisher, value, deadline) {
+            break;
+        }
+    }
+    panic!("PUB child exceeded measurement deadline");
+}
+
+fn run_pubsub_sub_child(endpoint: &Endpoint, duration: Duration, peers: usize) {
+    SETTINGS.affinity.pin(5);
+    let ctx = context(2, Side::Receiver);
+    let ready = Arc::new(Barrier::new(peers + 1));
+    let mut receivers = Vec::with_capacity(peers);
+    let mut windows = Vec::with_capacity(peers);
+    for index in 0..peers {
+        let subscriber = ctx.blocking_socket(SocketType::Sub, Options::default());
+        subscriber.connect(endpoint.clone()).expect("SUB connect");
+        subscriber.subscribe(Bytes::new()).expect("SUB subscribe");
+        let ready = ready.clone();
+        let (tx, rx) = mpsc::channel();
+        windows.push(tx);
+        receivers.push(thread::spawn(move || {
+            SETTINGS.affinity.pin(5 + index);
+            ready.wait();
+            count_blocking(&subscriber, rx.recv().expect("receive benchmark window"))
+        }));
+    }
+    ready.wait();
+    let warmup = duration_env("OMQ_PERF_WARMUP_MS", PUBSUB_32P_WARMUP);
+    let window = Window::new(Instant::now(), warmup, duration);
+    for tx in windows {
+        tx.send(window).expect("send benchmark window");
+    }
+    // The publisher tags all traffic as warmup until this command reaches it.
+    // Any warmup still in flight is discarded by the receiving counters.
+    thread::sleep(window.start.saturating_duration_since(Instant::now()));
+    println!("MEASURE");
+    std::io::stdout()
+        .flush()
+        .expect("flush measurement command");
+    let mut received = Received {
+        count: 0,
+        elapsed: duration,
+    };
+    for receiver in receivers {
+        received = received.combine(receiver.join().expect("SUB thread"));
+    }
+    ctx.term();
+    println!(
+        "RESULT {} {:.9}",
+        received.count,
+        received.elapsed.as_secs_f64()
+    );
+}
+
+#[derive(Debug)]
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
     }
 }
 
-fn run_pubsub_sub_child(endpoint: &Endpoint, size: usize, duration: Duration, peers: usize) {
-    let ctx = Context::with_config(ContextConfig { io_threads: 2 });
-    let drain_batch = if size <= 1024 { 64 } else { 256 };
-    let mut subscribers = Vec::with_capacity(peers);
-    for _ in 0..peers {
-        let subscriber = ctx.blocking_socket(SocketType::Sub, Options::default());
-        subscriber
-            .connect((*endpoint).clone())
-            .expect("SUB connect");
-        subscriber.subscribe(Bytes::new()).expect("SUB subscribe");
-        subscribers.push(subscriber);
+fn child_command() -> Command {
+    let mut command = Command::new(std::env::current_exe().expect("current executable"));
+    let cpus = SETTINGS.affinity.csv();
+    if !cpus.is_empty() {
+        // Children otherwise inherit the caller's one-CPU mask.
+        command.env("OMQ_PERF_CPUS", cpus);
     }
-
-    thread::sleep(PUBSUB_32P_WARMUP);
-    let counters: Vec<_> = (0..peers).map(|_| Arc::new(AtomicU64::new(0))).collect();
-    let deadline = Instant::now() + duration;
-    let started = Instant::now();
-    let receivers: Vec<_> = subscribers
-        .into_iter()
-        .zip(counters.iter().cloned())
-        .map(|(subscriber, counter)| {
-            thread::spawn(move || {
-                let mut count = 0_u64;
-                while Instant::now() < deadline {
-                    if subscriber.try_recv().is_ok() {
-                        count += 1;
-                        for _ in 1..drain_batch {
-                            if subscriber.try_recv().is_err() {
-                                break;
-                            }
-                            count += 1;
-                        }
-                    } else {
-                        thread::yield_now();
-                    }
-                }
-                counter.store(count, Ordering::Relaxed);
-            })
-        })
-        .collect();
-    for receiver in receivers {
-        receiver.join().expect("SUB thread");
-    }
-    let elapsed = started.elapsed().as_secs_f64();
-    let total: u64 = counters
-        .iter()
-        .map(|counter| counter.load(Ordering::Relaxed))
-        .sum();
-    ctx.term();
-    println!("{total} {elapsed:.6}");
+    command
 }
 
 fn pubsub_process_published_rate(size: usize, io_threads: usize, peers: usize) -> f64 {
-    let exe = std::env::current_exe().expect("current executable");
-    let mut publisher = Command::new(&exe)
-        .arg("--pubsub-pub-child")
-        .arg(size.to_string())
-        .arg(io_threads.to_string())
-        .arg(peers.to_string())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("spawn PUB child");
-    let stdout = publisher.stdout.take().expect("PUB stdout");
-    let mut reader = std::io::BufReader::new(stdout);
+    let mut publisher = ChildGuard(
+        child_command()
+            .arg("--pubsub-pub-child")
+            .arg(size.to_string())
+            .arg(io_threads.to_string())
+            .arg(peers.to_string())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn PUB child"),
+    );
+    let mut reader = std::io::BufReader::new(publisher.0.stdout.take().expect("PUB stdout"));
     let mut endpoint = String::new();
     reader.read_line(&mut endpoint).expect("read PUB endpoint");
-    let endpoint = endpoint.trim();
-    assert!(!endpoint.is_empty(), "PUB child did not report endpoint");
-
-    let output = Command::new(&exe)
-        .arg("--pubsub-sub-child")
-        .arg(endpoint)
-        .arg(size.to_string())
-        .arg(PUBSUB_32P_MEASURE.as_secs_f64().to_string())
-        .arg(peers.to_string())
-        .output()
-        .expect("run SUB child");
-    let _ = publisher.kill();
-    let _ = publisher.wait();
     assert!(
-        output.status.success(),
-        "SUB child failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !endpoint.trim().is_empty(),
+        "PUB child did not report endpoint"
     );
-    let stdout = String::from_utf8(output.stdout).expect("SUB stdout utf8");
-    let mut fields = stdout.split_whitespace();
+    let duration = duration_env("OMQ_PERF_MEASURE_MS", PUBSUB_32P_MEASURE);
+    let mut subscriber = ChildGuard(
+        child_command()
+            .arg("--pubsub-sub-child")
+            .arg(endpoint.trim())
+            .arg(size.to_string())
+            .arg(duration.as_secs_f64().to_string())
+            .arg(peers.to_string())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn SUB child"),
+    );
+    let mut reader = std::io::BufReader::new(subscriber.0.stdout.take().expect("SUB stdout"));
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .expect("read SUB measurement command");
+    assert_eq!(line.trim(), "MEASURE");
+    let stdin = publisher.0.stdin.as_mut().expect("PUB stdin");
+    writeln!(stdin, "MEASURE").expect("send measurement command");
+    stdin.flush().expect("flush measurement command");
+    line.clear();
+    reader.read_line(&mut line).expect("read SUB result");
+    assert!(
+        subscriber.0.wait().expect("wait SUB child").success(),
+        "SUB child failed"
+    );
+    let mut fields = line.split_whitespace();
+    assert_eq!(fields.next(), Some("RESULT"));
     let total: f64 = fields
         .next()
         .and_then(|s| s.parse().ok())
@@ -518,6 +631,7 @@ fn pubsub_process_published_rate(size: usize, io_threads: usize, peers: usize) -
         .next()
         .and_then(|s| s.parse().ok())
         .expect("SUB elapsed");
+    assert!(elapsed.is_finite() && elapsed > 0.0);
     total / elapsed / peers as f64
 }
 
@@ -582,95 +696,262 @@ async fn run_mode(args: &[String]) -> bool {
         }
         Some("--pubsub-sub-child") => {
             let endpoint = args[2].parse().expect("endpoint");
-            let size = args[3].parse().expect("size");
             let duration = Duration::from_secs_f64(args[4].parse().expect("duration"));
             let peers = args[5].parse().expect("peers");
-            run_pubsub_sub_child(&endpoint, size, duration, peers);
+            run_pubsub_sub_child(&endpoint, duration, peers);
             true
         }
         _ => false,
     }
 }
 
+#[derive(Debug)]
+enum Workload {
+    Reqrep,
+    Pushpull {
+        size: usize,
+        io_threads: usize,
+        inproc: bool,
+    },
+    Pubsub {
+        size: usize,
+        io_threads: usize,
+        peers: usize,
+    },
+    PubsubProcesses,
+}
+
+#[derive(Debug)]
+struct Case {
+    name: String,
+    workload: Workload,
+}
+
+fn cases() -> Vec<Case> {
+    let mut cases = vec![Case {
+        name: "reqrep_ct.p50_256b_us".to_owned(),
+        workload: Workload::Reqrep,
+    }];
+    for io_threads in [1, 2] {
+        for (size, suffix) in [(16, "16b"), (1024, "1k"), (16 * 1024, "16k")] {
+            cases.push(Case {
+                name: format!("pushpull_{io_threads}io.{suffix}_msgs_s"),
+                workload: Workload::Pushpull {
+                    size,
+                    io_threads,
+                    inproc: false,
+                },
+            });
+        }
+        for (size, suffix) in [(16, "16b"), (4096, "4k")] {
+            cases.push(Case {
+                name: format!("pubsub_{io_threads}io.{suffix}_msgs_s"),
+                workload: Workload::Pubsub {
+                    size,
+                    io_threads,
+                    peers: 4,
+                },
+            });
+        }
+    }
+    cases.push(Case {
+        name: "pubsub_2io.256b_32p_msgs_s".to_owned(),
+        workload: Workload::PubsubProcesses,
+    });
+    cases.push(Case {
+        name: "inproc_pushpull_1io.16b_msgs_s".to_owned(),
+        workload: Workload::Pushpull {
+            size: 16,
+            io_threads: 1,
+            inproc: true,
+        },
+    });
+    cases
+}
+
+async fn measure(case: &Case) -> Sample {
+    let (value, unit) = match case.workload {
+        Workload::Reqrep => (reqrep_latency().await, "us"),
+        Workload::Pushpull {
+            size,
+            io_threads,
+            inproc,
+        } => (
+            pushpull(
+                size,
+                io_threads,
+                if inproc {
+                    inproc_endpoint()
+                } else {
+                    tcp_zero()
+                },
+            )
+            .await,
+            "msg/s",
+        ),
+        Workload::Pubsub {
+            size,
+            io_threads,
+            peers,
+        } => (pubsub(size, io_threads, peers).await, "msg/s"),
+        Workload::PubsubProcesses => (pubsub_process_published_rate(256, 2, 32), "msg/s"),
+    };
+    Sample {
+        name: case.name.clone(),
+        value,
+        unit,
+    }
+}
+
+#[derive(Debug, Default)]
+struct RunOptions {
+    case: Option<String>,
+    repeat: usize,
+    measure_only: bool,
+    list: bool,
+}
+
+impl RunOptions {
+    fn parse(args: &[String]) -> Self {
+        let mut options = Self {
+            repeat: 1,
+            ..Self::default()
+        };
+        let mut args = args.iter().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--case" => {
+                    options.case = Some(args.next().expect("--case requires a name").clone());
+                }
+                "--repeat" => {
+                    options.repeat = args
+                        .next()
+                        .expect("--repeat requires a count")
+                        .parse()
+                        .expect("invalid repeat count");
+                }
+                "--measure-only" => options.measure_only = true,
+                "--list" => options.list = true,
+                _ => panic!("unknown option: {arg}"),
+            }
+        }
+        assert!(options.repeat > 0, "repeat count must be positive");
+        options
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
+    // Read the available CPU mask before pinning this thread; child modes
+    // restore the explicit CPU list passed by their parent.
+    let _ = &*SETTINGS;
+    SETTINGS.affinity.pin(0);
     if run_mode(&args).await {
         return;
     }
-
+    let options = RunOptions::parse(&args);
+    let cases = cases();
+    if options.list {
+        for case in cases {
+            println!("{}", case.name);
+        }
+        return;
+    }
+    if let Some(name) = &options.case {
+        assert!(
+            cases.iter().any(|case| &case.name == name),
+            "unknown benchmark case: {name}"
+        );
+    }
     let thresholds = read_thresholds();
-    let mut ok = true;
-    let name = "reqrep_ct.p50_256b_us";
-    if should_measure(name, &thresholds) {
-        let latency = reqrep_latency().await;
-        ok &= verify(
-            &Sample {
-                name: name.to_string(),
-                value: latency,
-                unit: "us",
-            },
-            &thresholds.values,
-        );
+    println!("placement: {}", SETTINGS.affinity.description());
+    println!(
+        "warmup: {:?}, measurement: {:?}, repetitions: {}",
+        SETTINGS.warmup, SETTINGS.measure, options.repeat
+    );
+    if options.measure_only {
+        println!("measurement only: thresholds are not checked");
+    } else if thresholds.mode == ThresholdMode::Smoke {
+        println!(".perf_hw absent: using smoke thresholds");
     }
-    for io_threads in [1, 2] {
-        for (size, suffix) in [(16, "16b"), (1024, "1k"), (16 * 1024, "16k")] {
-            let name = format!("pushpull_{io_threads}io.{suffix}_msgs_s");
-            if should_measure(&name, &thresholds) {
-                let value = pushpull(size, io_threads, tcp_zero()).await;
-                ok &= verify(
-                    &Sample {
-                        name,
-                        value,
-                        unit: "msg/s",
-                    },
-                    &thresholds.values,
+    for case in cases {
+        if let Some(name) = &options.case {
+            if name != &case.name {
+                continue;
+            }
+        } else if !options.measure_only && !should_measure(&case.name, &thresholds) {
+            continue;
+        }
+        let mut samples = Vec::with_capacity(options.repeat);
+        for round in 0..options.repeat {
+            let sample = measure(&case).await;
+            assert!(sample.value.is_finite(), "invalid benchmark measurement");
+            if options.repeat > 1 {
+                println!(
+                    "  sample {}: {:.2} {}",
+                    round + 1,
+                    sample.value,
+                    sample.unit
                 );
             }
+            samples.push(sample);
         }
-        for (size, suffix, peers) in [(16, "16b", 4), (4096, "4k", 4)] {
-            let name = format!("pubsub_{io_threads}io.{suffix}_msgs_s");
-            if should_measure(&name, &thresholds) {
-                let value = pubsub(size, io_threads, peers).await;
-                ok &= verify(
-                    &Sample {
-                        name,
-                        value,
-                        unit: "msg/s",
-                    },
-                    &thresholds.values,
-                );
-            }
+        samples.sort_by(|a, b| a.value.total_cmp(&b.value));
+        let mut sample = samples[samples.len() / 2].clone();
+        if samples.len() % 2 == 0 {
+            sample.value = sample.value.midpoint(samples[samples.len() / 2 - 1].value);
+        }
+        if options.repeat > 1 {
+            println!(
+                "  range: {:.2}..{:.2} {} (result is median)",
+                samples[0].value,
+                samples[samples.len() - 1].value,
+                sample.unit
+            );
+        }
+        if options.measure_only {
+            println!("{:<24} {:>12.2} {}", sample.name, sample.value, sample.unit);
+        } else if !verify(&sample, &thresholds.values) {
+            // Do not spend time measuring later cases after a failed gate.
+            std::process::exit(1);
         }
     }
-    let name = "pubsub_2io.256b_32p_msgs_s";
-    if should_measure(name, &thresholds) {
-        let value = pubsub_process_published_rate(256, 2, 32);
-        ok &= verify(
-            &Sample {
-                name: name.to_string(),
-                value,
-                unit: "msg/s",
-            },
-            &thresholds.values,
-        );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_blocking_sender_stops_at_deadline() {
+        let ctx = Context::new();
+        let sock = ctx.blocking_socket(SocketType::Push, Options::default());
+        let start = Instant::now();
+        assert!(!send_blocking_batch_until(
+            &sock,
+            &payload(16),
+            start + Duration::from_millis(5)
+        ));
+        assert!(start.elapsed() < Duration::from_secs(1));
+        ctx.term();
     }
-    let name = "inproc_pushpull_1io.16b_msgs_s";
-    if should_measure(name, &thresholds) {
-        let value = pushpull(16, 1, inproc_endpoint()).await;
-        ok &= verify(
-            &Sample {
-                name: name.to_string(),
-                value,
-                unit: "msg/s",
-            },
-            &thresholds.values,
-        );
+
+    #[tokio::test]
+    async fn full_async_sender_stops_at_deadline() {
+        let ctx = Context::current();
+        let sock = ctx.socket(SocketType::Push, Options::default());
+        let deadline = Instant::now() + Duration::from_millis(5);
+        assert!(!send_batch_until(&sock, &payload(16), deadline).await);
     }
-    if thresholds.mode == ThresholdMode::Smoke {
-        eprintln!("warning: .perf_hw missing; using smoke thresholds");
-    }
-    if !ok {
-        std::process::exit(1);
+
+    #[tokio::test]
+    async fn idle_receiver_finishes_without_a_wakeup_message() {
+        let ctx = Context::current();
+        let sock = ctx.socket(SocketType::Pull, Options::default());
+        let window = Window::new(Instant::now(), Duration::ZERO, Duration::from_millis(5));
+        let received = count_messages(sock, window).await;
+        assert_eq!(received.count, 0);
+        assert!(received.elapsed >= Duration::from_millis(5));
     }
 }

--- a/omq-tokio/src/bin/perf_verify/affinity.rs
+++ b/omq-tokio/src/bin/perf_verify/affinity.rs
@@ -1,0 +1,212 @@
+#[derive(Debug)]
+pub(super) struct Affinity {
+    cpus: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Side {
+    Sender,
+    Receiver,
+}
+
+impl Affinity {
+    pub(super) fn from_env() -> Self {
+        let requested = std::env::var("OMQ_PERF_CPUS").ok();
+        let cpus = if let Some(value) = requested {
+            let cpus = parse_cpus(&value);
+            platform::configure(&cpus);
+            cpus
+        } else {
+            platform::available()
+        };
+        Self { cpus }
+    }
+
+    pub(super) fn description(&self) -> String {
+        if self.cpus.is_empty() {
+            return "OS scheduling (explicit CPU placement requires Linux)".to_owned();
+        }
+        format!(
+            "guest CPUs {} (caller, TX IOs, RX IOs, receiver; controls share callers)",
+            self.csv()
+        )
+    }
+
+    pub(super) fn csv(&self) -> String {
+        self.cpus
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    pub(super) fn pin(&self, slot: usize) {
+        if !self.cpus.is_empty() {
+            platform::pin(0, self.cpus[slot % self.cpus.len()]);
+        }
+    }
+
+    pub(super) fn pin_context(&self, prefix: &str, io_threads: usize, side: Side) {
+        if self.cpus.is_empty() {
+            return;
+        }
+        assert!((1..=2).contains(&io_threads));
+        let (control, first_io) = match side {
+            Side::Sender => (0, 1),
+            Side::Receiver => (5, 3),
+        };
+        let mut names = Vec::new();
+        if io_threads > 1 {
+            names.push((
+                format!("{prefix}/Control"),
+                self.cpus[control % self.cpus.len()],
+            ));
+        }
+        for index in 0..io_threads {
+            names.push((
+                format!("{prefix}/IO/{index}"),
+                self.cpus[(first_io + index) % self.cpus.len()],
+            ));
+        }
+        platform::pin_named_threads(&names);
+    }
+}
+
+fn parse_cpus(value: &str) -> Vec<usize> {
+    let cpus: Vec<usize> = value
+        .split(',')
+        .map(|s| {
+            s.trim()
+                .parse()
+                .expect("OMQ_PERF_CPUS requires comma-separated CPU IDs")
+        })
+        .collect();
+    assert!(!cpus.is_empty(), "OMQ_PERF_CPUS cannot be empty");
+    for (i, cpu) in cpus.iter().enumerate() {
+        assert!(!cpus[..i].contains(cpu), "duplicate CPU in OMQ_PERF_CPUS");
+    }
+    cpus
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    fn mask(cpus: &[usize]) -> libc::cpu_set_t {
+        // SAFETY: cpu_set_t is a plain bit set; all IDs are checked before use.
+        unsafe {
+            let mut set = std::mem::zeroed();
+            libc::CPU_ZERO(&mut set);
+            for &cpu in cpus {
+                assert!(
+                    cpu < libc::CPU_SETSIZE as usize,
+                    "CPU ID exceeds CPU_SETSIZE"
+                );
+                libc::CPU_SET(cpu, &mut set);
+            }
+            set
+        }
+    }
+
+    pub(super) fn available() -> Vec<usize> {
+        let mut set = mask(&[]);
+        // SAFETY: set points to a writable cpu_set_t of the supplied size.
+        let result =
+            unsafe { libc::sched_getaffinity(0, std::mem::size_of_val(&set), &raw mut set) };
+        assert_eq!(
+            result,
+            0,
+            "sched_getaffinity: {}",
+            std::io::Error::last_os_error()
+        );
+        (0..libc::CPU_SETSIZE as usize)
+            // SAFETY: cpu is in range, and set was initialized above.
+            .filter(|&cpu| unsafe { libc::CPU_ISSET(cpu, &set) })
+            .collect()
+    }
+
+    fn set_affinity(tid: libc::pid_t, cpus: &[usize]) {
+        let set = mask(cpus);
+        // SAFETY: set is initialized and its size matches the supplied pointer.
+        let result =
+            unsafe { libc::sched_setaffinity(tid, std::mem::size_of_val(&set), &raw const set) };
+        assert_eq!(
+            result,
+            0,
+            "sched_setaffinity: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    pub(super) fn configure(cpus: &[usize]) {
+        // Explicit configuration also restores a child's inherited single-CPU
+        // mask before assigning its workers. Kernel cpuset restrictions still apply.
+        set_affinity(0, cpus);
+        let actual = available();
+        assert!(
+            cpus.iter().all(|cpu| actual.contains(cpu)),
+            "requested CPUs are unavailable"
+        );
+    }
+
+    pub(super) fn pin(tid: libc::pid_t, cpu: usize) {
+        set_affinity(tid, &[cpu]);
+    }
+
+    pub(super) fn pin_named_threads(names: &[(String, usize)]) {
+        let mut remaining: Vec<_> = names.iter().collect();
+        for entry in std::fs::read_dir("/proc/self/task").expect("read task directory") {
+            let entry = entry.expect("read task entry");
+            let Ok(name) = std::fs::read_to_string(entry.path().join("comm")) else {
+                continue;
+            };
+            if let Some(index) = remaining
+                .iter()
+                .position(|(expected, _)| expected == name.trim())
+            {
+                let (_, cpu) = remaining.remove(index);
+                let tid = entry
+                    .file_name()
+                    .to_str()
+                    .unwrap()
+                    .parse()
+                    .expect("task ID");
+                pin(tid, *cpu);
+            }
+        }
+        assert!(
+            remaining.is_empty(),
+            "benchmark context threads missing: {remaining:?}"
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod platform {
+    pub(super) fn available() -> Vec<usize> {
+        Vec::new()
+    }
+    pub(super) fn configure(_: &[usize]) {
+        panic!("OMQ_PERF_CPUS requires Linux")
+    }
+    pub(super) fn pin(_: i32, _: usize) {
+        unreachable!()
+    }
+    pub(super) fn pin_named_threads(_: &[(String, usize)]) {
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_cpu_order_for_explicit_sibling_selection() {
+        assert_eq!(parse_cpus("0, 2,4,6,8,10"), [0, 2, 4, 6, 8, 10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate CPU")]
+    fn rejects_duplicate_cpus() {
+        parse_cpus("0,2,0");
+    }
+}

--- a/omq-tokio/src/bin/perf_verify/measurement.rs
+++ b/omq-tokio/src/bin/perf_verify/measurement.rs
@@ -1,0 +1,266 @@
+use std::time::{Duration, Instant};
+
+use omq_tokio::Message;
+
+pub(super) const MEASURED_TAG: u8 = 0x5a;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Window {
+    pub start: Instant,
+    pub end: Instant,
+}
+
+impl Window {
+    pub(super) fn new(now: Instant, warmup: Duration, duration: Duration) -> Self {
+        let start = now + warmup;
+        Self {
+            start,
+            end: start + duration,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Counter {
+    window: Window,
+    count: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Received {
+    pub count: u64,
+    pub elapsed: Duration,
+}
+
+impl Received {
+    pub(super) fn rate(self) -> f64 {
+        self.count as f64 / self.elapsed.as_secs_f64()
+    }
+
+    pub(super) fn combine(self, other: Self) -> Self {
+        Self {
+            count: self.count + other.count,
+            elapsed: self.elapsed.max(other.elapsed),
+        }
+    }
+}
+
+impl Counter {
+    pub(super) fn new(window: Window) -> Self {
+        Self { window, count: 0 }
+    }
+
+    pub(super) fn record(&mut self, message: &Message, now: Instant) {
+        if now >= self.window.start && now < self.window.end && is_measured(message) {
+            self.count += 1;
+        }
+    }
+
+    pub(super) fn finish(self, now: Instant) -> Received {
+        assert!(now >= self.window.end, "receiver stopped before deadline");
+        Received {
+            count: self.count,
+            // Include scheduling delay at shutdown; never inflate a rate by
+            // counting an overrun against a shorter configured duration.
+            elapsed: now.duration_since(self.window.start),
+        }
+    }
+}
+
+fn is_measured(message: &Message) -> bool {
+    // ROUTER adds an identity frame; the body remains the last part.
+    message
+        .get(message.len().saturating_sub(1))
+        .and_then(|p| p.first())
+        == Some(&MEASURED_TAG)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DrainResult {
+    Empty,
+    Budget,
+    Deadline,
+}
+
+pub(super) fn drain_ready(
+    mut recv: impl FnMut() -> omq_tokio::Result<Message>,
+    counter: &mut Counter,
+    window: Window,
+    budget: &mut omq_proto::flow::DrainBudget,
+    mut now: impl FnMut() -> Instant,
+) -> DrainResult {
+    let started = now();
+    if started >= window.end {
+        return DrainResult::Deadline;
+    }
+    let mut count = 0;
+    let result = loop {
+        if budget.exhausted() {
+            break DrainResult::Budget;
+        }
+        match recv() {
+            Ok(message) => {
+                count += u64::from(is_measured(&message));
+                if !budget.account(message.byte_len()) {
+                    break DrainResult::Budget;
+                }
+            }
+            Err(omq_tokio::Error::WouldBlock) => break DrainResult::Empty,
+            Err(error) => panic!("perf recv failed: {error}"),
+        }
+    };
+    let finished = now();
+    // Timestamp the bounded batch, not every message. Commit only batches
+    // entirely within the window: preemption can lower the count, never add
+    // warmup or late traffic. At most one boundary batch per edge is discarded.
+    if started >= window.start && finished < window.end {
+        counter.count += count;
+    }
+    if finished >= window.end {
+        DrainResult::Deadline
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excludes_warmup_backlog_and_messages_after_deadline() {
+        let now = Instant::now();
+        let window = Window::new(now, Duration::from_secs(1), Duration::from_secs(2));
+        let mut counter = Counter::new(window);
+        let warmup = Message::from_slice(&[0]);
+        let measured = Message::from_slice(&[MEASURED_TAG]);
+        counter.record(&measured, now);
+        counter.record(&warmup, window.start);
+        counter.record(&measured, window.start);
+        counter.record(&measured, window.end);
+        counter.record(&measured, window.end + Duration::from_secs(1));
+        let received = counter.finish(window.end + Duration::from_secs(1));
+        assert_eq!(received.count, 1);
+        assert_eq!(received.elapsed, Duration::from_secs(3));
+        assert!((received.rate() - 1.0 / 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn classifies_router_messages_by_body_instead_of_identity() {
+        use bytes::Bytes;
+
+        let now = Instant::now();
+        let window = Window::new(now, Duration::ZERO, Duration::from_secs(1));
+        let mut counter = Counter::new(window);
+        let warmup = Message::multipart([
+            Bytes::from_static(&[MEASURED_TAG]),
+            Bytes::from_static(&[0]),
+        ]);
+        let measured = Message::multipart([
+            Bytes::from_static(&[0]),
+            Bytes::from_static(&[MEASURED_TAG]),
+        ]);
+        counter.record(&warmup, now);
+        counter.record(&measured, now);
+        assert_eq!(counter.finish(window.end).count, 1);
+    }
+
+    #[test]
+    fn uses_common_window_for_receivers_finishing_at_different_times() {
+        let first = Received {
+            count: 100,
+            elapsed: Duration::from_secs(1),
+        };
+        let second = Received {
+            count: 200,
+            elapsed: Duration::from_secs(2),
+        };
+        assert!((first.combine(second).rate() - 150.0).abs() < f64::EPSILON);
+    }
+    #[test]
+    fn continuously_ready_receiver_yields_at_both_budget_limits() {
+        let now = Instant::now();
+        let window = Window::new(now, Duration::ZERO, Duration::from_secs(1));
+        for (size, expected) in [(16, 256), (1024 * 1024, 2)] {
+            let message = Message::from_slice(&vec![MEASURED_TAG; size]);
+            let mut counter = Counter::new(window);
+            let mut budget = omq_proto::flow::DrainBudget::WORKER;
+            let mut clock_reads = 0;
+            let result = drain_ready(
+                || Ok(message.clone()),
+                &mut counter,
+                window,
+                &mut budget,
+                || {
+                    clock_reads += 1;
+                    now
+                },
+            );
+            assert_eq!(result, DrainResult::Budget);
+            assert_eq!(counter.count, expected);
+            assert_eq!(clock_reads, 2, "clock cost must be per batch");
+        }
+    }
+
+    #[test]
+    fn checks_clock_per_batch_and_excludes_batch_crossing_deadline() {
+        let now = Instant::now();
+        let window = Window::new(now, Duration::ZERO, Duration::from_secs(1));
+        let mut times = [now, window.end].into_iter();
+        let mut counter = Counter::new(window);
+        let mut budget = omq_proto::flow::DrainBudget::new(3, 1024);
+        let mut calls = 0;
+        let result = drain_ready(
+            || {
+                calls += 1;
+                Ok(Message::from_slice(&[MEASURED_TAG]))
+            },
+            &mut counter,
+            window,
+            &mut budget,
+            || times.next().unwrap(),
+        );
+        assert_eq!(result, DrainResult::Deadline);
+        assert_eq!(calls, 3);
+        assert_eq!(counter.count, 0);
+    }
+
+    #[test]
+    fn discards_batch_straddling_warmup_and_keeps_next_complete_batch() {
+        let now = Instant::now();
+        let window = Window::new(now, Duration::from_secs(1), Duration::from_secs(1));
+        let mut counter = Counter::new(window);
+        for (start, expected) in [(now, 0), (window.start, 2)] {
+            let mut times = [start, window.start + Duration::from_millis(1)].into_iter();
+            let mut messages = [0, MEASURED_TAG, MEASURED_TAG].into_iter();
+            assert_eq!(
+                drain_ready(
+                    || Ok(Message::from_slice(&[messages.next().unwrap()])),
+                    &mut counter,
+                    window,
+                    &mut omq_proto::flow::DrainBudget::new(3, 1024),
+                    || times.next().expect("only two clock reads per batch"),
+                ),
+                DrainResult::Budget,
+            );
+            assert_eq!(counter.count, expected);
+        }
+    }
+
+    #[test]
+    fn expired_window_does_not_receive_another_batch() {
+        let now = Instant::now();
+        let window = Window::new(now, Duration::ZERO, Duration::from_secs(1));
+        let mut budget = omq_proto::flow::DrainBudget::WORKER;
+        assert_eq!(
+            drain_ready(
+                || panic!("no receive after observed deadline"),
+                &mut Counter::new(window),
+                window,
+                &mut budget,
+                || window.end,
+            ),
+            DrainResult::Deadline,
+        );
+    }
+}

--- a/yring/CHANGELOG.md
+++ b/yring/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent lost data/space wakeups with registered waiter handshakes around
+  empty/full checks. Wakeup hints include registered waiters.
+- Drain the producer's final flush before returning stream EOF.
+- Release each stream item before returning it, waking blocked producers
+  without requiring another stream poll. Repeated releases are no-ops.
+- Reject producer thread-token exhaustion instead of reusing owner tokens.
+
 ## [0.3.15] - 2026-09-05
 
 ### Changed

--- a/yring/README.md
+++ b/yring/README.md
@@ -10,21 +10,23 @@ atomics become the bottleneck.
 
 ## The solution
 
-Three pointers instead of two:
+Separate writing from publication:
 
 - `head`: consumer read position (AtomicUsize, consumer-owned)
 - `cursor`: producer write position (plain usize, producer-private, no atomic)
 - `tail`: last flushed position (AtomicUsize, producer writes / consumer reads)
 
-`push()` writes to the ring with zero atomics. `flush()` makes all
+`push()` writes without atomics while cached space remains. `flush()` makes all
 pending writes visible with a single Release store. `prefetch()` loads
 all available items with a single Acquire load. `pop()` reads with zero
 atomics. `release()` publishes consumed slots back to the producer with
 a single Release store. Result: atomic synchronization happens per
 batch, not per item.
 
-This is the core ypipe innovation from ZeroMQ, applied to a fixed-capacity
-ring buffer instead of a linked list.
+The speedup comes from caching positions and publishing batches. The
+three-pointer description counts the producer's local cursor alongside two
+shared atomic cursors. The consumer also keeps a local read position and
+a cached publication boundary.
 
 ## Usage
 
@@ -47,8 +49,8 @@ consumer.release(); // one Release store frees slots for producer
 
 ## Sharing the producer handle
 
-`Producer` is `Send` but not `Sync`. When a producer handle must be stored in
-an `Arc` or shared with another owner, wrap it in `ProducerOwner`:
+`Producer` needs `&mut self` for writes. To write through a handle stored in
+an `Arc`, wrap it in `ProducerOwner`:
 
 ```rust
 use std::sync::Arc;
@@ -74,6 +76,7 @@ handle itself to be shared. The first producer call binds it to the current
 thread. Later calls from another thread panic. Multiple owners are fine, but
 all producer calls must come from the same thread. For producer access from
 multiple threads, use a channel with a multi-producer API instead.
+Thread tokens never wrap: allocation panics if the token range is exhausted.
 
 The key advantage over chunk-based batching APIs (like `rtrb`'s
 `write_chunk_uninit`): you keep the simple per-item `push()`/`pop()`
@@ -89,6 +92,31 @@ spins internally.
 The `async` feature (opt-in) adds `AsyncProducer`/`AsyncConsumer` with
 waker integration: the producer wakes the consumer on flush, the
 consumer wakes the producer on release.
+
+`AsyncConsumer`'s `Stream` implementation releases each item before returning
+it. Use `prefetch()`/`pop()`/`release()` directly for batched release.
+`push_async()` buffers without flushing; flush pending items before awaiting
+space in a full ring.
+
+## Wakeup hints
+
+`flush_and_check()` and `prefetch_and_pop_with_full()` provide conservative
+wakeup hints. Their booleans include registered waiters, so they are not
+exact empty/full snapshots. Signal whenever the returned hint is true.
+Calling either helper enables registration on the opposite endpoint. Hints
+remain conservatively true until that endpoint acknowledges activation.
+Queues using only ordinary flush/release skip this registration protocol.
+
+Once enabled, an empty `Consumer::prefetch()` window or `Consumer::is_empty()` check
+registers a data waiter before rechecking publication. A full
+`Producer::push()` or `Producer::is_full()` check registers a space waiter
+before retrying. These checks pair with the hint-producing operations so a
+concurrent flush or release cannot strand a waiter. Register any external
+waker before the final queue check, or use a stateful notification primitive.
+Exhausting the cached `pop()` window alone does not register a waiter.
+
+Ordinary `flush()` and `release()` still use one Release store. Use these
+when a separate signaling protocol handles wakeups.
 
 ## Correctness checks
 

--- a/yring/src/async.rs
+++ b/yring/src/async.rs
@@ -38,26 +38,27 @@ impl<T> Drop for AsyncRing<T> {
     }
 }
 
-/// Async sending half. Wakes the consumer on flush when the ring was empty.
+/// Async sending half. Wakes the consumer on flush.
 pub struct AsyncProducer<T> {
     ring: Arc<AsyncRing<T>>,
     cursor: Cursor,
     cached_head: Cursor,
 }
 
-// SAFETY: AsyncProducer<T> is Send because it is single-owner (not Sync) and
-// the underlying AsyncRing is Send+Sync.
+// SAFETY: Mutations require &mut self and the underlying AsyncRing is Send+Sync.
 unsafe impl<T: Send> Send for AsyncProducer<T> {}
 
-/// Async receiving half. Implements [`Stream`].
+/// Async receiving half. Implements [`Stream`], releasing each returned item.
+/// For batched slot release, use [`Self::prefetch`], [`Self::pop`] and
+/// [`Self::release`] explicitly.
 pub struct AsyncConsumer<T> {
     ring: Arc<AsyncRing<T>>,
     head: Cursor,
     cached_tail: Cursor,
+    released_head: Cursor,
 }
 
-// SAFETY: AsyncConsumer<T> is Send because it is single-owner (not Sync) and
-// the underlying AsyncRing is Send+Sync.
+// SAFETY: Mutations require &mut self and the underlying AsyncRing is Send+Sync.
 unsafe impl<T: Send> Send for AsyncConsumer<T> {}
 
 /// Create an async bounded SPSC ring with the given capacity (rounded up to
@@ -78,12 +79,13 @@ pub fn async_spsc<T>(capacity: usize) -> (AsyncProducer<T>, AsyncConsumer<T>) {
             ring,
             head: 0,
             cached_tail: 0,
+            released_head: 0,
         },
     )
 }
 
 impl<T> AsyncProducer<T> {
-    /// Write a value to the ring. Zero atomics. Returns `Err(val)` if full.
+    /// Write without atomics while cached space remains. Returns `Err(val)` if full.
     #[inline]
     pub fn push(&mut self, val: T) -> Result<(), T> {
         self.ring
@@ -118,6 +120,7 @@ impl<T> AsyncProducer<T> {
     /// Returns `Err(val)` only if the consumer has been dropped (the ring
     /// will never drain). On success the value is buffered but not yet
     /// visible to the consumer; call [`flush`](Self::flush) to publish.
+    /// Flush pending items before awaiting space in a full ring.
     #[inline]
     pub fn push_async(&mut self, val: T) -> PushFuture<'_, T> {
         PushFuture {
@@ -191,6 +194,15 @@ impl<T> Future for PushFuture<'_, T> {
                     return Poll::Ready(Err(returned));
                 }
                 this.producer.ring.producer_waker.0.register(cx.waker());
+                // Release acknowledges this registration after publishing
+                // head, or this exchange acquires its already-freed slots.
+                this.producer
+                    .ring
+                    .ring
+                    .producer_waiting
+                    .0
+                    .waiting
+                    .swap(true, Ordering::AcqRel);
                 match this.producer.push(returned) {
                     Ok(()) => Poll::Ready(Ok(())),
                     Err(returned) => {
@@ -224,8 +236,21 @@ impl<T> AsyncConsumer<T> {
     /// and wake the producer if it is waiting for space.
     #[inline]
     pub fn release(&mut self) {
+        if self.head == self.released_head {
+            return;
+        }
         self.ring.ring.release(self.head);
-        self.ring.producer_waker.0.wake();
+        self.released_head = self.head;
+        if self
+            .ring
+            .ring
+            .producer_waiting
+            .0
+            .waiting
+            .swap(false, Ordering::AcqRel)
+        {
+            self.ring.producer_waker.0.wake();
+        }
     }
 
     /// Load all items flushed since the last prefetch. One Acquire load.
@@ -275,13 +300,12 @@ impl<T> Stream for AsyncConsumer<T> {
             this.prefetch();
         }
         if let Some(val) = this.pop() {
+            this.release();
             return Poll::Ready(Some(val));
         }
 
-        // Release BEFORE registering the waker. Reversing this order
-        // deadlocks: the producer could fill the freed slots and call
-        // wake() between register and release, and we'd park with data
-        // available and no pending wake.
+        // Also release items removed through the manual pop API before
+        // registering and rechecking for the next stream item.
         this.release();
 
         this.ring.consumer_waker.0.register(cx.waker());
@@ -291,9 +315,15 @@ impl<T> Stream for AsyncConsumer<T> {
             this.prefetch();
         }
         if let Some(val) = this.pop() {
+            this.release();
             Poll::Ready(Some(val))
         } else if this.ring.ring.producer_dropped.load(Ordering::Acquire) {
-            Poll::Ready(None)
+            // Acquiring shutdown orders the producer's final flush before
+            // this read. An earlier prefetch may precede that final flush.
+            this.prefetch();
+            let val = this.pop();
+            this.release();
+            Poll::Ready(val)
         } else {
             Poll::Pending
         }
@@ -402,6 +432,23 @@ mod tests {
             assert_eq!(c.next().await, Some(20));
             assert_eq!(c.next().await, Some(30));
         });
+    }
+
+    #[test]
+    fn stream_releases_slot_before_returning_item() {
+        use std::task::Waker;
+
+        let (mut p, mut c) = async_spsc::<u32>(1);
+        p.push_and_flush(10).unwrap();
+        let mut cx = Context::from_waker(Waker::noop());
+
+        assert_eq!(Pin::new(&mut c).poll_next(&mut cx), Poll::Ready(Some(10)));
+        assert_eq!(c.len(), 0);
+
+        // The caller may await a send before polling the stream again.
+        // Consuming the only item must free its slot without another next().
+        let mut push = p.push_async(20);
+        assert_eq!(Pin::new(&mut push).poll(&mut cx), Poll::Ready(Ok(())));
     }
 
     #[test]

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -6,10 +6,11 @@
 //! - `cursor`: writer position (plain usize, producer-only, no atomic)
 //! - `tail`: last flushed position (`AtomicUsize`, producer writes, consumer reads)
 //!
-//! `push` writes to the ring with zero atomics. `flush` makes all
-//! pending writes visible with one Release store. `pop` reads with
-//! zero atomics. `prefetch` loads all flushed items with one Acquire
-//! load. Result: 1 atomic per batch on each side.
+//! `push` writes without atomics while cached space remains. `flush`
+//! publishes writes with one Release store. `pop` reads without atomics;
+//! `prefetch` acquires a batch, and `release` publishes consumed slots.
+//! When wakeup hints are enabled, empty/full checks register waiters so
+//! the optional wakeup hints cannot miss a concurrent state transition.
 
 #[cfg(feature = "async")]
 mod r#async;
@@ -35,6 +36,54 @@ type Cursor = usize;
 #[repr(align(128))]
 pub(crate) struct Padded<T>(pub(crate) T);
 
+// Enabled by the notifying endpoint on first use of a wakeup-hint helper.
+// The peer acknowledges activation before hints may suppress notifications.
+struct Waiter {
+    enabled: AtomicBool,
+    armed: AtomicBool,
+    waiting: AtomicBool,
+}
+
+impl Waiter {
+    fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            armed: AtomicBool::new(false),
+            waiting: AtomicBool::new(false),
+        }
+    }
+
+    #[inline]
+    fn enable(&self) {
+        if !self.enabled.load(Ordering::Relaxed) {
+            self.enabled.store(true, Ordering::Release);
+        }
+    }
+
+    #[inline]
+    fn register(&self) -> bool {
+        if !self.enabled.load(Ordering::Acquire) {
+            return false;
+        }
+        self.waiting.swap(true, Ordering::AcqRel);
+        // A notifier may suppress wakes only after acquiring this acknowledgment.
+        // Registration precedes it; the caller rechecks the queue afterward.
+        self.armed.store(true, Ordering::Release);
+        true
+    }
+
+    #[inline]
+    fn take(&self, observed: bool) -> bool {
+        if observed || !self.armed.load(Ordering::Acquire) {
+            // Until the peer acknowledges activation, every publication wakes.
+            self.waiting.store(false, Ordering::Release);
+            true
+        } else {
+            self.waiting.swap(false, Ordering::AcqRel)
+        }
+    }
+}
+
 pub(crate) struct Ring<T> {
     pub(crate) buf: Box<[UnsafeCell<MaybeUninit<T>>]>,
     pub(crate) mask: usize,
@@ -42,6 +91,10 @@ pub(crate) struct Ring<T> {
     pub(crate) head: Padded<AtomicCursor>,
     /// Last flushed position. Written by producer, read by consumer.
     pub(crate) tail: Padded<AtomicCursor>,
+    /// Empty/full observers register before rechecking the opposite cursor.
+    /// The notifying side exchanges this flag after publishing its cursor.
+    consumer_waiting: Padded<Waiter>,
+    producer_waiting: Padded<Waiter>,
     /// Set by `Producer::drop`. Lets the consumer detect that no more
     /// data will ever arrive.
     pub(crate) producer_dropped: AtomicBool,
@@ -76,6 +129,8 @@ impl<T> Ring<T> {
             mask: cap - 1,
             head: Padded(AtomicCursor::new(0)),
             tail: Padded(AtomicCursor::new(0)),
+            consumer_waiting: Padded(Waiter::new()),
+            producer_waiting: Padded(Waiter::new()),
             producer_dropped: AtomicBool::new(false),
             consumer_dropped: AtomicBool::new(false),
         }
@@ -124,6 +179,7 @@ impl<T> Ring<T> {
 
     #[inline]
     pub(crate) fn flush_to(&self, cursor: Cursor, cached_head: &mut Cursor) -> FlushResult {
+        self.consumer_waiting.0.enable();
         let prev_tail = self.tail.0.load(Ordering::Relaxed);
         if cursor == prev_tail {
             return FlushResult::NothingToFlush;
@@ -132,9 +188,12 @@ impl<T> Ring<T> {
         *cached_head = self.head.0.load(Ordering::Acquire);
         let was_empty = prev_tail == *cached_head;
         self.tail.0.store(cursor, Ordering::Release);
+        // Pair with the consumer's register-then-recheck exchange. Either
+        // this sees its registration, or its recheck sees our publication.
+        let wake = self.consumer_waiting.0.take(was_empty);
         FlushResult::Flushed {
             count: Self::count(count),
-            was_empty,
+            was_empty: wake,
         }
     }
 
@@ -239,14 +298,15 @@ pub enum FlushResult {
     Flushed {
         /// Number of items made visible.
         count: usize,
-        /// Whether the consumer had no visible items before this flush.
+        /// Whether the consumer needs a wake: the queue was observed empty
+        /// or a waiter may exist. Conservative during protocol activation too.
         was_empty: bool,
     },
     /// Nothing to flush (cursor == tail already).
     NothingToFlush,
 }
 
-/// Sending half. `Send` but not `Sync`.
+/// Sending half. Mutation requires exclusive access.
 pub struct Producer<T> {
     ring: Arc<Ring<T>>,
     /// Private write position. No atomic; only the producer touches it.
@@ -269,8 +329,8 @@ impl<T> Drop for Producer<T> {
     }
 }
 
-// SAFETY: Producer<T> is Send because it is single-owner (not Sync) and the
-// underlying Ring is Send+Sync. Moving the producer to another thread is safe.
+// SAFETY: Producer mutations require &mut self and the underlying Ring is
+// Send+Sync. Moving the producer to another thread is safe.
 unsafe impl<T: Send> Send for Producer<T> {}
 
 /// Single-thread owner handle for a producer shared through an `Arc`.
@@ -361,7 +421,21 @@ fn current_thread_token() -> usize {
         if current != 0 {
             return current;
         }
-        let current = NEXT_THREAD_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut next = NEXT_THREAD_TOKEN.load(std::sync::atomic::Ordering::Relaxed);
+        let current = loop {
+            let following = next
+                .checked_add(1)
+                .expect("ProducerOwner thread tokens exhausted");
+            match NEXT_THREAD_TOKEN.compare_exchange_weak(
+                next,
+                following,
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+            ) {
+                Ok(current) => break current,
+                Err(actual) => next = actual,
+            }
+        };
         token.set(current);
         current
     })
@@ -373,7 +447,7 @@ impl<T> std::fmt::Debug for ProducerOwner<T> {
     }
 }
 
-/// Receiving half. `Send` but not `Sync`.
+/// Receiving half. Mutation requires exclusive access.
 pub struct Consumer<T> {
     ring: Arc<Ring<T>>,
     /// Private read position. Only the consumer touches it.
@@ -390,8 +464,8 @@ impl<T> Consumer<T> {
     }
 }
 
-// SAFETY: Consumer<T> is Send because it is single-owner (not Sync) and the
-// underlying Ring is Send+Sync. Moving the consumer to another thread is safe.
+// SAFETY: Consumer mutations require &mut self and the underlying Ring is
+// Send+Sync. Moving the consumer to another thread is safe.
 unsafe impl<T: Send> Send for Consumer<T> {}
 
 /// Create a bounded SPSC ring with the given capacity (rounded up to
@@ -433,10 +507,23 @@ pub fn loom_spsc_with_cursors<T>(capacity: usize, cursor: usize) -> (Producer<T>
 }
 
 impl<T> Producer<T> {
-    /// Write a value to the ring. Zero atomics. Returns `Err(val)` if full.
+    /// Write a value without atomics while cached space remains.
+    /// Returns `Err(val)` if full. When space hints are enabled, registers a
+    /// waiter and retries before returning.
     /// The value is NOT visible to the consumer until [`flush`](Self::flush).
     #[inline]
     pub fn push(&mut self, val: T) -> Result<(), T> {
+        match self.ring.push(&mut self.cursor, &mut self.cached_head, val) {
+            Ok(()) => Ok(()),
+            Err(val) => self.push_after_full(val),
+        }
+    }
+
+    #[cold]
+    fn push_after_full(&mut self, val: T) -> Result<(), T> {
+        if !self.ring.producer_waiting.0.register() {
+            return Err(val);
+        }
         self.ring.push(&mut self.cursor, &mut self.cached_head, val)
     }
 
@@ -448,9 +535,13 @@ impl<T> Producer<T> {
         self.ring.tail.0.store(self.cursor, Ordering::Release);
     }
 
-    /// Flush and report whether the ring was empty (consumer fully caught
-    /// up). Loads `head` (one Acquire) in addition to the Release store.
-    /// Only needed when the caller uses `was_empty` for wakeup decisions.
+    /// Flush and report whether the consumer needs a wake.
+    ///
+    /// In addition to the empty snapshot, this acknowledges registrations
+    /// made by [`Consumer::prefetch`] or [`Consumer::is_empty`]. The consumer
+    /// must use one of those checks before waiting, and the caller must
+    /// signal whenever `was_empty` is true. Extra wakes are possible.
+    /// Use [`flush`](Self::flush) when signaling through a separate protocol.
     #[inline]
     pub fn flush_and_check(&mut self) -> FlushResult {
         self.ring.flush_to(self.cursor, &mut self.cached_head)
@@ -467,6 +558,12 @@ impl<T> Producer<T> {
     #[inline]
     /// Return whether the ring cannot accept another item.
     pub fn is_full(&mut self) -> bool {
+        if !self.ring.is_full(self.cursor, &mut self.cached_head) {
+            return false;
+        }
+        if !self.ring.producer_waiting.0.register() {
+            return true;
+        }
         self.ring.is_full(self.cursor, &mut self.cached_head)
     }
 
@@ -531,10 +628,23 @@ impl<T> Consumer<T> {
         self.ring.release(self.head);
     }
 
-    /// Load all items flushed since the last prefetch. One Acquire load.
-    /// Returns the count of newly available items.
+    /// Load all items flushed since the last prefetch.
+    /// Returns the count of newly available items. When data hints are enabled,
+    /// an empty window registers a waiter and rechecks before returning.
     #[inline]
     pub fn prefetch(&mut self) -> usize {
+        let count = self.ring.prefetch(&mut self.cached_tail);
+        if self.head != self.cached_tail {
+            return count;
+        }
+        self.prefetch_after_empty()
+    }
+
+    #[cold]
+    fn prefetch_after_empty(&mut self) -> usize {
+        if !self.ring.consumer_waiting.0.register() {
+            return 0;
+        }
         self.ring.prefetch(&mut self.cached_tail)
     }
 
@@ -552,24 +662,36 @@ impl<T> Consumer<T> {
         val
     }
 
-    /// Prefetch + pop + release, returning whether the ring was full before
-    /// the pop released one slot.
+    /// Prefetch + pop + release, returning whether the producer needs a wake.
     ///
-    /// This always prefetches before checking fullness. A producer may have
-    /// flushed more items behind the consumer's cached window, and a caller
-    /// using `was_full` for space wakeups must observe that state.
+    /// The hint includes both observed fullness and a producer registration
+    /// from [`Producer::push`] or [`Producer::is_full`]. It may conservatively
+    /// report true after a producer has already resumed. Signal whenever it
+    /// is true; register external waiters before rechecking the full queue.
     #[inline]
     pub fn prefetch_and_pop_with_full(&mut self) -> Option<(T, bool)> {
-        self.prefetch();
+        self.ring.producer_waiting.0.enable();
+        if self.head == self.cached_tail {
+            self.prefetch();
+        }
+        // A refilled ring can exceed this cached window. The producer's
+        // full registration covers that case without a tail load per pop.
         let was_full = self.cached_tail.wrapping_sub(self.head) >= self.capacity();
         let val = self.pop()?;
         self.release();
-        Some((val, was_full))
+        let wake = self.ring.producer_waiting.0.take(was_full);
+        Some((val, wake))
     }
 
     #[inline]
     /// Return whether the consumer has no visible items.
     pub fn is_empty(&self) -> bool {
+        if !self.ring.consumer_is_empty(self.head, self.cached_tail) {
+            return false;
+        }
+        if !self.ring.consumer_waiting.0.register() {
+            return true;
+        }
         self.ring.consumer_is_empty(self.head, self.cached_tail)
     }
 
@@ -661,8 +783,10 @@ mod tests {
     #[test]
     fn prefetch_and_pop_with_full_reports_full_transition() {
         let (mut p, mut c) = spsc::<u32>(2);
+        assert_eq!(c.prefetch_and_pop_with_full(), None);
         p.push(10).unwrap();
         p.push(20).unwrap();
+        assert!(p.is_full());
         p.flush();
 
         assert_eq!(c.prefetch_and_pop_with_full(), Some((10, true)));
@@ -671,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn prefetch_and_pop_with_full_prefetches_stale_tail_before_full_check() {
+    fn prefetch_and_pop_with_full_observes_waiter_behind_cached_tail() {
         let (mut p, mut c) = spsc::<u32>(2);
         p.push(10).unwrap();
         p.push(20).unwrap();
@@ -688,13 +812,30 @@ mod tests {
         assert_eq!(c.prefetch_and_pop_with_full(), Some((30, false)));
     }
 
+    #[test]
+    fn prefetch_and_pop_with_full_wakes_for_unflushed_full_ring() {
+        let (mut p, mut c) = spsc::<u32>(2);
+        p.push_and_flush(10).unwrap();
+        p.push(20).unwrap();
+        assert_eq!(p.push(30), Err(30));
+
+        // Fullness includes the producer's unpublished slot. The cached
+        // tail alone cannot tell that the producer needs a space wake.
+        assert_eq!(c.prefetch_and_pop_with_full(), Some((10, true)));
+        p.push_and_flush(30).unwrap();
+        assert_eq!(c.prefetch_and_pop(), Some(20));
+        assert_eq!(c.prefetch_and_pop(), Some(30));
+    }
+
     #[cfg(all(loom, target_pointer_width = "64"))]
     #[test]
     fn prefetch_and_pop_with_full_handles_cursor_wrap() {
         let base = usize::MAX - 1;
         let (mut p, mut c) = loom_spsc_with_cursors::<u32>(2, base);
+        assert_eq!(c.prefetch_and_pop_with_full(), None);
         p.push(10).unwrap();
         p.push(20).unwrap();
+        assert!(p.is_full());
         p.flush();
 
         assert_eq!(c.prefetch_and_pop_with_full(), Some((10, true)));
@@ -741,6 +882,64 @@ mod tests {
         let first = first.join();
         let second = second.join();
         assert_ne!(first.is_ok(), second.is_ok());
+    }
+
+    #[cfg(not(any(loom, miri)))]
+    #[test]
+    fn producer_owner_rejects_other_threads_after_token_wrap() {
+        use std::sync::{Arc, Barrier, mpsc};
+
+        const CHILD_ENV: &str = "OMQ_YRING_TOKEN_WRAP_TEST_CHILD";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            // Changing the global token counter must not affect other tests.
+            // Miri cannot launch this isolated subprocess.
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "tests::producer_owner_rejects_other_threads_after_token_wrap",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "isolated token wrap test failed:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return;
+        }
+
+        let (producer, _consumer) = spsc::<u32>(4);
+        let owner = Arc::new(ProducerOwner::new(producer));
+        let barrier = Arc::new(Barrier::new(2));
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let first_owner = owner.clone();
+        let first_barrier = barrier.clone();
+        let first = std::thread::spawn(move || {
+            first_owner.push(1).unwrap();
+            ready_tx.send(()).unwrap();
+            first_barrier.wait();
+        });
+        ready_rx.recv().unwrap();
+
+        // Skip to wraparound while the original owner thread remains alive.
+        // New threads get MAX, 0, then the original owner's token (1).
+        NEXT_THREAD_TOKEN.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
+        let mut accepted = 0;
+        for _ in 0..3 {
+            let other_owner = owner.clone();
+            if std::thread::spawn(move || other_owner.push(2))
+                .join()
+                .is_ok()
+            {
+                accepted += 1;
+            }
+        }
+        barrier.wait();
+        first.join().unwrap();
+        assert_eq!(accepted, 0, "another live thread passed the owner check");
     }
 
     #[test]

--- a/yring/src/lib.rs
+++ b/yring/src/lib.rs
@@ -421,24 +421,29 @@ fn current_thread_token() -> usize {
         if current != 0 {
             return current;
         }
-        let mut next = NEXT_THREAD_TOKEN.load(std::sync::atomic::Ordering::Relaxed);
-        let current = loop {
-            let following = next
-                .checked_add(1)
-                .expect("ProducerOwner thread tokens exhausted");
-            match NEXT_THREAD_TOKEN.compare_exchange_weak(
-                next,
-                following,
-                std::sync::atomic::Ordering::Relaxed,
-                std::sync::atomic::Ordering::Relaxed,
-            ) {
-                Ok(current) => break current,
-                Err(actual) => next = actual,
-            }
-        };
+        let current = allocate_thread_token(&NEXT_THREAD_TOKEN);
         token.set(current);
         current
     })
+}
+
+#[inline]
+fn allocate_thread_token(counter: &std::sync::atomic::AtomicUsize) -> usize {
+    let mut next = counter.load(std::sync::atomic::Ordering::Relaxed);
+    loop {
+        let following = next
+            .checked_add(1)
+            .expect("ProducerOwner thread tokens exhausted");
+        match counter.compare_exchange_weak(
+            next,
+            following,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        ) {
+            Ok(current) => return current,
+            Err(actual) => next = actual,
+        }
+    }
 }
 
 impl<T> std::fmt::Debug for ProducerOwner<T> {
@@ -884,62 +889,19 @@ mod tests {
         assert_ne!(first.is_ok(), second.is_ok());
     }
 
-    #[cfg(not(any(loom, miri)))]
+    #[cfg(not(loom))]
     #[test]
-    fn producer_owner_rejects_other_threads_after_token_wrap() {
-        use std::sync::{Arc, Barrier, mpsc};
+    fn producer_owner_tokens_never_wrap() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        const CHILD_ENV: &str = "OMQ_YRING_TOKEN_WRAP_TEST_CHILD";
-        if std::env::var_os(CHILD_ENV).is_none() {
-            // Changing the global token counter must not affect other tests.
-            // Miri cannot launch this isolated subprocess.
-            let output = std::process::Command::new(std::env::current_exe().unwrap())
-                .args([
-                    "--exact",
-                    "tests::producer_owner_rejects_other_threads_after_token_wrap",
-                    "--nocapture",
-                ])
-                .env(CHILD_ENV, "1")
-                .output()
-                .unwrap();
-            assert!(
-                output.status.success(),
-                "isolated token wrap test failed:\n{}\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-            );
-            return;
-        }
-
-        let (producer, _consumer) = spsc::<u32>(4);
-        let owner = Arc::new(ProducerOwner::new(producer));
-        let barrier = Arc::new(Barrier::new(2));
-        let (ready_tx, ready_rx) = mpsc::channel();
-        let first_owner = owner.clone();
-        let first_barrier = barrier.clone();
-        let first = std::thread::spawn(move || {
-            first_owner.push(1).unwrap();
-            ready_tx.send(()).unwrap();
-            first_barrier.wait();
-        });
-        ready_rx.recv().unwrap();
-
-        // Skip to wraparound while the original owner thread remains alive.
-        // New threads get MAX, 0, then the original owner's token (1).
-        NEXT_THREAD_TOKEN.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
-        let mut accepted = 0;
+        // Exercise the real allocator without exhausting other tests' tokens
+        // or relaunching this binary outside a cross-compilation runner.
+        let counter = AtomicUsize::new(usize::MAX - 1);
+        assert_eq!(allocate_thread_token(&counter), usize::MAX - 1);
         for _ in 0..3 {
-            let other_owner = owner.clone();
-            if std::thread::spawn(move || other_owner.push(2))
-                .join()
-                .is_ok()
-            {
-                accepted += 1;
-            }
+            assert!(std::panic::catch_unwind(|| allocate_thread_token(&counter)).is_err());
+            assert_eq!(counter.load(Ordering::Relaxed), usize::MAX);
         }
-        barrier.wait();
-        first.join().unwrap();
-        assert_eq!(accepted, 0, "another live thread passed the owner check");
     }
 
     #[test]

--- a/yring/tests/loom.rs
+++ b/yring/tests/loom.rs
@@ -60,9 +60,11 @@ fn prefetch_and_pop_with_full_reports_full_transition() {
     loom::model(|| {
         let (mut p, mut c) = yring::spsc::<u32>(2);
 
+        assert_eq!(c.prefetch_and_pop_with_full(), None);
         let h = thread::spawn(move || {
             p.push(10).unwrap();
             p.push(20).unwrap();
+            assert!(p.is_full());
             p.flush();
         });
 
@@ -82,8 +84,7 @@ fn prefetch_and_pop_with_full_reports_full_transition() {
 
 #[test]
 fn prefetch_and_pop_with_full_observes_refilled_full_ring() {
-    use loom::sync::Arc;
-    use loom::sync::atomic::{AtomicBool, Ordering};
+    use loom::sync::mpsc;
 
     loom::model(|| {
         let (mut p, mut c) = yring::spsc::<u32>(2);
@@ -91,26 +92,19 @@ fn prefetch_and_pop_with_full_observes_refilled_full_ring() {
         p.push(20).unwrap();
         p.flush();
 
-        let released_one = Arc::new(AtomicBool::new(false));
-        let attempted_second_push = Arc::new(AtomicBool::new(false));
-        let released_one_for_producer = released_one.clone();
-        let attempted_second_push_for_producer = attempted_second_push.clone();
+        let (released_tx, released_rx) = mpsc::channel();
+        let (attempted_tx, attempted_rx) = mpsc::channel();
 
         let h = thread::spawn(move || {
-            while !released_one_for_producer.load(Ordering::Acquire) {
-                thread::yield_now();
-            }
-
-            while p.push(30).is_err() {
-                thread::yield_now();
-            }
+            released_rx.recv().unwrap();
+            p.push(30).unwrap();
             p.flush();
 
             let mut value = match p.push(40) {
                 Ok(()) => panic!("released second slot before second pop"),
                 Err(value) => value,
             };
-            attempted_second_push_for_producer.store(true, Ordering::Release);
+            attempted_tx.send(()).unwrap();
 
             while let Err(returned) = p.push(value) {
                 value = returned;
@@ -121,11 +115,8 @@ fn prefetch_and_pop_with_full_observes_refilled_full_ring() {
 
         assert_eq!(c.prefetch(), 2);
         assert_eq!(c.prefetch_and_pop_with_full(), Some((10, true)));
-        released_one.store(true, Ordering::Release);
-
-        while !attempted_second_push.load(Ordering::Acquire) {
-            thread::yield_now();
-        }
+        released_tx.send(()).unwrap();
+        attempted_rx.recv().unwrap();
 
         assert_eq!(c.prefetch_and_pop_with_full(), Some((20, true)));
 
@@ -149,9 +140,11 @@ fn prefetch_and_pop_with_full_handles_cursor_wrap() {
         let base = usize::MAX - 1;
         let (mut p, mut c) = yring::loom_spsc_with_cursors::<u32>(2, base);
 
+        assert_eq!(c.prefetch_and_pop_with_full(), None);
         let h = thread::spawn(move || {
             p.push(10).unwrap();
             p.push(20).unwrap();
+            assert!(p.is_full());
             p.flush();
         });
 
@@ -366,6 +359,116 @@ fn is_disconnected_after_producer_drop() {
     });
 }
 
+#[cfg(feature = "async")]
+#[test]
+fn stream_drains_final_item_before_eof() {
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+
+    use futures_core::Stream;
+
+    loom::model(|| {
+        let (mut p, mut c) = yring::async_spsc::<u32>(1);
+        let h = thread::spawn(move || {
+            p.push(42).unwrap();
+            drop(p);
+        });
+
+        let mut cx = Context::from_waker(Waker::noop());
+        // Race the empty check and EOF check against the producer's final
+        // flush. Joining before this poll would hide the race.
+        let result = Pin::new(&mut c).poll_next(&mut cx);
+        h.join().unwrap();
+        match result {
+            Poll::Ready(None) => panic!("premature EOF with {} queued items", c.len()),
+            Poll::Ready(Some(value)) => assert_eq!(value, 42),
+            Poll::Pending => {
+                assert_eq!(Pin::new(&mut c).poll_next(&mut cx), Poll::Ready(Some(42)));
+            }
+        }
+    });
+}
+
+#[test]
+fn flush_and_check_reports_concurrent_empty_transition() {
+    for (check_empty, armed) in [(false, false), (true, false), (false, true), (true, true)] {
+        loom::model(move || {
+            let (mut p, mut c) = yring::spsc::<u32>(2);
+            if armed {
+                p.flush_and_check();
+                assert_eq!(c.prefetch(), 0);
+            }
+            p.push_and_flush(1).unwrap();
+            let h = thread::spawn(move || {
+                p.push(2).unwrap();
+                p.flush_and_check()
+            });
+
+            assert_eq!(c.prefetch_and_pop(), Some(1));
+            let empty = if check_empty {
+                c.is_empty()
+            } else {
+                c.prefetch_and_pop().is_none()
+            };
+            let result = h.join().unwrap();
+            if empty {
+                // A caller that parks after observing empty depends on this
+                // flag to receive a wake for the second item.
+                assert!(
+                    matches!(
+                        result,
+                        yring::FlushResult::Flushed {
+                            was_empty: true,
+                            ..
+                        }
+                    ),
+                    "consumer parks, but flush suppresses its wake: {result:?}"
+                );
+            }
+        });
+    }
+}
+
+#[test]
+fn prefetch_and_pop_with_full_reports_concurrent_full_transition() {
+    for (check_full, armed) in [(false, false), (true, false), (false, true), (true, true)] {
+        loom::model(move || {
+            let (mut p, mut c) = yring::spsc::<u32>(2);
+            if armed {
+                assert_eq!(c.prefetch_and_pop_with_full(), None);
+                p.push(0).unwrap();
+                p.push_and_flush(0).unwrap();
+                assert!(p.is_full());
+                assert_eq!(c.prefetch_and_pop_with_full(), Some((0, true)));
+                assert_eq!(c.prefetch_and_pop_with_full(), Some((0, false)));
+            }
+            p.push_and_flush(1).unwrap();
+            let h = thread::spawn(move || {
+                p.push_and_flush(2).unwrap();
+                let blocked = if check_full {
+                    p.is_full()
+                } else {
+                    p.push(3).is_err()
+                };
+                (p, blocked)
+            });
+
+            let (first, first_wake) = c.prefetch_and_pop_with_full().unwrap();
+            assert_eq!(first, 1);
+            // Keep the producer alive: shutdown must not rescue a lost space wake.
+            let (_p, blocked) = h.join().unwrap();
+            let (second, second_wake) = c.prefetch_and_pop_with_full().unwrap();
+            assert_eq!(second, 2);
+            if blocked {
+                assert!(
+                    first_wake || second_wake,
+                    "producer saw full, but both pops suppress its space wake"
+                );
+            }
+        });
+    }
+}
+
 /// Verify `push_async` doesn't lose wakeups.
 ///
 /// The critical race: consumer releases between the producer's
@@ -425,6 +528,54 @@ fn push_async_no_lost_wakeup() {
 
         h.join().unwrap();
         assert!(pushed.load(Ordering::Relaxed));
+    });
+}
+
+#[test]
+fn push_async_pending_receives_space_wake() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct CountWakes(AtomicUsize);
+
+    impl Wake for CountWakes {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    loom::model(|| {
+        let (mut p, mut c) = yring::async_spsc::<u32>(1);
+        p.push_and_flush(10).unwrap();
+        let notifications = Arc::new(CountWakes(AtomicUsize::new(0)));
+        let waker = Waker::from(notifications.clone());
+        let released = Arc::new(AtomicBool::new(false));
+        let released_for_producer = released.clone();
+        let h = thread::spawn(move || {
+            let mut cx = Context::from_waker(&waker);
+            let result = {
+                let mut future = p.push_async(20);
+                let result = Pin::new(&mut future).poll(&mut cx);
+                while !released_for_producer.load(Ordering::Acquire) {
+                    thread::yield_now();
+                }
+                result
+            };
+            (p, result)
+        });
+
+        assert_eq!(c.prefetch_and_pop(), Some(10));
+        released.store(true, Ordering::Release);
+        let (_p, result) = h.join().unwrap();
+        // Never repoll an unwoken Pending future: that would hide a lost wake.
+        match result {
+            Poll::Pending => assert!(notifications.0.load(Ordering::Relaxed) > 0),
+            Poll::Ready(result) => assert_eq!(result, Ok(())),
+        }
     });
 }
 


### PR DESCRIPTION
- Fix `yring` data/space wakeup races, final-flush EOF handling, stream slot release, and owner-token exhaustion.
- Add native and Loom regression coverage and clarify existing API behavior.
- Correct local performance-gate accounting; add bounded work, Linux CPU placement, and repeatable case measurements.
