### PR TITLE
pyomq: complete pyzmq API compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,7 +759,7 @@ jobs:
       - name: formatting
         if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
-        run: .venv/bin/ruff format .
+        run: .venv/bin/ruff format --check .
       - name: linting
         if: matrix.kind == 'pyomq' && needs.changes.outputs.run_pyomq == 'true'
         working-directory: bindings/pyomq
@@ -770,6 +770,8 @@ jobs:
         run: |
           .venv/bin/ty check . --python-platform linux
           .venv/bin/ty check . --python-platform win32
+          .venv/bin/pyright --pythonpath .venv/bin/python --pythonplatform Linux python
+          .venv/bin/pyright --pythonpath .venv/bin/python --pythonplatform Windows python
 
   pyomq-test:
     name: pyomq-test
@@ -780,7 +782,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.11"
+          - python-version: "3.12"
             os: ubuntu-latest
           - python-version: "3.14"
             os: ubuntu-latest

--- a/.github/workflows/release-pyomq.yml
+++ b/.github/workflows/release-pyomq.yml
@@ -113,21 +113,24 @@ jobs:
           path: bindings/pyomq/dist
 
   smoke-test:
-    name: Smoke test (x86_64 wheel)
+    name: Smoke test (x86_64 wheel, Python ${{ matrix.python }})
     runs-on: ubuntu-latest
     needs: [linux]
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python }}
       - uses: actions/download-artifact@v7
         with:
           name: wheels-linux-x86_64-auto
           path: dist
       - run: pip install dist/*.whl pytest 'pytest-asyncio>=1.4.0' 'pytest-timeout>=2.4'
-      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py -v --timeout=60 --timeout-method=thread
+      - run: pytest bindings/pyomq/tests/test_basic.py bindings/pyomq/tests/test_curve.py bindings/pyomq/tests/test_plain.py bindings/pyomq/tests/test_tracking.py bindings/pyomq/tests/test_wheel_contract.py -v --timeout=60 --timeout-method=thread
 
   smoke-test-macos:
     name: Smoke test macOS (${{ matrix.platform.target }} wheel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to omq.rs will be documented here. Format loosely follows
 
 ### Added
 
+- pyomq RADIO/DISH now exposes groups as pyzmq-style metadata: pass
+  `group=` when sending and read `Frame.group` when receiving.
 - Tokio byte-stream sockets can enforce hard per-connection and aggregate
   per-IP receive token buckets with `Options::recv_rate_limit()` and
   `Options::recv_ip_rate_limit()`. Offending connections are disconnected.

--- a/bindings/pyomq/AGENTS.md
+++ b/bindings/pyomq/AGENTS.md
@@ -3,13 +3,25 @@
 ## Purpose
 
 PyO3 binding for `omq-tokio`. Drop-in pyzmq API for Python: sync
-(`pyomq`) and async (`pyomq.asyncio`). Stable ABI (`abi3-py311`,
-Python 3.11+) via maturin. Release workflow publishes Linux wheels and
+(`pyomq`) and async (`pyomq.asyncio`). Stable ABI (`abi3-py312`,
+Python 3.12+) via maturin. Release workflow publishes Linux wheels and
 an sdist. Windows pyomq support is pending.
 
 See [`doc/architecture.md`](../../doc/architecture.md) for internals:
 threading model, queue relay, send/recv paths, zero-copy conversions,
 proxy, authentication, error mapping, and known limitations.
+
+## Python native stub maintenance
+
+The native Python API is defined in `python/pyomq/_native.pyi` and is
+maintained manually. Treat this stub as the authoritative contract for
+`pyomq._native`.
+
+When a Rust-exported symbol changes in `src/lib.rs`—including any new
+`#[pyfunction]`, `#[pymodule_export]`, or `#[pyclass]` member—the stub
+must be kept in sync in the same change. Do not assume PyO3's generated
+information is complete enough to serve as a final API contract for the
+Python binding.
 
 ## Build / test / lint
 

--- a/bindings/pyomq/CHANGELOG.md
+++ b/bindings/pyomq/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Complete native type stubs and shared buffer, connection, and monitor types.
+- Consumer typing tests for ty, mypy, and pyright, plus native stub checks.
+- Real buffer-lifetime tracking for frames and sync, async, and shadow sends.
+- pyzmq-style bind/connect scope managers, `recv_into()`, `routing_id` send
+  keywords, and public `Context(shadow=...)` construction.
+
+### Changed
+
+- Raise the Python minimum from 3.11 to 3.12 and use `abi3-py312` wheels.
+- Match pyzmq public keyword names for endpoints, subscriptions, multipart
+  sends, socket-option strings, `curve_public()`, and `strerror()`.
+- Accept contiguous buffer-protocol objects, including multibyte formats,
+  consistently across send APIs. Reject strided buffers and implicit text
+  conversion; use `send_string()` for text.
+- Match pyzmq's copied-send and tracked-frame return contracts.
+- Reduce tracked-send wrapper allocations, especially for multipart messages.
+
+### Fixed
+
+- Preserve converted multipart messages and one-shot iterables across async
+  and shadow send backpressure. Release pending buffers on cancel and close.
+- Correct receive overloads, option descriptors, callback and factory types,
+  byte endpoints, and the `ZMQStream` import cycle.
+- Honor per-send stream callbacks and pass their message parts and tracker.
+- Preserve queued messages when an asyncio receive is canceled before its
+  readiness callback runs.
+- Release completed future descriptors even when callers retain the future
+  after polling `done()`.
+
 ## [0.21.0] - 2026-09-04
 
 ### Added

--- a/bindings/pyomq/Cargo.lock
+++ b/bindings/pyomq/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.22.0"
+version = "0.22.2"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.14"
+version = "0.3.16"
 dependencies = [
  "atomic-waker",
  "futures-core",

--- a/bindings/pyomq/Cargo.toml
+++ b/bindings/pyomq/Cargo.toml
@@ -32,8 +32,8 @@ futures = { version = "0.3", default-features = false, features = ["std", "async
 futures-core = { version = "0.3", default-features = false }
 yring = { path = "../../yring", features = ["async"] }
 
-# PyO3 stable ABI: one wheel covers Python 3.11+.
-pyo3 = { version = "0.29.0", features = ["abi3-py311", "extension-module"] }
+# PyO3 stable ABI: one wheel covers Python 3.12+.
+pyo3 = { version = "0.29.0", features = ["abi3-py312", "extension-module"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security"] }

--- a/bindings/pyomq/README.md
+++ b/bindings/pyomq/README.md
@@ -16,10 +16,12 @@ port. Drop-in pyzmq replacement on the common path.
 - Built on [`omq-tokio`](https://github.com/paddor/omq.rs/tree/main/omq-tokio);
   runtime work runs on a dedicated background thread and Python calls release
   the GIL across the runtime trip.
-- DISH groups use `socket.join()` / `socket.leave()` and multipart group
-  messages.
+- RADIO/DISH groups use `socket.join()` / `socket.leave()`,
+  `socket.send(body, group="...")`, and `Frame.group` on receive.
 
 ## Install
+
+Requires Python **3.12+**. Wheels use the `cp312-abi3` stable ABI.
 
 ```sh
 uv pip install pyomq
@@ -54,12 +56,49 @@ import pyomq.asyncio as zmq_async
 
 ctx = zmq_async.Context()
 sock = ctx.socket(pyomq.PUSH)
-await sock.connect("tcp://127.0.0.1:5555")
+sock.connect("tcp://127.0.0.1:5555")
 await sock.send(b"hello")
-await sock.close()
+sock.close()
 ```
 
 Zguide-style runnable examples live in [examples/zguide/](examples/zguide/).
+
+### Buffers, tracking, and types
+
+`send()` accepts `pyomq.Sendable`: buffer-protocol objects and `Frame`.
+`send_multipart()` also accepts generators of these values. Buffers must
+be contiguous; multidimensional and multibyte buffers are sent as raw bytes.
+Use `send_string()` for text. `__bytes__` alone does not make an object sendable.
+
+With `copy=False, track=True`, sends return a `MessageTracker`; asyncio
+sends resolve to that tracker when awaited. `tracker.done` and
+`tracker.wait(timeout)` indicate when borrowed buffers are no longer in use,
+not peer delivery. Timeouts are in seconds; `wait()` raises `NotDone` when
+the deadline expires. Do not
+mutate borrowed data before completion. Keeping a zero-copy `Frame`, an
+exported view, or an inproc receiver's frame alive can delay completion.
+Multipart tracking covers every part. Copied buffer sends return `None`,
+even with `track=True`. Sending a `Frame` returns its own tracker; requesting
+tracking on an untracked frame raises `ValueError`.
+
+`wait()` blocks its calling thread. In asyncio code, awaiting `send()` only
+waits for queue admission. Use `await asyncio.to_thread(tracker.wait)` when
+you need buffer completion without blocking the event loop.
+
+Python-defined buffer exporters may run `__release_buffer__` on an I/O
+thread. Release callbacks must not make blocking socket or context calls:
+those calls can deadlock the I/O thread. Use `copy=True` for such exporters
+or hand their cleanup work to an application thread. This limitation also
+applies when tracking is disabled.
+
+Tracking adds bookkeeping only when requested. For repeated sends of unchanged
+data, a tracked `Frame` reuses its tracking state across sends. Its tracker
+still cannot finish until the frame and every outstanding user release it.
+
+The package includes native stubs and precise sync/async receive overloads.
+`copy=False` returns `Frame` values, and a runtime boolean yields the union
+of byte and frame result types. Serialization callbacks retain their return
+types; socket options, authentication policies, and monitor events are typed.
 
 PLAIN servers require an explicit policy before bind. Use fixed credentials
 with `pull.plain_server = 1; pull.set_plain_auth([("alice", "secret")])`, or

--- a/bindings/pyomq/doc/architecture.md
+++ b/bindings/pyomq/doc/architecture.md
@@ -1,7 +1,7 @@
 # pyomq Architecture
 
 PyO3 binding for `omq-tokio`. Drop-in pyzmq API for Python (sync and
-async). Single stable-ABI wheel (`abi3-py311`, Python 3.11+) via maturin.
+async). Single stable-ABI wheel (`abi3-py312`, Python 3.12+) via maturin.
 
 ## Source layout
 
@@ -410,18 +410,34 @@ Python `bytes`. `bytes(frame)` and `frame.bytes` still allocate a Python
 `bytes` object on demand. `frame.buffer` returns a memoryview directly
 over the immutable Rust `Bytes` storage via the Python buffer protocol.
 
-Other buffer types (`bytearray`, `memoryview`) go through
-`copy_from_slice` because their contents can be mutated from Python.
+Other contiguous buffer types (`bytearray`, `memoryview`, multibyte arrays)
+go through `copy_from_slice` by default. With `copy=False`, a `PyUntypedBuffer`
+export pins their storage until the last native owner releases it. Strided
+buffers are rejected, including with `copy=True`.
+
+Buffer exports are currently released on the thread dropping the last native
+owner, including I/O threads. Python-defined `__release_buffer__` callbacks
+must not make blocking socket/context calls there. That preexisting limitation
+also affects untracked zero-copy sends. Such exporters can use `copy=True` or
+schedule their cleanup on an application thread.
 
 ## MessageTracker
 
-pyzmq's `track=True` tracks whether the zero-copy send buffer has
-been flushed to the wire (so the caller knows when it's safe to
-mutate the buffer). pyomq copies mutable Python buffers on send, so the
-buffer is always safe to reuse immediately. Received `Frame`/`Message`
-objects use immutable `Bytes` storage and can be re-sent without copying.
-`send(track=True)` returns a `MessageTracker` that reports done
-immediately.
+Tracking follows buffer ownership, not queue admission or delivery. Tracked
+zero-copy sends wrap `Bytes` in an owner whose final drop releases the Python
+export before notifying a condition variable. The Python tracker owns only
+completion tokens or existing Frame trackers, never the payload. Multipart
+conversion builds one Python tracker over all parts without intermediate
+per-buffer Python trackers. No token or tracking synchronization is allocated
+for untracked sends. `wait()` releases the GIL; a single token handles its own
+timeout, while aggregates share one monotonic deadline across all sources.
+
+Copied buffer sends return `None`. Sending a `Frame` returns its own tracker;
+tracking an untracked frame is an error. Tracked receive frames have completed
+trackers, but an inproc frame or exported view can still keep the original
+sender's tracker pending. Async queue backpressure allocates a `PendingSend`
+that retains the converted message across retries, so generators are consumed
+once. Cancellation and socket close release these retained messages.
 
 jupyter-client's `Session.send()` shadows async sockets to sync
 (`zmq.Socket.shadow(stream.underlying)`) before calling

--- a/bindings/pyomq/examples/zguide/01_req_rep/broker.py
+++ b/bindings/pyomq/examples/zguide/01_req_rep/broker.py
@@ -5,6 +5,7 @@ backend (workers). Runs until interrupted.
 
     python broker.py [frontend] [backend]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/examples/zguide/01_req_rep/client.py
+++ b/bindings/pyomq/examples/zguide/01_req_rep/client.py
@@ -4,6 +4,7 @@ Connects to the broker's ROUTER frontend, sends requests, prints replies.
 
     python client.py [frontend] [n_requests]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/examples/zguide/01_req_rep/echo.py
+++ b/bindings/pyomq/examples/zguide/01_req_rep/echo.py
@@ -4,6 +4,7 @@ Single-process demo: REP server echoes messages back to a REQ client.
 
     python echo.py [endpoint]
 """
+
 import sys
 import threading
 import time

--- a/bindings/pyomq/examples/zguide/01_req_rep/worker.py
+++ b/bindings/pyomq/examples/zguide/01_req_rep/worker.py
@@ -5,6 +5,7 @@ worker-ID prefix. Runs until interrupted.
 
     python worker.py [backend] [id]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/examples/zguide/02_pub_sub/proxy.py
+++ b/bindings/pyomq/examples/zguide/02_pub_sub/proxy.py
@@ -5,6 +5,7 @@ PUB socket downstream. Runs until interrupted.
 
     python proxy.py [upstream] [downstream]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/examples/zguide/02_pub_sub/publisher.py
+++ b/bindings/pyomq/examples/zguide/02_pub_sub/publisher.py
@@ -6,6 +6,7 @@ runs until interrupted.
 
     python publisher.py [endpoint] [count]
 """
+
 import sys
 import time
 

--- a/bindings/pyomq/examples/zguide/02_pub_sub/subscriber.py
+++ b/bindings/pyomq/examples/zguide/02_pub_sub/subscriber.py
@@ -5,6 +5,7 @@ matching messages. If count is given, exits after that many messages.
 
     python subscriber.py [endpoint] [topic] [count]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/examples/zguide/03_pipeline/sink.py
+++ b/bindings/pyomq/examples/zguide/03_pipeline/sink.py
@@ -5,6 +5,7 @@ distribution when the expected count is reached.
 
     python sink.py [sink_ep] [expected_count]
 """
+
 import sys
 from collections import defaultdict
 

--- a/bindings/pyomq/examples/zguide/03_pipeline/ventilator.py
+++ b/bindings/pyomq/examples/zguide/03_pipeline/ventilator.py
@@ -5,6 +5,7 @@ worker knows when to stop.
 
     python ventilator.py [vent_ep] [n_tasks] [n_workers]
 """
+
 import sys
 import time
 

--- a/bindings/pyomq/examples/zguide/03_pipeline/worker.py
+++ b/bindings/pyomq/examples/zguide/03_pipeline/worker.py
@@ -5,6 +5,7 @@ prefix. Exits on END sentinel.
 
     python worker.py [vent_ep] [sink_ep] [worker_id]
 """
+
 import sys
 
 import pyomq as zmq

--- a/bindings/pyomq/pyproject.toml
+++ b/bindings/pyomq/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.21.0"
 description = "Python binding for omq.rs (Rust libzmq port). Drop-in pyzmq replacement on the common path."
 readme = "README.md"
 license = { text = "ISC" }
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [{ name = "Patrik Wenger", email = "paddor@gmail.com" }]
 keywords = ["zeromq", "omq", "messaging", "pyzmq", "zmq"]
 classifiers = [
@@ -33,8 +33,8 @@ test = [
     "pyzmq>=25",
     "tornado>=6",
 ]
-lint = ["ruff==0.15.22"]
-type-check = ["ty==0.0.63"]
+lint = ["ruff==0.16.6"]
+type-check = ["ty==0.0.63", "mypy>=1.19", "pyright>=1.1.400"]
 dev = [
   { include-group = "test" },
   { include-group = "lint" },
@@ -52,15 +52,20 @@ addopts = "--ignore=tests/soak"
 timeout = 60
 timeout_method = "thread"
 
+[tool.ruff.lint]
+ignore = ["BLE001"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E402", "E702", "F401", "F841"]
+# Shared private aliases are consumed by the native stub and both facades.
+"python/pyomq/_typing.py" = ["PYI047"]
 
 [tool.ty.src]
-exclude = ["tests/soak/**"]
+exclude = ["tests/soak/**", "tests/typing/narrowing.py"]
 
 [tool.maturin]
 # Stable ABI - one wheel covers all supported Python versions.
-features = ["pyo3/abi3-py311", "plain", "curve", "lz4", "zstd"]
+features = ["pyo3/abi3-py312", "plain", "curve", "lz4", "zstd"]
 # The native module lives at pyomq._native; pyomq itself is a pure
 # Python package re-exporting from it.
 module-name = "pyomq._native"

--- a/bindings/pyomq/python/pyomq/__init__.py
+++ b/bindings/pyomq/python/pyomq/__init__.py
@@ -23,156 +23,159 @@ import pickle
 import select as _select
 import sys
 import threading
+import types
 import weakref
+from collections.abc import Callable, Iterable, Iterator
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Callable,
-    cast,
     Final,
-    Iterable,
-    Iterator,
     Literal,
     Protocol,
     Self,
+    cast,
     overload,
 )
 
-from . import _native  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
-from . import error as error  # noqa: F401
-
-from ._native import (  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
-    backend_name,
-    version,
-    Frame,
-    # Socket types
-    PAIR,
-    PUB,
-    SUB,
-    REQ,
-    REP,
-    DEALER,
-    ROUTER,
-    PULL,
-    PUSH,
-    XPUB,
-    XSUB,
-    STREAM,
-    # Draft socket types (RFC 41 / 48 / 49 / 51 + PEER)
-    SERVER,
-    CLIENT,
-    RADIO,
-    DISH,
-    GATHER,
-    SCATTER,
-    PEER,
-    CHANNEL,
+from . import _native
+from . import error as error
+from ._native import (
     # Option constants
     AFFINITY,
-    IDENTITY,
-    SUBSCRIBE,
-    UNSUBSCRIBE,
-    RCVMORE,
-    TYPE,
-    LINGER,
-    RECONNECT_IVL,
-    RECONNECT_IVL_MAX,
     BACKLOG,
-    MAXMSGSIZE,
-    SNDHWM,
-    RCVHWM,
-    RCVTIMEO,
-    SNDTIMEO,
-    ROUTER_MANDATORY,
-    IMMEDIATE,
-    IPV6,
-    HEARTBEAT_IVL,
-    HEARTBEAT_TTL,
-    HEARTBEAT_TIMEOUT,
-    HANDSHAKE_IVL,
+    CHANNEL,
+    CLIENT,
     CONFLATE,
-    TCP_KEEPALIVE,
-    TCP_KEEPALIVE_IDLE,
-    TCP_KEEPALIVE_CNT,
-    TCP_KEEPALIVE_INTVL,
-    SNDMORE,
-    NOBLOCK,
-    DONTWAIT,
-    # CURVE option ids
-    CURVE_SERVER,
     CURVE_PUBLICKEY,
     CURVE_SECRETKEY,
+    # CURVE option ids
+    CURVE_SERVER,
     CURVE_SERVERKEY,
+    DEALER,
+    DISH,
+    DONTWAIT,
+    GATHER,
+    HANDSHAKE_IVL,
+    HEARTBEAT_IVL,
+    HEARTBEAT_TIMEOUT,
+    HEARTBEAT_TTL,
+    IDENTITY,
+    IMMEDIATE,
+    IPV6,
+    LINGER,
+    MAXMSGSIZE,
+    NOBLOCK,
+    OMQ_COMPRESSION_AUTO_TRAIN,
+    OMQ_COMPRESSION_DICT,
+    OMQ_COMPRESSION_LEVEL,
     # omq-specific options
     OMQ_ON_MUTE,
-    OMQ_COMPRESSION_LEVEL,
-    OMQ_COMPRESSION_DICT,
-    OMQ_COMPRESSION_AUTO_TRAIN,
     OMQ_ON_MUTE_BLOCK,
     OMQ_ON_MUTE_DROP_NEWEST,
     OMQ_ON_MUTE_DROP_OLDEST,
+    # Socket types
+    PAIR,
+    PEER,
+    PUB,
+    PULL,
+    PUSH,
+    RADIO,
+    RCVHWM,
+    RCVMORE,
+    RCVTIMEO,
+    RECONNECT_IVL,
+    RECONNECT_IVL_MAX,
+    REP,
+    REQ,
+    ROUTER,
+    ROUTER_MANDATORY,
+    SCATTER,
+    # Draft socket types (RFC 41 / 48 / 49 / 51 + PEER)
+    SERVER,
+    SNDHWM,
+    SNDMORE,
+    SNDTIMEO,
+    STREAM,
+    SUB,
+    SUBSCRIBE,
+    TCP_KEEPALIVE,
+    TCP_KEEPALIVE_CNT,
+    TCP_KEEPALIVE_IDLE,
+    TCP_KEEPALIVE_INTVL,
+    TYPE,
+    UNSUBSCRIBE,
+    XPUB,
+    XSUB,
+    Frame,
+    backend_name,
+    version,
 )
-
-from .error import (  # noqa: F401  re-exports
-    ZMQBaseError,
-    ZMQError,
+from .error import (
     Again,
     ContextTerminated,
-    ZMQBindError,
-    ZMQVersionError,
     InterruptedSystemCall,
+    ZMQBaseError,
+    ZMQBindError,
+    ZMQError,
+    ZMQVersionError,
+)
+from .error import (
     NotImplementedError as ZMQNotImplementedError,
 )
 
+if TYPE_CHECKING:
+    from .asyncio import Socket as AsyncSocket
+
 # ── Constants ─────────────────────────────────────────────────────────
 
-POLLIN: Final[int] = 1
-POLLOUT: Final[int] = 2
-POLLERR: Final[int] = 4
-POLLPRI: Final[int] = 32
-HWM: Final[int] = 1
+POLLIN: Final = 1
+POLLOUT: Final = 2
+POLLERR: Final = 4
+POLLPRI: Final = 32
+HWM: Final = 1
 
 # Windows specific constants
 _IS_WINDOWS: Final[bool] = sys.platform == "win32"
-_WAKEUP_MODE_NONE: Final[int] = 0
-_WAKEUP_MODE_ASYNC: Final[int] = 1
-_WAKEUP_MODE_SYNC: Final[int] = 2
+_WAKEUP_MODE_NONE: Final = 0
+_WAKEUP_MODE_ASYNC: Final = 1
+_WAKEUP_MODE_SYNC: Final = 2
 
-ROUTING_ID: Final[int] = 5
-LAST_ENDPOINT: Final[int] = 32
-FD: Final[int] = 14
-EVENTS: Final[int] = 15
-MECHANISM: Final[int] = 43
-SNDBUF: Final[int] = 11
-RCVBUF: Final[int] = 12
-RATE: Final[int] = 8
-CONNECT_TIMEOUT: Final[int] = 79
-XPUB_VERBOSE: Final[int] = 40
-PROBE_ROUTER: Final[int] = 51
-REQ_CORRELATE: Final[int] = 52
-REQ_RELAXED: Final[int] = 53
-ROUTER_HANDOVER: Final[int] = 56
-IPV4ONLY: Final[int] = 31
-TCP_ACCEPT_FILTER: Final[int] = 38
-TCP_MAXRT: Final[int] = 80
-MULTICAST_HOPS: Final[int] = 25
-RECOVERY_IVL: Final[int] = 9
-RECONNECT_STOP: Final[int] = 109
-PLAIN_SERVER: Final[int] = 44
-PLAIN_USERNAME: Final[int] = 45
-PLAIN_PASSWORD: Final[int] = 46
-ZAP_DOMAIN: Final[int] = 55
+ROUTING_ID: Final = 5
+LAST_ENDPOINT: Final = 32
+FD: Final = 14
+EVENTS: Final = 15
+MECHANISM: Final = 43
+SNDBUF: Final = 11
+RCVBUF: Final = 12
+RATE: Final = 8
+CONNECT_TIMEOUT: Final = 79
+XPUB_VERBOSE: Final = 40
+PROBE_ROUTER: Final = 51
+REQ_CORRELATE: Final = 52
+REQ_RELAXED: Final = 53
+ROUTER_HANDOVER: Final = 56
+IPV4ONLY: Final = 31
+TCP_ACCEPT_FILTER: Final = 38
+TCP_MAXRT: Final = 80
+MULTICAST_HOPS: Final = 25
+RECOVERY_IVL: Final = 9
+RECONNECT_STOP: Final = 109
+PLAIN_SERVER: Final = 44
+PLAIN_USERNAME: Final = 45
+PLAIN_PASSWORD: Final = 46
+ZAP_DOMAIN: Final = 55
 
-FORWARDER: Final[int] = 2
-QUEUE: Final[int] = 3
-STREAMER: Final[int] = 1
+FORWARDER: Final = 2
+QUEUE: Final = 3
+STREAMER: Final = 1
 
-NULL: Final[int] = 0
-PLAIN: Final[int] = 1
-CURVE: Final[int] = 2
+NULL: Final = 0
+PLAIN: Final = 1
+CURVE: Final = 2
 
-ETERM: Final[int] = 156384765
-ENOTSOCK: Final[int] = 108
-COPY_THRESHOLD: Final[int] = 65536
+ETERM: Final = 156384765
+ENOTSOCK: Final = 108
+COPY_THRESHOLD: Final = 65536
 
 # errno constants (pyzmq exposes these at top level)
 EAGAIN: Final[int] = _errno.EAGAIN
@@ -196,16 +199,30 @@ EADDRNOTAVAIL: Final[int] = _errno.EADDRNOTAVAIL
 __version__: Final[str] = version()
 zmq_version_info: Final[tuple[int, int, int]] = (4, 3, 4)
 
+from ._tracker import MessageTracker, NotDone
+from ._typing import (
+    AuthCallback,
+    ConnectionInfo,
+    CurveAuth,
+    FutureResult,
+    MonitorEvent,
+    PlainAuth,
+    Sendable,
+    _BytesOption,
+    _IntOption,
+)
+
+SENDABLE_TYPES = Sendable
 
 # ── Top-level functions ──────────────────────────────────────────────
 
 
-def strerror(errnum: int) -> str:
-    return os.strerror(errnum)
+def strerror(errno: int) -> str:
+    return os.strerror(errno)
 
 
 def zmq_version() -> str:
-    return "%d.%d.%d" % zmq_version_info
+    return "{:d}.{:d}.{:d}".format(*zmq_version_info)
 
 
 def pyomq_version() -> str:
@@ -232,12 +249,12 @@ def curve_keypair() -> tuple[bytes, bytes]:
     return _native.curve_keypair()
 
 
-def curve_public(secret: bytes | str) -> bytes:
+def curve_public(secret_key: bytes | str) -> bytes:
     if not hasattr(_native, "curve_public"):
         raise ZMQNotImplementedError("curve feature not compiled")
-    if isinstance(secret, str):
-        secret = secret.encode("ascii")
-    return _native.curve_public(secret)
+    if isinstance(secret_key, str):
+        secret_key = secret_key.encode("ascii")
+    return _native.curve_public(secret_key)
 
 
 if hasattr(_native, "PeerInfo"):
@@ -273,134 +290,142 @@ _TYPE_NAMES: Final[dict[int, str]] = {
 # ── MessageTracker / Message / Frame (pyzmq compat) ─────────────────
 
 
-class NotDone(ZMQBaseError):
-    pass
-
-
-class MessageTracker:
-    """Tracks the delivery status of a message (pyzmq compatibility)."""
-
-    done: bool
-
-    def __init__(self, *args: Any, _pending: bool = False, **kwargs: Any) -> None:
-        self.done = not _pending
-
-    def wait(self, timeout: int | None = None) -> None:
-        if not self.done:
-            raise NotDone
-
-
 Message = Frame
+
+
+class _SocketScope(Protocol):
+    @property
+    def closed(self) -> bool: ...
+
+    def unbind(self, addr: str | bytes) -> None: ...
+
+    def disconnect(self, addr: str | bytes) -> None: ...
+
+
+class _SocketContext[S: _SocketScope]:
+    """Temporary bind or connect scope, compatible with pyzmq."""
+
+    def __init__(
+        self,
+        socket: S,
+        kind: Literal["bind", "connect"],
+        addr: str | bytes,
+    ) -> None:
+        self.socket = socket
+        self.kind = kind
+        self.addr = addr
+
+    def __repr__(self) -> str:
+        return f"<SocketContext({self.kind}={self.addr!r})>"
+
+    def __enter__(self) -> S:
+        return self.socket
+
+    def __exit__(self, *args: object) -> None:
+        if self.socket.closed:
+            return
+        if self.kind == "bind":
+            self.socket.unbind(self.addr)
+        else:
+            self.socket.disconnect(self.addr)
+
+
+def _copy_received_into(buffer: Any, data: bytes, nbytes: int) -> int:
+    view = memoryview(buffer)
+    if view.readonly:
+        raise TypeError("recv_into() requires a writable buffer")
+    try:
+        target = view.cast("B")
+    except TypeError as e:
+        raise BufferError("recv_into() requires a contiguous buffer") from e
+    limit = target.nbytes if nbytes == 0 else min(nbytes, target.nbytes)
+    target[: min(len(data), limit)] = data[:limit]
+    return len(data)
 
 
 # ── Socket wrapper ───────────────────────────────────────────────────
 
 
-class _NativeSocket(Protocol):
-    """Protocol for native socket implementation (sync or async)."""
-
-    def getsockopt(self, option: int) -> Any: ...
-
-    def setsockopt(self, option: int, value: Any) -> Any: ...
-
-    def bind(self, endpoint: str | bytes) -> str | bytes: ...
-
-    def connect(self, endpoint: str | bytes) -> None: ...
-
-    def unbind(self, endpoint: str | bytes) -> None: ...
-
-    def disconnect(self, endpoint: str | bytes) -> None: ...
-
-    def subscribe(self, prefix: bytes | str) -> None: ...
-
-    def unsubscribe(self, prefix: bytes | str) -> None: ...
-
-    def join(self, group: bytes | str) -> None: ...
-
-    def leave(self, group: bytes | str) -> None: ...
-
-    def monitor(self) -> Any: ...
-
-    def connections(self) -> Any: ...
-
-    def connection_info(self, connection_id: int) -> Any: ...
-
-    def set_curve_auth(self, auth: Any) -> Any: ...
-
-    def set_plain_auth(self, auth: Any) -> Any:
-        """Configure a PLAIN server allowlist or callback before socket use."""
-        ...
-
-    def close(self, linger: int | None = None) -> None: ...
-
-
 # Socket option descriptor for IDE autocomplete support
-class _SocketOptionDescriptor:
+class _SocketOptionDescriptor[T]:
     """Descriptor for socket options providing IDE autocomplete."""
 
     def __init__(self, option_code: int) -> None:
         self.option_code = option_code
 
-    def __get__(self, obj: Any, objtype: type[Any] | None = None) -> Any:
+    @overload
+    def __get__(self, obj: None, objtype: type[object] | None = None) -> Self: ...
+
+    @overload
+    def __get__(
+        self, obj: _SocketOptionsBase, objtype: type[object] | None = None
+    ) -> T: ...
+
+    def __get__(
+        self, obj: _SocketOptionsBase | None, objtype: type[object] | None = None
+    ) -> T | Self:
         if obj is None:
             return self
         if self.option_code == LAST_ENDPOINT:
-            return obj._last_endpoint
-        return obj.getsockopt(self.option_code)
+            return cast(T, obj._last_endpoint)
+        return cast(T, obj.getsockopt(self.option_code))
 
-    def __set__(self, obj: Any, value: Any) -> None:
-        obj.setsockopt(self.option_code, value)
+    def __set__(self, obj: _SocketOptionsBase, value: T) -> None:
+        obj.setsockopt(self.option_code, cast(int | bytes, value))
 
 
 class _SocketOptionsBase:
     """Base class with socket option descriptors and shared methods."""
 
     # Attributes (subclasses must define these)
-    _sock: _NativeSocket
+    # Concrete subclasses initialize and narrow these private handles. Shared
+    # methods never replace them with a different socket or context kind.
+    _sock: _native.Socket | _native.AsyncSocket
     _context: Context
+
     _closed: bool
-    _last_endpoint: bytes | str | None
+    _last_endpoint: bytes
 
     # Socket options
-    affinity = _SocketOptionDescriptor(AFFINITY)
-    identity = _SocketOptionDescriptor(IDENTITY)
-    routing_id = _SocketOptionDescriptor(ROUTING_ID)
-    rcvmore = _SocketOptionDescriptor(RCVMORE)
-    sndhwm = _SocketOptionDescriptor(SNDHWM)
-    rcvhwm = _SocketOptionDescriptor(RCVHWM)
-    linger = _SocketOptionDescriptor(LINGER)
-    reconnect_ivl = _SocketOptionDescriptor(RECONNECT_IVL)
-    reconnect_ivl_max = _SocketOptionDescriptor(RECONNECT_IVL_MAX)
-    backlog = _SocketOptionDescriptor(BACKLOG)
-    maxmsgsize = _SocketOptionDescriptor(MAXMSGSIZE)
-    rcvtimeo = _SocketOptionDescriptor(RCVTIMEO)
-    sndtimeo = _SocketOptionDescriptor(SNDTIMEO)
-    ipv6 = _SocketOptionDescriptor(IPV6)
-    immediate = _SocketOptionDescriptor(IMMEDIATE)
-    router_mandatory = _SocketOptionDescriptor(ROUTER_MANDATORY)
-    tcp_keepalive = _SocketOptionDescriptor(TCP_KEEPALIVE)
-    tcp_keepalive_idle = _SocketOptionDescriptor(TCP_KEEPALIVE_IDLE)
-    tcp_keepalive_cnt = _SocketOptionDescriptor(TCP_KEEPALIVE_CNT)
-    tcp_keepalive_intvl = _SocketOptionDescriptor(TCP_KEEPALIVE_INTVL)
-    heartbeat_ivl = _SocketOptionDescriptor(HEARTBEAT_IVL)
-    heartbeat_ttl = _SocketOptionDescriptor(HEARTBEAT_TTL)
-    heartbeat_timeout = _SocketOptionDescriptor(HEARTBEAT_TIMEOUT)
-    handshake_ivl = _SocketOptionDescriptor(HANDSHAKE_IVL)
-    conflate = _SocketOptionDescriptor(CONFLATE)
-    curve_server = _SocketOptionDescriptor(CURVE_SERVER)
-    curve_publickey = _SocketOptionDescriptor(CURVE_PUBLICKEY)
-    curve_secretkey = _SocketOptionDescriptor(CURVE_SECRETKEY)
-    curve_serverkey = _SocketOptionDescriptor(CURVE_SERVERKEY)
-    on_mute = _SocketOptionDescriptor(OMQ_ON_MUTE)
-    compression_level = _SocketOptionDescriptor(OMQ_COMPRESSION_LEVEL)
-    compression_dict = _SocketOptionDescriptor(OMQ_COMPRESSION_DICT)
-    compression_auto_train = _SocketOptionDescriptor(OMQ_COMPRESSION_AUTO_TRAIN)
-    sndbuf = _SocketOptionDescriptor(SNDBUF)
-    rcvbuf = _SocketOptionDescriptor(RCVBUF)
-    mechanism = _SocketOptionDescriptor(MECHANISM)
-    plain_server = _SocketOptionDescriptor(PLAIN_SERVER)
-    plain_username = _SocketOptionDescriptor(PLAIN_USERNAME)
-    plain_password = _SocketOptionDescriptor(PLAIN_PASSWORD)
+    affinity = _SocketOptionDescriptor[int](AFFINITY)
+    identity = _SocketOptionDescriptor[bytes](IDENTITY)
+    routing_id = _SocketOptionDescriptor[bytes](ROUTING_ID)
+    rcvmore = _SocketOptionDescriptor[int](RCVMORE)
+    sndhwm = _SocketOptionDescriptor[int](SNDHWM)
+    rcvhwm = _SocketOptionDescriptor[int](RCVHWM)
+    linger = _SocketOptionDescriptor[int](LINGER)
+    reconnect_ivl = _SocketOptionDescriptor[int](RECONNECT_IVL)
+    reconnect_ivl_max = _SocketOptionDescriptor[int](RECONNECT_IVL_MAX)
+    backlog = _SocketOptionDescriptor[int](BACKLOG)
+    maxmsgsize = _SocketOptionDescriptor[int](MAXMSGSIZE)
+    rcvtimeo = _SocketOptionDescriptor[int](RCVTIMEO)
+    sndtimeo = _SocketOptionDescriptor[int](SNDTIMEO)
+    ipv6 = _SocketOptionDescriptor[int](IPV6)
+    immediate = _SocketOptionDescriptor[int](IMMEDIATE)
+    router_mandatory = _SocketOptionDescriptor[int](ROUTER_MANDATORY)
+    tcp_keepalive = _SocketOptionDescriptor[int](TCP_KEEPALIVE)
+    tcp_keepalive_idle = _SocketOptionDescriptor[int](TCP_KEEPALIVE_IDLE)
+    tcp_keepalive_cnt = _SocketOptionDescriptor[int](TCP_KEEPALIVE_CNT)
+    tcp_keepalive_intvl = _SocketOptionDescriptor[int](TCP_KEEPALIVE_INTVL)
+    heartbeat_ivl = _SocketOptionDescriptor[int](HEARTBEAT_IVL)
+    heartbeat_ttl = _SocketOptionDescriptor[int](HEARTBEAT_TTL)
+    heartbeat_timeout = _SocketOptionDescriptor[int](HEARTBEAT_TIMEOUT)
+    handshake_ivl = _SocketOptionDescriptor[int](HANDSHAKE_IVL)
+    conflate = _SocketOptionDescriptor[int](CONFLATE)
+    curve_server = _SocketOptionDescriptor[int](CURVE_SERVER)
+    curve_publickey = _SocketOptionDescriptor[bytes](CURVE_PUBLICKEY)
+    curve_secretkey = _SocketOptionDescriptor[bytes](CURVE_SECRETKEY)
+    curve_serverkey = _SocketOptionDescriptor[bytes](CURVE_SERVERKEY)
+    on_mute = _SocketOptionDescriptor[int](OMQ_ON_MUTE)
+    compression_level = _SocketOptionDescriptor[int](OMQ_COMPRESSION_LEVEL)
+    compression_dict = _SocketOptionDescriptor[bytes](OMQ_COMPRESSION_DICT)
+    compression_auto_train = _SocketOptionDescriptor[int](OMQ_COMPRESSION_AUTO_TRAIN)
+    sndbuf = _SocketOptionDescriptor[int](SNDBUF)
+    rcvbuf = _SocketOptionDescriptor[int](RCVBUF)
+    mechanism = _SocketOptionDescriptor[int](MECHANISM)
+    plain_server = _SocketOptionDescriptor[int](PLAIN_SERVER)
+    plain_username = _SocketOptionDescriptor[bytes](PLAIN_USERNAME)
+    plain_password = _SocketOptionDescriptor[bytes](PLAIN_PASSWORD)
 
     # ── Shared properties ────────────────────────────────────────────
 
@@ -417,22 +442,37 @@ class _SocketOptionsBase:
         return self._sock.getsockopt(TYPE)
 
     @property
-    def last_endpoint(self) -> bytes | str | None:
+    def last_endpoint(self) -> bytes:
         return self._last_endpoint
 
     @property
-    def underlying(self) -> _SocketOptionsBase:
+    def underlying(self) -> Self:
         return self
 
     # ── Options ──────────────────────────────────────────────────────
 
-    def setsockopt(self, option: int, value: Any) -> Any:
+    def setsockopt(self, option: int, value: int | bytes) -> None:
         try:
             return self._sock.setsockopt(option, value)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def getsockopt(self, option: int) -> Any:
+    @overload
+    def getsockopt(self, option: _BytesOption) -> bytes: ...
+
+    @overload
+    def getsockopt(self, option: Literal[32]) -> bytes: ...
+
+    @overload
+    def getsockopt(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+
+    @overload
+    def getsockopt(self, option: int) -> int | bytes | None: ...
+
+    def getsockopt(self, option: int) -> int | bytes | None:
         if option == LAST_ENDPOINT:
             return self._last_endpoint
         try:
@@ -440,16 +480,31 @@ class _SocketOptionsBase:
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def set(self, option: int, value: Any) -> Any:
+    def set(self, option: int, value: int | bytes) -> None:
         return self.setsockopt(option, value)
 
-    def get(self, option: int) -> Any:
+    @overload
+    def get(self, option: _BytesOption) -> bytes: ...
+
+    @overload
+    def get(self, option: Literal[32]) -> bytes: ...
+
+    @overload
+    def get(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+
+    @overload
+    def get(self, option: int) -> int | bytes | None: ...
+
+    def get(self, option: int) -> int | bytes | None:
         return self.getsockopt(option)
 
     def setsockopt_string(
-        self, option: int, value: str, encoding: str = "utf-8"
-    ) -> Any:
-        return self.setsockopt(option, value.encode(encoding))
+        self, option: int, optval: str, encoding: str = "utf-8"
+    ) -> None:
+        return self.setsockopt(option, optval.encode(encoding))
 
     def getsockopt_string(self, option: int, encoding: str = "utf-8") -> str:
         v = self.getsockopt(option)
@@ -468,7 +523,12 @@ class _BaseSocket(_SocketOptionsBase):
 
     """
 
-    def set_curve_auth(self, auth: Any) -> Any:
+    _closed: bool
+    _pid: int
+    _binds: list[str | bytes]
+    _connects: list[str | bytes]
+
+    def set_curve_auth(self, auth: CurveAuth) -> None:
         try:
             return self._sock.set_curve_auth(auth)
         except _native.ZMQError as e:
@@ -476,7 +536,7 @@ class _BaseSocket(_SocketOptionsBase):
         except AttributeError:
             raise ZMQNotImplementedError("curve feature not compiled")
 
-    def set_plain_auth(self, auth: Any) -> Any:
+    def set_plain_auth(self, auth: PlainAuth) -> None:
         """Configure PLAIN server admission before first socket use.
 
         Pass an iterable of exact ``(username, password)`` pairs or a callable
@@ -506,16 +566,19 @@ class _BaseSocket(_SocketOptionsBase):
         return self.getsockopt(FD)
 
     @overload
-    def bind(self, endpoint: str) -> str: ...
+    def bind(self, addr: str) -> _SocketContext[Self]: ...
 
     @overload
-    def bind(self, endpoint: bytes) -> bytes: ...
+    def bind(self, addr: bytes) -> _SocketContext[Self]: ...
 
-    def bind(self, endpoint):
+    def bind(self, addr: str | bytes) -> _SocketContext[Self]:
+        endpoint = addr
+        if isinstance(endpoint, bytes):
+            endpoint = endpoint.decode("utf-8")
         try:
             ep = self._sock.bind(self._context._namespace_inproc(endpoint))
             self._last_endpoint = ep.encode() if isinstance(ep, str) else ep
-            return ep
+            return _SocketContext(self, "bind", ep)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
@@ -526,12 +589,17 @@ class _BaseSocket(_SocketOptionsBase):
         max_port: int = 65536,
         max_tries: int = 100,
     ) -> int:
-        ep = self.bind(f"{addr}:0")
-        if isinstance(ep, bytes):
-            ep = ep.decode()
-        return int(ep.rsplit(":", 1)[1])
+        self.bind(f"{addr}:0")
+        endpoint = self.last_endpoint
+        if not endpoint:
+            raise RuntimeError("bind did not report an endpoint")
+        return int(endpoint.decode().rsplit(":", 1)[1])
 
-    def connect(self, endpoint: str | bytes) -> None:
+    def connect(
+        self,
+        addr: str | bytes,
+    ) -> _SocketContext[Self]:
+        endpoint = addr
         if isinstance(endpoint, bytes):
             endpoint = endpoint.decode("utf-8")
         try:
@@ -539,16 +607,23 @@ class _BaseSocket(_SocketOptionsBase):
             self._last_endpoint = (
                 endpoint.encode() if isinstance(endpoint, str) else endpoint
             )
+            return _SocketContext(self, "connect", addr)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unbind(self, endpoint: str | bytes) -> None:
+    def unbind(self, addr: str | bytes) -> None:
+        endpoint = addr
+        if isinstance(endpoint, bytes):
+            endpoint = endpoint.decode("utf-8")
         try:
             return self._sock.unbind(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def disconnect(self, endpoint: str | bytes) -> None:
+    def disconnect(self, addr: str | bytes) -> None:
+        endpoint = addr
+        if isinstance(endpoint, bytes):
+            endpoint = endpoint.decode("utf-8")
         try:
             return self._sock.disconnect(self._context._namespace_inproc(endpoint))
         except _native.ZMQError as e:
@@ -556,18 +631,18 @@ class _BaseSocket(_SocketOptionsBase):
 
     # ── Subscriptions ────────────────────────────────────────────────
 
-    def subscribe(self, prefix: bytes | str) -> None:
+    def subscribe(self, topic: bytes | str) -> None:
         try:
             return self._sock.subscribe(
-                prefix.encode() if isinstance(prefix, str) else prefix
+                topic.encode() if isinstance(topic, str) else topic
             )
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def unsubscribe(self, prefix: bytes | str) -> None:
+    def unsubscribe(self, topic: bytes | str) -> None:
         try:
             return self._sock.unsubscribe(
-                prefix.encode() if isinstance(prefix, str) else prefix
+                topic.encode() if isinstance(topic, str) else topic
             )
         except _native.ZMQError as e:
             raise error.from_native(e) from None
@@ -586,13 +661,13 @@ class _BaseSocket(_SocketOptionsBase):
 
     # ── Monitoring ───────────────────────────────────────────────────
 
-    def monitor(self) -> Any:
+    def monitor(self) -> _native.Monitor:
         return self._sock.monitor()
 
-    def connections(self) -> Any:
+    def connections(self) -> list[ConnectionInfo]:
         return self._sock.connections()
 
-    def connection_info(self, connection_id: int) -> Any:
+    def connection_info(self, connection_id: int) -> ConnectionInfo | None:
         return self._sock.connection_info(connection_id)
 
     # ── Lifecycle ────────────────────────────────────────────────────
@@ -608,7 +683,12 @@ class _BaseSocket(_SocketOptionsBase):
     def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, *args: Any) -> bool:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> bool:
         self.close()
         return False
 
@@ -631,16 +711,12 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     _sock: _native.Socket
     _context: Context
-    _closed: bool
-    _pid: int
-    _binds: list[str | bytes]
-    _connects: list[str | bytes]
 
     def __init__(self, _sock: _native.Socket, _context: Context) -> None:
-        self._sock = _sock
+        self._sock = _sock  # pyright: ignore[reportIncompatibleVariableOverride]
         self._context = _context
         self._closed = False
-        self._last_endpoint = None
+        self._last_endpoint = b""
         self._pid = os.getpid()
         self._binds = []
         self._connects = []
@@ -649,7 +725,15 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
         return cls
 
     @classmethod
-    def shadow(cls, socket: Any) -> Socket | _ShadowSocket:
+    @overload
+    def shadow[S: Socket](cls, socket: S) -> S: ...
+
+    @classmethod
+    @overload
+    def shadow(cls, socket: AsyncSocket) -> _ShadowSocket: ...
+
+    @classmethod
+    def shadow(cls, socket: Socket | AsyncSocket) -> Socket | _ShadowSocket:
         from . import asyncio as _zmq_async
 
         if isinstance(socket, _zmq_async.Socket):
@@ -664,18 +748,23 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     def send(
         self,
-        data: Any,
+        data: SENDABLE_TYPES,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
+        routing_id: int | None = None,
+        group: str | None = None,
     ) -> MessageTracker | None:
         try:
-            self._sock.send(data, flags, copy)
+            if group is not None:
+                if routing_id is not None:
+                    raise ValueError("routing_id and group are mutually exclusive")
+                return self._sock._send_with_group(data, group, flags, copy, track)
+            if routing_id is None:
+                return self._sock.send(data, flags, copy, track)
+            return self._sock._send_with_routing(data, routing_id, flags, copy, track)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
-        if track:
-            return MessageTracker(_pending=True)
-        return None
 
     @overload
     def recv(
@@ -684,8 +773,16 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
 
     @overload
     def recv(
-        self, flags: int = 0, copy: Literal[False] = False, track: bool = False
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
     ) -> Frame: ...
+
+    @overload
+    def recv(self, flags: int, copy: Literal[False], track: bool = False) -> Frame: ...
+
+    @overload
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> bytes | Frame: ...
 
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
@@ -693,35 +790,73 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
         try:
             if copy:
                 return self._sock.recv(flags)
-            return self._sock.recv_frame(flags)
+            frame = self._sock.recv_frame(flags)
+            if track:
+                frame._track_received()
+            return frame
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
     def send_multipart(
         self,
-        parts: Iterable[Any],
+        msg_parts: Iterable[SENDABLE_TYPES],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
+        routing_id: int | None = None,
+        group: str | None = None,
     ) -> MessageTracker | None:
-        parts = [p.encode("utf-8") if isinstance(p, str) else p for p in parts]
+        if group is not None:
+            if routing_id is not None:
+                raise ValueError("routing_id and group are mutually exclusive")
+            return self._sock._send_multipart_with_group(
+                msg_parts, group, flags, copy, track
+            )
         try:
-            self._sock.send_multipart(parts, flags, copy)
+            if routing_id is None:
+                return self._sock.send_multipart(msg_parts, flags, copy, track)
+            return self._sock._send_multipart_with_routing(
+                msg_parts, routing_id, flags, copy, track
+            )
         except _native.ZMQError as e:
             raise error.from_native(e) from None
-        if track:
-            return MessageTracker(_pending=True)
-        return None
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: Literal[True] = True, track: bool = False
+    ) -> list[bytes]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
+    ) -> list[Frame]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int, copy: Literal[False], track: bool = False
+    ) -> list[Frame]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> list[bytes] | list[Frame]: ...
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> list[bytes | Frame]:
+    ) -> list[bytes] | list[Frame]:
         try:
             if copy:
                 return self._sock.recv_multipart(flags)
-            return self._sock.recv_multipart_frames(flags)
+            frames = self._sock.recv_multipart_frames(flags)
+            if track:
+                for frame in frames:
+                    frame._track_received()
+            return frames
         except _native.ZMQError as e:
             raise error.from_native(e) from None
+
+    def recv_into(self, buffer: Any, /, *, nbytes: int = 0, flags: int = 0) -> int:
+        return _copy_received_into(buffer, self.recv(flags), nbytes)
 
     # ── Serialization helpers ────────────────────────────────────────
 
@@ -749,10 +884,10 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
     def recv_pyobj(self, flags: int = 0) -> Any:
         return pickle.loads(self.recv(flags))
 
-    def send_serialized(
+    def send_serialized[T](
         self,
-        msg: Any,
-        serialize: Callable[[Any], list[bytes]],
+        msg: T,
+        serialize: Callable[[T], Iterable[SENDABLE_TYPES]],
         flags: int = 0,
         copy: bool = True,
         **kwargs: Any,
@@ -760,12 +895,39 @@ class Socket(_BaseSocket, metaclass=_SocketMeta):
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
-    def recv_serialized(
+    @overload
+    def recv_serialized[T](
         self,
-        deserialize: Callable[[list[bytes]], Any],
+        deserialize: Callable[[list[bytes]], T],
+        flags: int = 0,
+        copy: Literal[True] = True,
+    ) -> T: ...
+
+    @overload
+    def recv_serialized[T](
+        self,
+        deserialize: Callable[[list[Frame]], T],
+        flags: int = 0,
+        *,
+        copy: Literal[False],
+    ) -> T: ...
+
+    @overload
+    def recv_serialized[T](
+        self, deserialize: Callable[[list[Frame]], T], flags: int, copy: Literal[False]
+    ) -> T: ...
+
+    @overload
+    def recv_serialized[T](
+        self,
+        deserialize: Callable[[list[bytes] | list[Frame]], T],
         flags: int = 0,
         copy: bool = True,
-    ) -> Any:
+    ) -> T: ...
+
+    def recv_serialized[T](
+        self, deserialize: Callable[[Any], T], flags: int = 0, copy: bool = True
+    ) -> T:
         frames = self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
@@ -791,7 +953,7 @@ class _ShadowSocket(_SocketOptionsBase):
 
     """
 
-    _async_socket: Any  # pyomq.asyncio.Socket
+    _async_socket: AsyncSocket
     _native: _native.AsyncSocket
     _context: Context
     _closed: bool
@@ -800,13 +962,13 @@ class _ShadowSocket(_SocketOptionsBase):
     _recv_wakeup_event: threading.Event
     _send_wakeup_event: threading.Event
 
-    def __init__(self, async_socket: Any) -> None:
+    def __init__(self, async_socket: AsyncSocket) -> None:
         self._async_socket = async_socket
         self._native = async_socket._sock
         self._context = async_socket._context
         self._closed = False
         self._last_endpoint = async_socket._last_endpoint
-        if _IS_WINDOWS:
+        if sys.platform == "win32":
             self._recv_waiter_pending = False
             self._send_waiter_pending = False
             self._recv_wakeup_event = async_socket._recv_wakeup_event
@@ -825,28 +987,58 @@ class _ShadowSocket(_SocketOptionsBase):
         return self._native.getsockopt(TYPE)
 
     @property
-    def underlying(self) -> _ShadowSocket:
+    def underlying(self) -> Self:
         return self
 
-    def getsockopt(self, option: int) -> Any:
+    @overload
+    def getsockopt(self, option: _BytesOption) -> bytes: ...
+
+    @overload
+    def getsockopt(self, option: Literal[32]) -> bytes: ...
+
+    @overload
+    def getsockopt(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+
+    @overload
+    def getsockopt(self, option: int) -> int | bytes | None: ...
+
+    def getsockopt(self, option: int) -> int | bytes | None:
         try:
             return self._native.getsockopt(option)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def setsockopt(self, option: int, value: Any) -> Any:
+    def setsockopt(self, option: int, value: int | bytes) -> None:
         try:
             return self._native.setsockopt(option, value)
         except _native.ZMQError as e:
             raise error.from_native(e) from None
 
-    def set(self, option: int, value: Any) -> Any:
+    def set(self, option: int, value: int | bytes) -> None:
         return self.setsockopt(option, value)
 
-    def get(self, option: int) -> Any:
+    @overload
+    def get(self, option: _BytesOption) -> bytes: ...
+
+    @overload
+    def get(self, option: Literal[32]) -> bytes: ...
+
+    @overload
+    def get(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+
+    @overload
+    def get(self, option: int) -> int | bytes | None: ...
+
+    def get(self, option: int) -> int | bytes | None:
         return self.getsockopt(option)
 
-    if _IS_WINDOWS:
+    if sys.platform == "win32":
 
         def _register_wakeup_hooks(self) -> None:
             self._async_socket._register_wakeup_hooks()
@@ -855,7 +1047,7 @@ class _ShadowSocket(_SocketOptionsBase):
         def _register_wakeup_hooks(self) -> None:
             return None
 
-    if _IS_WINDOWS:
+    if sys.platform == "win32":
 
         def _blocking_recv(self, try_fn: Callable[[], Any]) -> Any:
             if self._recv_waiter_pending:
@@ -929,47 +1121,122 @@ class _ShadowSocket(_SocketOptionsBase):
             finally:
                 os.close(fd)
 
+    @overload
+    def recv(
+        self, flags: int = 0, copy: Literal[True] = True, track: bool = False
+    ) -> bytes: ...
+
+    @overload
+    def recv(
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
+    ) -> Frame: ...
+
+    @overload
+    def recv(self, flags: int, copy: Literal[False], track: bool = False) -> Frame: ...
+
+    @overload
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> bytes | Frame: ...
+
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
     ) -> bytes | Frame:
         if copy:
             return self._blocking_recv(self._native._try_recv)
-        return self._blocking_recv(self._native._try_recv_frame)
+        frame = self._blocking_recv(self._native._try_recv_frame)
+        if track:
+            frame._track_received()
+        return frame
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: Literal[True] = True, track: bool = False
+    ) -> list[bytes]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
+    ) -> list[Frame]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int, copy: Literal[False], track: bool = False
+    ) -> list[Frame]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> list[bytes] | list[Frame]: ...
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> list[bytes | Frame]:
+    ) -> list[bytes] | list[Frame]:
         if copy:
             return self._blocking_recv(self._native._try_recv_multipart)
-        return self._blocking_recv(self._native._try_recv_multipart_frames)
+        frames = self._blocking_recv(self._native._try_recv_multipart_frames)
+        if track:
+            for frame in frames:
+                frame._track_received()
+        return frames
 
     def send(
         self,
-        data: Any,
+        data: SENDABLE_TYPES,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
+        routing_id: int | None = None,
+        group: str | None = None,
     ) -> MessageTracker | None:
-        self._blocking_send(lambda: self._native.send(data, flags, copy))
-        if track:
-            return MessageTracker(_pending=True)
-        return None
+        if group is not None:
+            if routing_id is not None:
+                raise ValueError("routing_id and group are mutually exclusive")
+            return self._blocking_send(
+                lambda: self._native._send_with_group(data, group, flags, copy, track)
+            )
+        if routing_id is None:
+            return self._blocking_send(
+                lambda: self._native.send(data, flags, copy, track)
+            )
+        return self._blocking_send(
+            lambda: self._native._send_with_routing(
+                data, routing_id, flags, copy, track
+            )
+        )
 
     def send_multipart(
         self,
-        parts: list[Any],
+        msg_parts: Iterable[SENDABLE_TYPES],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
+        routing_id: int | None = None,
+        group: str | None = None,
     ) -> MessageTracker | None:
-        self._blocking_send(lambda: self._native.send_multipart(parts, flags, copy))
-        if track:
-            return MessageTracker(_pending=True)
-        return None
+        if group is not None:
+            if routing_id is not None:
+                raise ValueError("routing_id and group are mutually exclusive")
+            return self._blocking_send(
+                lambda: self._native._send_multipart_with_group(
+                    msg_parts, group, flags, copy, track
+                )
+            )
+        if routing_id is None:
+            return self._blocking_send(
+                lambda: self._native.send_multipart(msg_parts, flags, copy, track)
+            )
+        return self._blocking_send(
+            lambda: self._native._send_multipart_with_routing(
+                msg_parts, routing_id, flags, copy, track
+            )
+        )
 
-    if _IS_WINDOWS:
+    if sys.platform == "win32":
 
-        def _blocking_send(self, send_fn: Callable[[], None]) -> None:
+        def _blocking_send(
+            self, send_fn: Callable[[], MessageTracker | None]
+        ) -> MessageTracker | None:
             if self._send_waiter_pending:
                 raise RuntimeError(
                     "cannot have more than one pending send waiter on a shadow socket"
@@ -981,27 +1248,30 @@ class _ShadowSocket(_SocketOptionsBase):
             )
             try:
                 try:
-                    send_fn()
-                    return
+                    return send_fn()
                 except _native.ZMQError as e:
                     if getattr(e, "errno", None) != _errno.EAGAIN:
                         raise error.from_native(e) from None
+                    if hasattr(e, "_pending_send"):
+                        send_fn = e._pending_send.retry
 
                 while True:
                     self._send_wakeup_event.clear()
                     try:
-                        send_fn()
-                        return
+                        return send_fn()
                     except _native.ZMQError as e:
                         if getattr(e, "errno", None) != _errno.EAGAIN:
                             raise error.from_native(e) from None
+                        if hasattr(e, "_pending_send"):
+                            send_fn = e._pending_send.retry
                     self._send_wakeup_event.wait()
                     try:
-                        send_fn()
-                        return
+                        return send_fn()
                     except _native.ZMQError as e:
                         if getattr(e, "errno", None) != _errno.EAGAIN:
                             raise error.from_native(e) from None
+                        if hasattr(e, "_pending_send"):
+                            send_fn = e._pending_send.retry
             finally:
                 self._send_waiter_pending = False
                 self._async_socket._clear_wakeup_modes(
@@ -1009,22 +1279,26 @@ class _ShadowSocket(_SocketOptionsBase):
                 )
     else:
 
-        def _blocking_send(self, send_fn: Callable[[], None]) -> None:
+        def _blocking_send(
+            self, send_fn: Callable[[], MessageTracker | None]
+        ) -> MessageTracker | None:
             try:
-                send_fn()
-                return
+                return send_fn()
             except _native.ZMQError as e:
                 if getattr(e, "errno", None) != _errno.EAGAIN:
                     raise error.from_native(e) from None
+                if hasattr(e, "_pending_send"):
+                    send_fn = e._pending_send.retry
 
             fd = self._native._send_fd()
             try:
                 try:
-                    send_fn()
-                    return
+                    return send_fn()
                 except _native.ZMQError as e:
                     if getattr(e, "errno", None) != _errno.EAGAIN:
                         raise error.from_native(e) from None
+                    if hasattr(e, "_pending_send"):
+                        send_fn = e._pending_send.retry
 
                 while True:
                     _select.select([fd], [], [])
@@ -1033,11 +1307,12 @@ class _ShadowSocket(_SocketOptionsBase):
                     except OSError:
                         pass
                     try:
-                        send_fn()
-                        return
+                        return send_fn()
                     except _native.ZMQError as e:
                         if getattr(e, "errno", None) != _errno.EAGAIN:
                             raise error.from_native(e) from None
+                        if hasattr(e, "_pending_send"):
+                            send_fn = e._pending_send.retry
             finally:
                 os.close(fd)
 
@@ -1074,8 +1349,23 @@ class Context(metaclass=_ContextMeta):
     _ctx_id: int
 
     def __init__(
-        self, io_threads: int = 1, *, _shadow_ctx: Context | None = None
+        self,
+        io_threads: int | Context = 1,
+        shadow: Context | int = 0,
+        *,
+        _shadow_ctx: Context | None = None,
     ) -> None:
+        if isinstance(io_threads, Context):
+            if shadow != 0 or _shadow_ctx is not None:
+                raise TypeError("shadow context specified more than once")
+            shadow = io_threads
+            io_threads = 1
+        if shadow != 0:
+            if _shadow_ctx is not None:
+                raise TypeError("shadow context specified more than once")
+            if not isinstance(shadow, Context):
+                raise TypeError("shadow must be a pyomq Context")
+            _shadow_ctx = shadow
         if _shadow_ctx is not None:
             if isinstance(_shadow_ctx._ctx, _native.AsyncContext):
                 self._ctx = _native.Context.shadow_async(_shadow_ctx._ctx)
@@ -1091,7 +1381,7 @@ class Context(metaclass=_ContextMeta):
             _shadow_ctx._ctx_id if _shadow_ctx is not None else next(_next_ctx_id)
         )
 
-    def _namespace_inproc(self, endpoint: str | bytes) -> str | bytes:
+    def _namespace_inproc[T: (str, bytes)](self, endpoint: T) -> T:
         # `inproc://` names are scoped by the native context core. Keep the
         # user endpoint unchanged so LAST_ENDPOINT and errors match input.
         return endpoint
@@ -1102,6 +1392,16 @@ class Context(metaclass=_ContextMeta):
     @property
     def closed(self) -> bool:
         return self._closed
+
+    @overload
+    def socket(
+        self, socket_type: int, socket_class: None = None, **kwargs: Any
+    ) -> Socket: ...
+
+    @overload
+    def socket[S: Socket](
+        self, socket_type: int, socket_class: type[S], **kwargs: Any
+    ) -> S: ...
 
     def socket(
         self,
@@ -1115,7 +1415,7 @@ class Context(metaclass=_ContextMeta):
         s._sock = native
         s._context = self
         s._closed = False
-        s._last_endpoint = None
+        s._last_endpoint = b""
         s._pid = os.getpid()
         self._sockets.add(s)
         return s
@@ -1141,7 +1441,7 @@ class Context(metaclass=_ContextMeta):
         obj._closed = False
         obj._sockets = weakref.WeakSet()
         obj._ctx_id = next(_next_ctx_id)
-        return cast(Self, obj)
+        return obj
 
     @classmethod
     def instance(cls, io_threads: int = 1) -> Self:
@@ -1172,10 +1472,15 @@ class Context(metaclass=_ContextMeta):
         if not self._closed:
             self.term()
 
-    def __enter__(self) -> Context:
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, *args: Any) -> bool:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> bool:
         self.term()
         return False
 
@@ -1286,11 +1591,16 @@ def device(device_type: int, frontend: Socket, backend: Socket) -> None:
     proxy(frontend, backend)
 
 
-# ── ZMQStream re-export ─────────────────────────────────────────────
+from .zmqstream import ZMQStream
 
-from .zmqstream import ZMQStream  # noqa: E402
-
-__all__ = [
+__all__ = [  # noqa: RUF022
+    "AuthCallback",
+    "CurveAuth",
+    "PlainAuth",
+    "FutureResult",
+    "Sendable",
+    "ConnectionInfo",
+    "MonitorEvent",
     "Context",
     "Socket",
     "Poller",
@@ -1458,16 +1768,25 @@ __all__ = [
 # pyzmq supports ZMQError(errno, msg) which sets .errno on the instance.
 # The native _native.ZMQError doesn't. Patch __init__ so ipykernel's
 # mock-based tests and heartbeat code can construct ZMQError(errno, msg).
-_orig_zmqerror_init = _native.ZMQError.__init__
+_orig_zmqerror_init = cast(Callable[..., None], _native.ZMQError.__init__)
 
 
-def _zmqerror_init(self, *args, **kwargs):
-    if args and isinstance(args[0], int):
-        _orig_zmqerror_init(self, args[1] if len(args) > 1 else "")
-        self.errno = args[0]
-        self.strerror = args[1] if len(args) > 1 else ""
-    else:
-        _orig_zmqerror_init(self, *args, **kwargs)
+def _zmqerror_init(
+    self: ZMQError, errno: int | str | None = None, msg: str | None = None
+) -> None:
+    if isinstance(errno, str):
+        if msg is not None:
+            raise TypeError("message specified twice")
+        msg, errno = errno, None
+    elif errno is not None and not isinstance(errno, int):
+        raise TypeError("errno must be an integer or None")
+    if msg is not None and not isinstance(msg, str):
+        raise TypeError("msg must be a string or None")
+    self.errno = errno
+    self.strerror = (
+        msg if msg is not None else (strerror(errno) if errno is not None else "")
+    )
+    _orig_zmqerror_init(self, self.strerror)
 
 
 _native.ZMQError.__init__ = _zmqerror_init

--- a/bindings/pyomq/python/pyomq/_native.pyi
+++ b/bindings/pyomq/python/pyomq/_native.pyi
@@ -1,0 +1,506 @@
+"""Interface of the PyO3 library.
+
+This file is deliberately maintained by hand because PyO3's generated
+stubs are intentionally limited and do not cover the full public
+Python/native API contract of pyomq.
+
+"""
+
+import builtins
+import sys
+import types
+from collections.abc import Buffer, Callable, Iterable, Sequence
+from threading import Event
+from typing import Final, Literal, Self, final, overload
+
+from ._tracker import MessageTracker
+from ._typing import (
+    ConnectionInfo,
+    CurveAuth,
+    MonitorEvent,
+    PlainAuth,
+    Sendable,
+    _BytesOption,
+    _IntOption,
+)
+
+class ZMQBaseError(Exception): ...
+
+class ZMQError(ZMQBaseError):
+    errno: int | None
+    strerror: str
+    _pending_send: PendingSend
+    @overload
+    def __init__(self, errno: int | None = None, msg: str | None = None) -> None: ...
+    @overload
+    def __init__(self, msg: str, /) -> None: ...
+
+# Socket type constants (libzmq-compatible)
+PAIR: Final = 0
+PUB: Final = 1
+SUB: Final = 2
+REQ: Final = 3
+REP: Final = 4
+DEALER: Final = 5
+ROUTER: Final = 6
+PULL: Final = 7
+PUSH: Final = 8
+XPUB: Final = 9
+XSUB: Final = 10
+STREAM: Final = 11
+SERVER: Final = 12
+CLIENT: Final = 13
+RADIO: Final = 14
+DISH: Final = 15
+GATHER: Final = 16
+SCATTER: Final = 17
+PEER: Final = 19
+CHANNEL: Final = 20
+
+# Socket option constants
+AFFINITY: Final = 4
+IDENTITY: Final = 5
+SUBSCRIBE: Final = 6
+UNSUBSCRIBE: Final = 7
+RCVMORE: Final = 13
+TYPE: Final = 16
+LINGER: Final = 17
+RECONNECT_IVL: Final = 18
+BACKLOG: Final = 19
+RECONNECT_IVL_MAX: Final = 21
+MAXMSGSIZE: Final = 22
+SNDHWM: Final = 23
+RCVHWM: Final = 24
+RCVTIMEO: Final = 27
+SNDTIMEO: Final = 28
+ROUTER_MANDATORY: Final = 33
+TCP_KEEPALIVE: Final = 34
+TCP_KEEPALIVE_CNT: Final = 35
+TCP_KEEPALIVE_IDLE: Final = 36
+TCP_KEEPALIVE_INTVL: Final = 37
+IMMEDIATE: Final = 39
+IPV6: Final = 42
+HEARTBEAT_IVL: Final = 75
+HEARTBEAT_TTL: Final = 76
+HEARTBEAT_TIMEOUT: Final = 77
+HANDSHAKE_IVL: Final = 66
+CONFLATE: Final = 54
+CURVE_SERVER: Final = 47
+CURVE_PUBLICKEY: Final = 48
+CURVE_SECRETKEY: Final = 49
+CURVE_SERVERKEY: Final = 50
+OMQ_ON_MUTE: Final = 1004
+OMQ_ON_MUTE_BLOCK: Final = 0
+OMQ_ON_MUTE_DROP_NEWEST: Final = 1
+OMQ_ON_MUTE_DROP_OLDEST: Final = 2
+OMQ_COMPRESSION_LEVEL: Final = 1005
+OMQ_COMPRESSION_DICT: Final = 1006
+OMQ_COMPRESSION_AUTO_TRAIN: Final = 1007
+
+# Compatibility constants
+NOBLOCK: Final = 1
+DONTWAIT: Final = 1
+SNDMORE: Final = 2
+
+# In-process connection metadata
+@final
+class PeerInfo:
+    @property
+    def public_key(self) -> bytes: ...
+    @property
+    def identity(self) -> bytes | None: ...
+    @property
+    def peer_address(self) -> str | None: ...
+    @property
+    def username(self) -> str | None: ...
+    @property
+    def password(self) -> str | None: ...
+
+# Module-level helpers
+
+def backend_name() -> str: ...
+def version() -> str: ...
+def has_feature(name: str) -> bool: ...
+def wait_any(
+    sockets: Sequence[Socket | AsyncSocket], timeout_ms: int | None = ...
+) -> list[int]: ...
+def rust_thread_send_via_share_key(
+    share_key: int, endpoint: str, payload: bytes
+) -> None: ...
+def native_proxy(
+    frontend: Socket,
+    backend: Socket,
+    capture: Socket | None = ...,
+    control: Socket | None = ...,
+) -> None: ...
+def curve_keypair() -> tuple[bytes, bytes]: ...
+def curve_public(secret_z85: bytes) -> bytes: ...
+
+@final
+class ReleaseToken:
+    @property
+    def done(self) -> bool: ...
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+@final
+class PendingSend:
+    def retry(self) -> MessageTracker | None: ...
+    def cancel(self) -> None: ...
+
+@final
+class Context:
+    def __new__(cls, io_threads: int = 1) -> Self: ...
+    @staticmethod
+    def shadow_async(context: AsyncContext) -> Context: ...
+    def share_key(self) -> int: ...
+    @staticmethod
+    def from_share_key(share_key: int) -> Context: ...
+    def socket(self, socket_type: int, /) -> Socket: ...
+    def term(self) -> None: ...
+    def destroy(self) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = ...,
+        exc_val: BaseException | None = ...,
+        exc_tb: types.TracebackType | None = ...,
+    ) -> bool: ...
+
+@final
+class AsyncContext:
+    def __new__(cls, io_threads: int = 1) -> Self: ...
+    @staticmethod
+    def shadow_sync(context: Context) -> AsyncContext: ...
+    def share_key(self) -> int: ...
+    @staticmethod
+    def from_share_key(share_key: int) -> AsyncContext: ...
+    def socket(self, socket_type: int, /) -> AsyncSocket: ...
+    def term(self) -> None: ...
+    def destroy(self) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = ...,
+        exc_val: BaseException | None = ...,
+        exc_tb: types.TracebackType | None = ...,
+    ) -> bool: ...
+
+@final
+class Frame(Buffer):
+    def __new__(
+        cls,
+        data: Sendable | None = None,
+        track: bool = False,
+        copy: bool | None = ...,
+        copy_threshold: int | None = ...,
+    ) -> Self: ...
+    @property
+    def bytes(self) -> builtins.bytes: ...
+    @property
+    def buffer(self) -> memoryview: ...
+    @property
+    def more(self) -> bool: ...
+    @property
+    def routing_id(self) -> int: ...
+    @routing_id.setter
+    def routing_id(self, routing_id: int) -> None: ...
+    @property
+    def group(self) -> str | None: ...
+    @group.setter
+    def group(self, group: str | None) -> None: ...
+    @property
+    def tracker(self) -> MessageTracker | None: ...
+    def _track_received(self) -> None: ...
+    def __buffer__(self, flags: int, /) -> memoryview: ...
+    def __bytes__(self) -> builtins.bytes: ...
+    def __len__(self) -> int: ...
+    def __bool__(self) -> bool: ...
+    def __eq__(self, other: object, /) -> bool: ...
+    def __ne__(self, other: object, /) -> bool: ...
+
+@final
+class Monitor:
+    def recv(self, timeout_ms: int = ...) -> MonitorEvent: ...
+    def recv_nowait(self) -> MonitorEvent: ...
+
+@final
+class Socket:
+    def socket_id(self) -> int: ...
+    def bind(self, endpoint: str) -> str: ...
+    def connect(self, endpoint: str) -> None: ...
+    def unbind(self, endpoint: str) -> None: ...
+    def disconnect(self, endpoint: str) -> None: ...
+    def send(
+        self,
+        payload: Sendable,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_with_routing(
+        self,
+        payload: Sendable,
+        routing_id: int,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_with_group(
+        self,
+        payload: Sendable,
+        group: str,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def send_multipart(
+        self,
+        parts: Iterable[Sendable],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_multipart_with_group(
+        self,
+        parts: Iterable[Sendable],
+        group: str,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_multipart_with_routing(
+        self,
+        parts: Iterable[Sendable],
+        routing_id: int,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def recv(self, flags: int = 0) -> bytes: ...
+    def recv_frame(self, flags: int = 0) -> Frame: ...
+    def recv_multipart(self, flags: int = 0) -> list[bytes]: ...
+    def recv_multipart_frames(self, flags: int = 0) -> list[Frame]: ...
+    def subscribe(self, prefix: bytes) -> None: ...
+    def unsubscribe(self, prefix: bytes) -> None: ...
+    def join(self, group: bytes) -> None: ...
+    def leave(self, group: bytes) -> None: ...
+    def connections(self) -> list[ConnectionInfo]: ...
+    def connection_info(self, connection_id: int) -> ConnectionInfo | None: ...
+    def monitor(self) -> Monitor: ...
+    def setsockopt(self, option: int, value: int | bytes) -> None: ...
+    @overload
+    def getsockopt(self, option: _BytesOption | Literal[32]) -> bytes: ...
+    @overload
+    def getsockopt(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+    @overload
+    def getsockopt(self, option: int) -> int | bytes: ...
+    def set_curve_auth(self, auth: CurveAuth) -> None: ...
+    def set_plain_auth(self, auth: PlainAuth) -> None: ...
+    def close(self, linger: int | None = None) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = ...,
+        exc_val: BaseException | None = ...,
+        exc_tb: types.TracebackType | None = ...,
+    ) -> bool: ...
+
+@final
+class AsyncSocket:
+    def socket_id(self) -> int: ...
+    def _try_recv(self) -> bytes | None: ...
+    def _try_recv_frame(self) -> Frame | None: ...
+    def _try_recv_multipart(self) -> list[bytes] | None: ...
+    def _try_recv_multipart_frames(self) -> list[Frame] | None: ...
+    def _recv_fd(self) -> int: ...
+    def _send_fd(self) -> int: ...
+    if sys.platform == "win32":
+        def _set_wakeup_hooks(
+            self,
+            recv_async: Callable[[], object] | None = ...,
+            recv_event: Event | None = ...,
+            send_async: Callable[[], object] | None = ...,
+            send_event: Event | None = ...,
+        ) -> None: ...
+        def _set_wakeup_modes(
+            self,
+            recv_mode: int | None = ...,
+            send_mode: int | None = ...,
+        ) -> None: ...
+        def _clear_wakeup_modes(
+            self,
+            recv_mode: int | None = ...,
+            send_mode: int | None = ...,
+        ) -> None: ...
+        def _mark_recv_drain_complete(self) -> None: ...
+        def _mark_send_drain_complete(self) -> None: ...
+    def bind(self, endpoint: str) -> str: ...
+    def connect(self, endpoint: str) -> None: ...
+    def unbind(self, endpoint: str) -> None: ...
+    def disconnect(self, endpoint: str) -> None: ...
+    def send(
+        self,
+        payload: Sendable,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_with_routing(
+        self,
+        payload: Sendable,
+        routing_id: int,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_with_group(
+        self,
+        payload: Sendable,
+        group: str,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def send_multipart(
+        self,
+        parts: Iterable[Sendable],
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_multipart_with_group(
+        self,
+        parts: Iterable[Sendable],
+        group: str,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def _send_multipart_with_routing(
+        self,
+        parts: Iterable[Sendable],
+        routing_id: int,
+        flags: int = 0,
+        copy: bool = True,
+        track: bool = False,
+    ) -> MessageTracker | None: ...
+    def subscribe(self, prefix: bytes) -> None: ...
+    def unsubscribe(self, prefix: bytes) -> None: ...
+    def join(self, group: bytes) -> None: ...
+    def leave(self, group: bytes) -> None: ...
+    def connections(self) -> list[ConnectionInfo]: ...
+    def connection_info(self, connection_id: int) -> ConnectionInfo | None: ...
+    def monitor(self) -> Monitor: ...
+    def setsockopt(self, option: int, value: int | bytes) -> None: ...
+    @overload
+    def getsockopt(self, option: _BytesOption | Literal[32]) -> bytes: ...
+    @overload
+    def getsockopt(
+        self,
+        option: _IntOption,
+    ) -> int: ...
+    @overload
+    def getsockopt(self, option: int) -> int | bytes: ...
+    def set_curve_auth(self, auth: CurveAuth) -> None: ...
+    def set_plain_auth(self, auth: PlainAuth) -> None: ...
+    def close(self, linger: int | None = None) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = ...,
+        exc_val: BaseException | None = ...,
+        exc_tb: types.TracebackType | None = ...,
+    ) -> bool: ...
+    def __aenter__(self) -> Self: ...
+    def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = ...,
+        exc_val: BaseException | None = ...,
+        exc_tb: types.TracebackType | None = ...,
+    ) -> bool: ...
+
+__all__ = [
+    "AFFINITY",
+    "BACKLOG",
+    "CHANNEL",
+    "CLIENT",
+    "CONFLATE",
+    "CURVE_PUBLICKEY",
+    "CURVE_SECRETKEY",
+    "CURVE_SERVER",
+    "CURVE_SERVERKEY",
+    "DEALER",
+    "DISH",
+    "DONTWAIT",
+    "GATHER",
+    "HANDSHAKE_IVL",
+    "HEARTBEAT_IVL",
+    "HEARTBEAT_TIMEOUT",
+    "HEARTBEAT_TTL",
+    "IDENTITY",
+    "IMMEDIATE",
+    "IPV6",
+    "LINGER",
+    "MAXMSGSIZE",
+    "NOBLOCK",
+    "OMQ_COMPRESSION_AUTO_TRAIN",
+    "OMQ_COMPRESSION_DICT",
+    "OMQ_COMPRESSION_LEVEL",
+    "OMQ_ON_MUTE",
+    "OMQ_ON_MUTE_BLOCK",
+    "OMQ_ON_MUTE_DROP_NEWEST",
+    "OMQ_ON_MUTE_DROP_OLDEST",
+    "PAIR",
+    "PEER",
+    "PUB",
+    "PULL",
+    "PUSH",
+    "RADIO",
+    "RCVHWM",
+    "RCVMORE",
+    "RCVTIMEO",
+    "RECONNECT_IVL",
+    "RECONNECT_IVL_MAX",
+    "REP",
+    "REQ",
+    "ROUTER",
+    "ROUTER_MANDATORY",
+    "SCATTER",
+    "SERVER",
+    "SNDHWM",
+    "SNDMORE",
+    "SNDTIMEO",
+    "STREAM",
+    "SUB",
+    "SUBSCRIBE",
+    "TCP_KEEPALIVE",
+    "TCP_KEEPALIVE_CNT",
+    "TCP_KEEPALIVE_IDLE",
+    "TCP_KEEPALIVE_INTVL",
+    "TYPE",
+    "UNSUBSCRIBE",
+    "XPUB",
+    "XSUB",
+    "AsyncContext",
+    "AsyncSocket",
+    "Context",
+    "Frame",
+    "Monitor",
+    "PeerInfo",
+    "PendingSend",
+    "ReleaseToken",
+    "Socket",
+    "ZMQBaseError",
+    "ZMQError",
+    "backend_name",
+    "curve_keypair",
+    "curve_public",
+    "has_feature",
+    "native_proxy",
+    "rust_thread_send_via_share_key",
+    "version",
+    "wait_any",
+]

--- a/bindings/pyomq/python/pyomq/_tracker.py
+++ b/bindings/pyomq/python/pyomq/_tracker.py
@@ -1,0 +1,77 @@
+"""Track the lifetime of buffers borrowed by native messages."""
+
+from __future__ import annotations
+
+import math
+import time
+from threading import Event
+
+from . import _native
+from .error import ZMQBaseError
+
+
+class NotDone(ZMQBaseError):
+    """A tracked buffer is still in use."""
+
+
+class MessageTracker:
+    """Completion means buffer reuse is safe, not that a peer received data."""
+
+    _sources: tuple[Event | MessageTracker | _native.ReleaseToken, ...]
+
+    def __init__(
+        self, *towatch: Event | MessageTracker | _native.Frame | _native.ReleaseToken
+    ) -> None:
+        sources: list[Event | MessageTracker | _native.ReleaseToken] = []
+        for source in towatch:
+            if isinstance(source, _native.Frame):
+                if source.tracker is None:
+                    raise ValueError("Not a tracked message")
+                source = source.tracker
+            if not isinstance(source, (Event, MessageTracker, _native.ReleaseToken)):
+                raise TypeError("expected an Event, MessageTracker, or tracked Frame")
+            sources.append(source)
+        self._sources = tuple(sources)
+
+    @property
+    def done(self) -> bool:
+        return all(
+            s.is_set() if isinstance(s, Event) else s.done for s in self._sources
+        )
+
+    def wait(self, timeout: float | None = -1) -> None:
+        if timeout is not None and not math.isfinite(timeout):
+            raise ValueError("timeout must be finite")
+        if len(self._sources) == 1 and isinstance(
+            self._sources[0], _native.ReleaseToken
+        ):
+            # One native wait already owns its timeout. Avoid computing a
+            # deadline and remaining time when there are no other sources.
+            if not self._sources[0].wait(
+                None if timeout is None or timeout < 0 else timeout
+            ):
+                raise NotDone
+            return
+        deadline = (
+            None if timeout is None or timeout < 0 else time.monotonic() + timeout
+        )
+        for source in self._sources:
+            remaining = (
+                None if deadline is None else max(0.0, deadline - time.monotonic())
+            )
+            if isinstance(source, MessageTracker):
+                source.wait(remaining)
+            elif not source.wait(remaining):
+                raise NotDone
+
+
+def _from_sources(
+    *sources: MessageTracker | _native.ReleaseToken,
+) -> MessageTracker:
+    """Native callers already validated sources and resolved tracked Frames."""
+    tracker = MessageTracker.__new__(MessageTracker)
+    tracker._sources = sources
+    return tracker
+
+
+_FINISHED_TRACKER = MessageTracker()

--- a/bindings/pyomq/python/pyomq/_typing.py
+++ b/bindings/pyomq/python/pyomq/_typing.py
@@ -1,0 +1,125 @@
+"""Shared public value types. No socket imports or runtime validation."""
+
+from collections.abc import Buffer, Callable, Generator, Iterable
+from typing import Any, Literal, NotRequired, Protocol, TypedDict
+
+from ._native import Frame, PeerInfo
+
+type Sendable = Buffer | Frame
+type _BytesOption = Literal[5, 38, 45, 46, 48, 49, 50, 55, 1006]
+type _IntOption = Literal[
+    4,
+    8,
+    9,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    21,
+    22,
+    23,
+    24,
+    25,
+    27,
+    28,
+    31,
+    33,
+    34,
+    35,
+    36,
+    37,
+    39,
+    40,
+    42,
+    43,
+    44,
+    47,
+    51,
+    52,
+    53,
+    54,
+    56,
+    66,
+    75,
+    76,
+    77,
+    79,
+    80,
+    109,
+    1004,
+    1005,
+    1007,
+]
+type Multipart = list[bytes] | list[Frame]
+type AuthCallback = Callable[[PeerInfo], bool]
+type CurveAuth = Iterable[bytes] | AuthCallback | None
+type PlainAuth = Iterable[tuple[str, str]] | AuthCallback
+
+
+class ConnectionInfo(TypedDict):
+    connection_id: int
+    endpoint: str
+    identity: bytes
+
+
+class ListeningEvent(TypedDict):
+    event: Literal["listening"]
+    endpoint: str
+
+
+class ConnectionEvent(TypedDict):
+    event: Literal["accepted", "connected", "disconnected", "peer_command"]
+    endpoint: str
+    connection_id: int
+
+
+class HandshakeEvent(TypedDict):
+    event: Literal["handshake_succeeded"]
+    endpoint: str
+    connection_id: int
+    peer_identity: NotRequired[bytes]
+
+
+class HandshakeFailedEvent(TypedDict):
+    event: Literal["handshake_failed"]
+    endpoint: str
+    reason: str
+
+
+class ConnectDelayedEvent(TypedDict):
+    event: Literal["connect_delayed"]
+    endpoint: str
+    attempt: int
+
+
+class LaggedEvent(TypedDict):
+    event: Literal["lagged"]
+    count: int
+
+
+class TerminalEvent(TypedDict):
+    event: Literal["closed", "unknown"]
+
+
+type MonitorEvent = (
+    ListeningEvent
+    | ConnectionEvent
+    | HandshakeEvent
+    | HandshakeFailedEvent
+    | ConnectDelayedEvent
+    | LaggedEvent
+    | TerminalEvent
+)
+
+
+class FutureResult[T](Protocol):
+    """Common interface of native-ready results and asyncio futures."""
+
+    def __await__(self) -> Generator[Any, None, T]: ...
+    def result(self) -> T: ...
+    def done(self) -> bool: ...

--- a/bindings/pyomq/python/pyomq/asyncio.py
+++ b/bindings/pyomq/python/pyomq/asyncio.py
@@ -23,22 +23,29 @@ import pickle
 import select as _select
 import sys
 import threading
+import types
 import weakref
 from collections import deque
-from typing import Any, Awaitable, Callable, Final
-from . import _native  # type: ignore[attr-defined]
-from . import error
-from . import Context as _SyncContext
-from . import _next_ctx_id
+from collections.abc import Callable, Generator, Iterable
+from typing import Any, Final, Literal, Self, cast, overload
+
 from . import (
-    LINGER,
     _TYPE_NAMES,
+    LINGER,
     POLLIN,
     POLLOUT,
+    SENDABLE_TYPES,
+    Frame,
+    MessageTracker,
     _BaseSocket,
+    _copy_received_into,
+    _native,  # type: ignore[attr-defined]
+    _next_ctx_id,
+    error,
 )
+from . import Context as _SyncContext
+from ._typing import FutureResult
 
-_IS_WINDOWS = sys.platform == "win32"
 _WAKEUP_MODE_NONE = 0
 _WAKEUP_MODE_ASYNC = 1
 _WAKEUP_MODE_SYNC = 2
@@ -47,7 +54,7 @@ _WAKEUP_MODE_SYNC = 2
 def _resolved_future(result: Any) -> asyncio.Future[Any]:
     loop = asyncio.get_running_loop()
     fut: asyncio.Future[Any] = loop.create_future()
-    fut.set_result(result)
+    fut.set_result(None if result is _SEND_DONE else result)
     return fut
 
 
@@ -56,14 +63,19 @@ _MISSING: Final[object] = object()
 
 
 class _DoneFuture:
-    """Lightweight awaitable that resolves immediately to None."""
+    """Immediate send completion; the untracked None instance is shared."""
 
-    def __await__(self) -> Any:
-        return
+    __slots__ = ("_value",)
+
+    def __init__(self, value: MessageTracker | None = None) -> None:
+        self._value = value
+
+    def __await__(self) -> Generator[Any, None, MessageTracker | None]:
+        return self._value
         yield  # makes this a generator
 
-    def result(self) -> None:
-        return None
+    def result(self) -> MessageTracker | None:
+        return self._value
 
     def done(self) -> bool:
         return True
@@ -72,14 +84,51 @@ class _DoneFuture:
 _SEND_DONE: Final[_DoneFuture] = _DoneFuture()
 
 
+class _CleanupFuture(asyncio.Future[Any]):
+    def __init__(
+        self, *, loop: asyncio.AbstractEventLoop, cleanup: Callable[[], None]
+    ) -> None:
+        super().__init__(loop=loop)
+        self._cleanup = cleanup
+
+    def set_cleanup(self, cleanup: Callable[[], None]) -> None:
+        self._cleanup = cleanup
+
+    def cancel(self, msg: Any = None) -> bool:
+        cancelled = super().cancel(msg)
+        if cancelled:
+            self._cleanup()
+        return cancelled
+
+
 class _WindowsWaiter:
     """One loop-owned Windows readiness waiter."""
 
-    __slots__ = ("future", "try_fn")
+    __slots__ = ("cleanup", "future", "try_fn")
 
-    def __init__(self, future: asyncio.Future[Any], try_fn: Callable[[], Any]) -> None:
+    def __init__(
+        self,
+        future: asyncio.Future[Any],
+        try_fn: Callable[[], Any],
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
         self.future = future
         self.try_fn = try_fn
+        self.cleanup = cleanup
+
+    def release(self) -> None:
+        if self.cleanup is not None:
+            cleanup, self.cleanup = self.cleanup, None
+            cleanup()
+
+    def cancel(self) -> None:
+        self.release()
+        self.future.cancel()
+
+    def fail(self, exc: Exception) -> None:
+        self.release()
+        if not self.future.done():
+            self.future.set_exception(exc)
 
     def __call__(self) -> bool:
         future = self.future
@@ -92,26 +141,43 @@ class _WindowsWaiter:
                 future.set_exception(error)
             return True
         if result is not None and not future.done():
-            future.set_result(result)
+            future.set_result(None if result is _SEND_DONE else result)
             return True
         return False
 
 
-class _RecvFuture:
+class _RecvFuture[T]:
     """Supports both ``await fut`` (event-loop) and ``fut.result()`` (blocking)."""
 
-    __slots__ = ("_try_fn", "_fd", "_result", "_exception")
+    __slots__ = ("_cleanup", "_exception", "_fd", "_result", "_try_fn")
 
     _try_fn: Callable[[], Any]
     _fd: int
     _result: Any
-    _exception: Exception | None
+    _exception: BaseException | None
 
-    def __init__(self, try_fn: Callable[[], Any], fd: int) -> None:
+    def __init__(
+        self,
+        try_fn: Callable[[], Any],
+        fd: int,
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
         self._try_fn = try_fn
         self._fd = fd
         self._result = _MISSING
         self._exception = None
+        self._cleanup = cleanup
+
+    def _finish(self) -> None:
+        fd, self._fd = self._fd, -1
+        cleanup, self._cleanup = self._cleanup, None
+        if fd >= 0:
+            os.close(fd)
+        if cleanup is not None:
+            cleanup()
+
+    def __del__(self) -> None:
+        self._finish()
 
     def done(self) -> bool:
         if self._result is not _MISSING or self._exception is not None:
@@ -120,17 +186,19 @@ class _RecvFuture:
             r = self._try_fn()
         except Exception as e:
             self._exception = e
+            self._finish()
             return True
         if r is not None:
             self._result = r
+            self._finish()
             return True
         return False
 
-    def result(self) -> Any:
+    def result(self) -> T:
         if self._exception is not None:
             raise self._exception
         if self._result is not _MISSING:
-            return self._result
+            return cast(T, None if self._result is _SEND_DONE else self._result)
         try:
             while True:
                 _select.select([self._fd], [], [])
@@ -145,20 +213,15 @@ class _RecvFuture:
                     raise
                 if r is not None:
                     self._result = r
-                    return r
+                    return cast(T, None if r is _SEND_DONE else r)
         finally:
-            if self._fd >= 0:
-                os.close(self._fd)
-                self._fd = -1
+            self._finish()
 
-    def __await__(self) -> Any:
+    def __await__(self) -> Generator[Any, None, T]:
         if self.done():
-            if self._fd >= 0:
-                os.close(self._fd)
-                self._fd = -1
             if self._exception is not None:
                 raise self._exception
-            return self._result
+            return cast(T, None if self._result is _SEND_DONE else self._result)
 
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[Any] = loop.create_future()
@@ -167,8 +230,10 @@ class _RecvFuture:
         try_fn = self._try_fn
 
         def _on_readable() -> None:
-            # Check fut.done() before closing. After cancellation,
-            # _on_cancel owns the descriptor.
+            # A queued callback may run after cancellation. Do not consume
+            # a message or touch a descriptor now owned by _on_cancel.
+            if fut.done():
+                return
             try:
                 os.read(fd, 8)
             except OSError:
@@ -191,7 +256,7 @@ class _RecvFuture:
                     return
                 loop.remove_reader(fd)
                 os.close(fd)
-                fut.set_result(r)
+                fut.set_result(None if r is _SEND_DONE else r)
 
         def _on_cancel(f: asyncio.Future[Any]) -> None:
             if f.cancelled():
@@ -200,7 +265,14 @@ class _RecvFuture:
 
         fut.add_done_callback(_on_cancel)
         loop.add_reader(fd, _on_readable)
-        return (yield from fut.__await__())
+        try:
+            self._result = yield from fut.__await__()
+            return cast(T, self._result)
+        except BaseException as exc:
+            self._exception = exc
+            raise
+        finally:
+            self._finish()
 
 
 class Socket(_BaseSocket):
@@ -217,11 +289,11 @@ class Socket(_BaseSocket):
     _wakeup_registered: bool
 
     def _init_socket_state(self, _sock: _native.AsyncSocket, _context: Context) -> None:
-        self._sock = _sock
-        self._context = _context
+        self._sock = _sock  # pyright: ignore[reportIncompatibleVariableOverride]
+        self._context = _context  # pyright: ignore[reportIncompatibleVariableOverride]
         self._closed = False
-        self._last_endpoint = None
-        if _IS_WINDOWS:
+        self._last_endpoint = b""
+        if sys.platform == "win32":
             self._loop = None
             self._recv_waiters = deque()
             self._send_waiters = deque()
@@ -236,51 +308,151 @@ class Socket(_BaseSocket):
         st = _TYPE_NAMES.get(self.socket_type, str(self.socket_type))
         return f"<pyomq.asyncio.Socket(pyomq.{st}) at {id(self):#x}>"
 
+    def close(self, linger: int | None = None) -> None:
+        if not self._closed and sys.platform == "win32":
+            for waiter in tuple(self._recv_waiters) + tuple(self._send_waiters):
+                waiter.fail(error.ZMQError("socket closed"))
+            self._recv_waiters.clear()
+            self._send_waiters.clear()
+        super().close(linger)
+
+    @property
+    def context(self) -> Context:
+        return self._context
+
     def send(
         self,
-        data: Any,
+        data: SENDABLE_TYPES,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Awaitable[Any | None]:
+        routing_id: int | None = None,
+        group: str | None = None,
+    ) -> FutureResult[MessageTracker | None]:
         try:
-            self._sock.send(data, flags, copy)
+            if group is not None:
+                if routing_id is not None:
+                    raise ValueError("routing_id and group are mutually exclusive")
+                result = self._sock._send_with_group(data, group, flags, copy, track)
+            elif routing_id is None:
+                result = self._sock.send(data, flags, copy, track)
+            else:
+                result = self._sock._send_with_routing(
+                    data, routing_id, flags, copy, track
+                )
         except _native.ZMQError as e:
             if e.errno == _EAGAIN:
-                return self._send_with_backpressure(data, flags, copy)
+                return self._send_with_backpressure(e._pending_send)
             raise error.from_native(e) from None
-        return _SEND_DONE
+        return _SEND_DONE if result is None else _DoneFuture(result)
+
+    @overload
+    def recv(
+        self, flags: int = 0, copy: Literal[True] = True, track: bool = False
+    ) -> FutureResult[bytes]: ...
+
+    @overload
+    def recv(
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
+    ) -> FutureResult[Frame]: ...
+
+    @overload
+    def recv(
+        self, flags: int, copy: Literal[False], track: bool = False
+    ) -> FutureResult[Frame]: ...
+
+    @overload
+    def recv(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> FutureResult[bytes | Frame]: ...
 
     def recv(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Awaitable[bytes | Any]:
-        if not copy:
+    ) -> FutureResult[bytes | Frame]:
+        if copy:
+            return self._add_recv_event(self._sock._try_recv)
+        if not track:
             return self._add_recv_event(self._sock._try_recv_frame)
-        return self._add_recv_event(self._sock._try_recv)
+        return self._add_recv_event(self._try_recv_tracked_frame)
+
+    def _try_recv_tracked_frame(self) -> Frame | None:
+        # Keep tracking outside recv(): even an unused closure makes Python
+        # allocate a cell for self on every untracked fast-path receive.
+        result = self._sock._try_recv_frame()
+        if result is not None:
+            result._track_received()
+        return result
 
     def send_multipart(
         self,
-        parts: list[Any],
+        msg_parts: Iterable[SENDABLE_TYPES],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-    ) -> Awaitable[Any | None]:
+        routing_id: int | None = None,
+        group: str | None = None,
+    ) -> FutureResult[MessageTracker | None]:
         try:
-            self._sock.send_multipart(parts, flags, copy)
+            if group is not None:
+                if routing_id is not None:
+                    raise ValueError("routing_id and group are mutually exclusive")
+                result = self._sock._send_multipart_with_group(
+                    msg_parts, group, flags, copy, track
+                )
+            elif routing_id is None:
+                result = self._sock.send_multipart(msg_parts, flags, copy, track)
+            else:
+                result = self._sock._send_multipart_with_routing(
+                    msg_parts, routing_id, flags, copy, track
+                )
         except _native.ZMQError as e:
             if e.errno == _EAGAIN:
-                return self._send_multipart_with_backpressure(parts, flags, copy)
+                return self._send_with_backpressure(e._pending_send)
             raise error.from_native(e) from None
-        return _SEND_DONE
+        return _SEND_DONE if result is None else _DoneFuture(result)
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: Literal[True] = True, track: bool = False
+    ) -> FutureResult[list[bytes]]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, *, copy: Literal[False], track: bool = False
+    ) -> FutureResult[list[Frame]]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int, copy: Literal[False], track: bool = False
+    ) -> FutureResult[list[Frame]]: ...
+
+    @overload
+    def recv_multipart(
+        self, flags: int = 0, copy: bool = True, track: bool = False
+    ) -> FutureResult[list[bytes] | list[Frame]]: ...
 
     def recv_multipart(
         self, flags: int = 0, copy: bool = True, track: bool = False
-    ) -> Awaitable[list[bytes] | list[Any]]:
-        if not copy:
+    ) -> FutureResult[list[bytes] | list[Frame]]:
+        if copy:
+            return self._add_recv_event(self._sock._try_recv_multipart)
+        if not track:
             return self._add_recv_event(self._sock._try_recv_multipart_frames)
-        return self._add_recv_event(self._sock._try_recv_multipart)
+        return self._add_recv_event(self._try_recv_tracked_frames)
 
-    if _IS_WINDOWS:
+    def _try_recv_tracked_frames(self) -> list[Frame] | None:
+        result = self._sock._try_recv_multipart_frames()
+        if result is not None:
+            for frame in result:
+                frame._track_received()
+        return result
+
+    async def recv_into(
+        self, buffer: Any, /, *, nbytes: int = 0, flags: int = 0
+    ) -> int:
+        return _copy_received_into(buffer, await self.recv(flags), nbytes)
+
+    if sys.platform == "win32":
 
         def _register_wakeup_hooks(self) -> None:
             if not self._wakeup_registered:
@@ -378,6 +550,7 @@ class Socket(_BaseSocket):
             waiters: deque[_WindowsWaiter],
             set_mode: Callable[[], None],
             clear_mode: Callable[[], None],
+            cleanup: Callable[[], None] | None = None,
         ) -> asyncio.Future[Any]:
             """Register a Windows waiter that resolves when try_fn returns
             non-None. try_fn must return None when not ready and raise on
@@ -395,12 +568,19 @@ class Socket(_BaseSocket):
                 return _resolved_future(result)
 
             self._register_wakeup_hooks()
-            fut: asyncio.Future[Any] = loop.create_future()
-            waiter = _WindowsWaiter(fut, try_fn)
+            fut: asyncio.Future[Any]
+            if cleanup is None:
+                fut = loop.create_future()
+            else:
+                fut = _CleanupFuture(loop=loop, cleanup=cleanup)
+            waiter = _WindowsWaiter(fut, try_fn, cleanup)
+            if isinstance(fut, _CleanupFuture):
+                fut.set_cleanup(waiter.release)
 
             def _on_cancel(done: asyncio.Future[Any]) -> None:
                 if not done.cancelled():
                     return
+                waiter.release()
                 try:
                     waiters.remove(waiter)
                 except ValueError:
@@ -441,42 +621,25 @@ class Socket(_BaseSocket):
             )
 
         def _send_with_backpressure(
-            self, data: Any, flags: int, copy: bool
-        ) -> asyncio.Future[Any]:
-            def try_send() -> bool | None:
+            self, pending: _native.PendingSend
+        ) -> asyncio.Future[MessageTracker | None]:
+            def try_send():
                 try:
-                    self._sock.send(data, flags, copy)
-                    return True
+                    result = pending.retry()
+                    return _SEND_DONE if result is None else result
                 except _native.ZMQError as e:
-                    if e.errno == _errno.EAGAIN:
+                    if e.errno == _EAGAIN:
                         return None
                     raise error.from_native(e) from None
 
-            return self._add_waitable(
+            future = self._add_waitable(
                 try_send,
                 self._send_waiters,
                 lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
                 lambda: self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
+                pending.cancel,
             )
-
-        def _send_multipart_with_backpressure(
-            self, parts: list[Any], flags: int, copy: bool
-        ) -> asyncio.Future[Any]:
-            def try_send() -> bool | None:
-                try:
-                    self._sock.send_multipart(parts, flags, copy)
-                    return True
-                except _native.ZMQError as e:
-                    if e.errno == _errno.EAGAIN:
-                        return None
-                    raise error.from_native(e) from None
-
-            return self._add_waitable(
-                try_send,
-                self._send_waiters,
-                lambda: self._set_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
-                lambda: self._clear_wakeup_modes(send_mode=_WAKEUP_MODE_ASYNC),
-            )
+            return future
     else:
 
         def _add_recv_event(
@@ -504,42 +667,26 @@ class Socket(_BaseSocket):
             return _RecvFuture(try_fn, fd)
 
         def _send_with_backpressure(
-            self, data: Any, flags: int, copy: bool
-        ) -> _RecvFuture:
+            self, pending: _native.PendingSend
+        ) -> _RecvFuture[MessageTracker | None]:
             fd = self._sock._send_fd()
 
-            def try_send() -> bool | None:
+            def try_send():
                 try:
-                    self._sock.send(data, flags, copy)
-                    return True
+                    result = pending.retry()
+                    return _SEND_DONE if result is None else result
                 except _native.ZMQError as e:
                     if e.errno == _EAGAIN:
                         return None
-                    raise
+                    raise error.from_native(e) from None
 
-            return _RecvFuture(try_send, fd)
-
-        def _send_multipart_with_backpressure(
-            self, parts: list[Any], flags: int, copy: bool
-        ) -> _RecvFuture:
-            fd = self._sock._send_fd()
-
-            def try_send() -> bool | None:
-                try:
-                    self._sock.send_multipart(parts, flags, copy)
-                    return True
-                except _native.ZMQError as e:
-                    if e.errno == _EAGAIN:
-                        return None
-                    raise
-
-            return _RecvFuture(try_send, fd)
+            return _RecvFuture(try_send, fd, pending.cancel)
 
     # ── Serialization helpers ────────────────────────────────────────
 
     def send_string(
         self, u: str, flags: int = 0, encoding: str = "utf-8"
-    ) -> Awaitable[Any | None]:
+    ) -> FutureResult[MessageTracker | None]:
         return self.send(u.encode(encoding), flags)
 
     async def recv_string(self, flags: int = 0, encoding: str = "utf-8") -> str:
@@ -547,7 +694,7 @@ class Socket(_BaseSocket):
 
     def send_json(
         self, obj: Any, flags: int = 0, **kwargs: Any
-    ) -> Awaitable[Any | None]:
+    ) -> FutureResult[MessageTracker | None]:
         return self.send(json.dumps(obj, **kwargs).encode("utf-8"), flags)
 
     async def recv_json(self, flags: int = 0, **kwargs: Any) -> Any:
@@ -555,29 +702,56 @@ class Socket(_BaseSocket):
 
     def send_pyobj(
         self, obj: Any, flags: int = 0, protocol: int = -1
-    ) -> Awaitable[Any | None]:
+    ) -> FutureResult[MessageTracker | None]:
         return self.send(pickle.dumps(obj, protocol), flags)
 
     async def recv_pyobj(self, flags: int = 0) -> Any:
         return pickle.loads(await self.recv(flags))
 
-    def send_serialized(
+    def send_serialized[T](
         self,
-        msg: Any,
-        serialize: Callable[[Any], list[bytes | str]],
+        msg: T,
+        serialize: Callable[[T], Iterable[SENDABLE_TYPES]],
         flags: int = 0,
         copy: bool = True,
         **kwargs: Any,
-    ) -> Awaitable[Any | None]:
+    ) -> FutureResult[MessageTracker | None]:
         frames = serialize(msg)
         return self.send_multipart(frames, flags=flags, copy=copy, **kwargs)
 
-    async def recv_serialized(
+    @overload
+    async def recv_serialized[T](
         self,
-        deserialize: Callable[[list[bytes]], Any],
+        deserialize: Callable[[list[bytes]], T],
+        flags: int = 0,
+        copy: Literal[True] = True,
+    ) -> T: ...
+
+    @overload
+    async def recv_serialized[T](
+        self,
+        deserialize: Callable[[list[Frame]], T],
+        flags: int = 0,
+        *,
+        copy: Literal[False],
+    ) -> T: ...
+
+    @overload
+    async def recv_serialized[T](
+        self, deserialize: Callable[[list[Frame]], T], flags: int, copy: Literal[False]
+    ) -> T: ...
+
+    @overload
+    async def recv_serialized[T](
+        self,
+        deserialize: Callable[[list[bytes] | list[Frame]], T],
         flags: int = 0,
         copy: bool = True,
-    ) -> Any:
+    ) -> T: ...
+
+    async def recv_serialized[T](
+        self, deserialize: Callable[[Any], T], flags: int = 0, copy: bool = True
+    ) -> T:
         frames = await self.recv_multipart(flags=flags, copy=copy)
         return deserialize(frames)
 
@@ -600,10 +774,15 @@ class Socket(_BaseSocket):
                 return mask
         return 0
 
-    async def __aenter__(self) -> Socket:
+    async def __aenter__(self) -> Self:
         return self
 
-    async def __aexit__(self, *args: Any) -> bool:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: types.TracebackType | None = None,
+    ) -> bool:
         self.close()
         return False
 
@@ -653,7 +832,9 @@ class Poller:
 class Context(_SyncContext):
     """Async context for creating ZMQ sockets."""
 
-    _socket_class: type | None = None
+    # Preserve the public runtime inheritance while replacing the sync
+    # constructor, native storage, and socket factory with async equivalents.
+    _socket_class: type | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
     _ctx: _native.AsyncContext
     _is_shadow: bool
     _closed: bool
@@ -661,8 +842,23 @@ class Context(_SyncContext):
     _ctx_id: int
 
     def __init__(
-        self, io_threads: int = 1, *, _shadow_ctx: _SyncContext | None = None
+        self,
+        io_threads: int | _SyncContext = 1,
+        shadow: _SyncContext | int = 0,
+        *,
+        _shadow_ctx: _SyncContext | None = None,
     ) -> None:
+        if isinstance(io_threads, _SyncContext):
+            if shadow != 0 or _shadow_ctx is not None:
+                raise TypeError("shadow context specified more than once")
+            shadow = io_threads
+            io_threads = 1
+        if shadow != 0:
+            if _shadow_ctx is not None:
+                raise TypeError("shadow context specified more than once")
+            if not isinstance(shadow, _SyncContext):
+                raise TypeError("shadow must be a pyomq Context")
+            _shadow_ctx = shadow
         if _shadow_ctx is not None:
             if isinstance(_shadow_ctx._ctx, _native.Context):
                 self._ctx = _native.AsyncContext.shadow_sync(_shadow_ctx._ctx)
@@ -670,10 +866,10 @@ class Context(_SyncContext):
                 self._ctx = _shadow_ctx._ctx
             self._is_shadow = True
         else:
-            self._ctx = _native.AsyncContext(io_threads)
+            self._ctx = _native.AsyncContext(io_threads)  # pyright: ignore[reportIncompatibleVariableOverride]
             self._is_shadow = False
         self._closed = False
-        self._sockets = weakref.WeakSet()
+        self._sockets = weakref.WeakSet()  # pyright: ignore[reportIncompatibleVariableOverride]
         self._ctx_id = (
             _shadow_ctx._ctx_id if _shadow_ctx is not None else next(_next_ctx_id)
         )
@@ -682,7 +878,17 @@ class Context(_SyncContext):
     def closed(self) -> bool:
         return self._closed
 
+    @overload
     def socket(
+        self, socket_type: int, socket_class: None = None, **kwargs: Any
+    ) -> Socket: ...
+
+    @overload
+    def socket[S: Socket](
+        self, socket_type: int, socket_class: type[S], **kwargs: Any
+    ) -> S: ...
+
+    def socket(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         socket_type: int,
         socket_class: type[Socket] | None = None,
@@ -694,7 +900,7 @@ class Context(_SyncContext):
         s._sock = native
         s._context = self
         s._closed = False
-        s._last_endpoint = None
+        s._last_endpoint = b""
         s._pid = os.getpid()
         s._binds = []
         s._connects = []
@@ -703,7 +909,7 @@ class Context(_SyncContext):
         return s
 
     @classmethod
-    def from_share_key(cls, key: int) -> Context:
+    def from_share_key(cls, key: int) -> Self:
         obj = object.__new__(cls)
         obj._ctx = _native.AsyncContext.from_share_key(key)
         obj._is_shadow = True
@@ -734,14 +940,19 @@ class Context(_SyncContext):
         if not self._closed:
             self.term()
 
-    def __enter__(self) -> Context:
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, *args: Any) -> bool:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> bool:
         self.term()
         return False
 
 
 Context._socket_class = Socket
 
-__all__ = ["Context", "Socket", "Poller"]
+__all__ = ["Context", "Poller", "Socket"]

--- a/bindings/pyomq/python/pyomq/error.py
+++ b/bindings/pyomq/python/pyomq/error.py
@@ -11,8 +11,19 @@ import builtins
 import errno as _errno
 from typing import Final
 
-from ._native import ZMQBaseError as ZMQBaseError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
-from ._native import ZMQError as ZMQError  # type: ignore[attr-defined]  # ty:ignore[unresolved-import]
+from ._native import ZMQBaseError, ZMQError
+
+__all__ = [
+    "Again",
+    "ContextTerminated",
+    "InterruptedSystemCall",
+    "NotImplementedError",
+    "ZMQBaseError",
+    "ZMQBindError",
+    "ZMQError",
+    "ZMQVersionError",
+    "from_native",
+]
 
 
 class Again(ZMQError):
@@ -23,7 +34,7 @@ class ContextTerminated(ZMQError):
     """Operation issued against a terminated Context (``ETERM`` ≈ 156)."""
 
 
-class NotImplementedError(ZMQError):  # noqa: A001  shadow OK; matches pyzmq
+class NotImplementedError(ZMQError):
     """The requested option / feature is not implemented in pyomq."""
 
 

--- a/bindings/pyomq/python/pyomq/zmqstream.py
+++ b/bindings/pyomq/python/pyomq/zmqstream.py
@@ -9,12 +9,23 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Callable
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import pyomq
 
+from . import SENDABLE_TYPES
+from ._typing import _BytesOption, _IntOption
 
-def _get_IOLoop() -> type:
+if TYPE_CHECKING:
+    from tornado.ioloop import IOLoop
+
+type SendCallback = Callable[
+    [list[SENDABLE_TYPES], pyomq.MessageTracker | None], object
+]
+
+
+def _get_IOLoop() -> type[IOLoop]:
     from tornado.ioloop import IOLoop
 
     return IOLoop
@@ -24,18 +35,18 @@ class ZMQStream:
     """Integration layer for pyomq sockets with Tornado IOLoop."""
 
     socket: pyomq.Socket
-    io_loop: Any  # tornado.ioloop.IOLoop
-    _recv_callback: Callable[[Any], Any] | None
+    io_loop: IOLoop
+    _recv_callback: Callable[[Any], object] | None
     _recv_copy: bool
-    _send_callback: Callable[[Any, Any | None], Any] | None
+    _send_callback: SendCallback | None
     _closed: bool
     _fd: int
     _watching: bool
 
-    def __init__(self, socket: pyomq.Socket, io_loop: Any | None = None) -> None:
+    def __init__(self, socket: pyomq.Socket, io_loop: IOLoop | None = None) -> None:
         IOLoop = _get_IOLoop()
         self.socket = socket
-        self.io_loop = io_loop or IOLoop.current()  # type: ignore[ty:unresolved-attribute]
+        self.io_loop = io_loop or IOLoop.current()
         self._recv_callback = None
         self._recv_copy = True
         self._send_callback = None
@@ -43,7 +54,30 @@ class ZMQStream:
         self._fd = socket.getsockopt(pyomq.FD)
         self._watching = False
 
-    def on_recv(self, callback: Callable[[Any], Any] | None, copy: bool = True) -> None:
+    @overload
+    def on_recv(
+        self,
+        callback: Callable[[list[bytes]], object] | None,
+        copy: Literal[True] = True,
+    ) -> None: ...
+
+    @overload
+    def on_recv(
+        self,
+        callback: Callable[[list[pyomq.Frame]], object] | None,
+        copy: Literal[False],
+    ) -> None: ...
+
+    @overload
+    def on_recv(
+        self,
+        callback: Callable[[list[bytes] | list[pyomq.Frame]], object] | None,
+        copy: bool = True,
+    ) -> None: ...
+
+    def on_recv(
+        self, callback: Callable[[Any], object] | None, copy: bool = True
+    ) -> None:
         """Set a callback to be invoked when messages are received."""
         self._recv_callback = callback
         self._recv_copy = copy
@@ -52,7 +86,7 @@ class ZMQStream:
         else:
             self._stop_watching()
 
-    def on_send(self, callback: Callable[[Any, Any | None], Any] | None) -> None:
+    def on_send(self, callback: SendCallback | None) -> None:
         """Set a callback to be invoked when sends complete."""
         self._send_callback = callback
 
@@ -66,37 +100,43 @@ class ZMQStream:
 
     def send(
         self,
-        msg: bytes | str,
+        msg: SENDABLE_TYPES,
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-        callback: Callable[[Any, Any], Any] | None = None,
+        callback: SendCallback | None = None,
         **kwargs: Any,
-    ) -> Any:
+    ) -> pyomq.MessageTracker | None:
         """Send a message."""
         result = self.socket.send(msg, flags=flags, copy=copy, track=track)
-        if self._send_callback:
-            self._send_callback(msg, None)
+        if callback is None:
+            callback = self._send_callback
+        if callback is not None:
+            callback([msg], result)
         return result
 
     def send_multipart(
         self,
-        msg_list: list[bytes | str],
+        msg_list: Iterable[SENDABLE_TYPES],
         flags: int = 0,
         copy: bool = True,
         track: bool = False,
-        callback: Callable[[Any, Any], Any] | None = None,
+        callback: SendCallback | None = None,
         **kwargs: Any,
-    ) -> Any:
+    ) -> pyomq.MessageTracker | None:
         """Send a multipart message."""
+        if callback is None:
+            callback = self._send_callback
+        # Materialize one-shot iterables only when a callback needs them too.
+        callback_parts = None if callback is None else list(msg_list)
         result = self.socket.send_multipart(
-            msg_list,
+            msg_list if callback_parts is None else callback_parts,
             flags=flags,
             copy=copy,
             track=track,
         )
-        if self._send_callback:
-            self._send_callback(msg_list, None)
+        if callback is not None and callback_parts is not None:
+            callback(callback_parts, result)
         return result
 
     def flush(self, flag: int = 3, limit: int | None = None) -> None:
@@ -144,9 +184,9 @@ class ZMQStream:
             if self._closed or self._watching:
                 return
             try:
-                io_loop.add_handler(fd, handler, _get_IOLoop().READ)  # type: ignore[ty:unresolved-attribute]
+                io_loop.add_handler(fd, handler, _get_IOLoop().READ)
                 self._watching = True
-            except Exception:
+            except Exception:  # noqa S110
                 pass
 
         try:
@@ -161,7 +201,7 @@ class ZMQStream:
         self._watching = False
         try:
             self.io_loop.remove_handler(self._fd)
-        except Exception:
+        except Exception:  # noqa BLE001
             pass
 
     def close(self, linger: int | None = None) -> None:
@@ -171,11 +211,23 @@ class ZMQStream:
         self._closed = True
         self._stop_watching()
 
-    def setsockopt(self, opt: int, value: Any) -> Any:
+    def setsockopt(self, opt: int, value: int | bytes) -> None:
         """Set a socket option."""
         return self.socket.setsockopt(opt, value)
 
-    def getsockopt(self, opt: int) -> Any:
+    @overload
+    def getsockopt(self, opt: _BytesOption) -> bytes: ...
+
+    @overload
+    def getsockopt(self, opt: _IntOption) -> int: ...
+
+    @overload
+    def getsockopt(self, opt: Literal[32]) -> bytes | None: ...
+
+    @overload
+    def getsockopt(self, opt: int) -> int | bytes | None: ...
+
+    def getsockopt(self, opt: int) -> int | bytes | None:
         """Get a socket option."""
         return self.socket.getsockopt(opt)
 

--- a/bindings/pyomq/scripts/update_perf.py
+++ b/bindings/pyomq/scripts/update_perf.py
@@ -57,8 +57,7 @@ def load_jsonl():
 def append_jsonl(rows):
     os.makedirs(os.path.dirname(JSONL_FILE), exist_ok=True)
     with open(JSONL_FILE, "a") as f:
-        for r in rows:
-            f.write(json.dumps(r) + "\n")
+        f.writelines(json.dumps(r) + "\n" for r in rows)
 
 
 def save_results(
@@ -375,6 +374,7 @@ def _run_subprocess(code, label, timeout=None, retries=None):
             capture_output=True,
             text=True,
             timeout=timeout,
+            check=False,
         )
     except subprocess.TimeoutExpired as error:
         raise RuntimeError(f"{label} timeout after {timeout}s") from error
@@ -1150,6 +1150,7 @@ sys.stdout.flush(); os._exit(0)
             capture_output=True,
             text=True,
             timeout=LATENCY_TIMEOUT_S,
+            check=False,
         )
         if r.returncode != 0:
             return 0.0
@@ -1229,6 +1230,7 @@ except Exception:
             capture_output=True,
             text=True,
             timeout=duration + 10,
+            check=False,
         )
         if r.returncode != 0:
             return 0.0
@@ -1668,10 +1670,14 @@ def build_proxy_table():
         [
             "|                    | pyomq     | pyzmq     | ratio     |",
             "|--------------------|----------:|----------:|----------:|",
-            f"| PUSH/PULL msg/s    | {fmt_rate(pp_omq):>9} "
-            f"| {fmt_rate(pp_pz):>9} | **{pp_ratio:.2f}x** |",
-            f"| REQ/REP rt/s       | {fmt_int(rr_omq) + '/s':>9} "
-            f"| {fmt_int(rr_pz) + '/s':>9} | **{rr_ratio:.2f}x** |",
+            (
+                f"| PUSH/PULL msg/s    | {fmt_rate(pp_omq):>9} "
+                f"| {fmt_rate(pp_pz):>9} | **{pp_ratio:.2f}x** |"
+            ),
+            (
+                f"| REQ/REP rt/s       | {fmt_int(rr_omq) + '/s':>9} "
+                f"| {fmt_int(rr_pz) + '/s':>9} | **{rr_ratio:.2f}x** |"
+            ),
         ]
     )
 

--- a/bindings/pyomq/src/auth.rs
+++ b/bindings/pyomq/src/auth.rs
@@ -149,11 +149,15 @@ pub(crate) fn set_plain_auth_impl(inner: &SocketInner, auth: &Bound<'_, PyAny>) 
     let policy = if auth.is_callable() {
         PlainAuthenticator::Callback(auth.clone().unbind())
     } else {
-        let credentials: Vec<(String, String)> = auth.extract().map_err(|_| {
-            pyo3::exceptions::PyTypeError::new_err(
-                "set_plain_auth expects an iterable of (username, password) pairs or a callable",
-            )
-        })?;
+        let credentials: Vec<(String, String)> = auth
+            .try_iter()
+            .and_then(|items| items.map(|item| item?.extract()).collect())
+            .map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(concat!(
+                    "set_plain_auth expects an iterable of ",
+                    "(username, password) pairs or a callable",
+                ))
+            })?;
         for (username, password) in &credentials {
             if username.len() > 255
                 || password.len() > 255

--- a/bindings/pyomq/src/conversions.rs
+++ b/bindings/pyomq/src/conversions.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use omq_proto::message::Message;
-use pyo3::buffer::PyBuffer;
+use pyo3::buffer::PyUntypedBuffer;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList};
 
@@ -51,13 +51,13 @@ impl AsRef<[u8]> for PyBytesOwner {
 /// backing storage as `&[u8]`.
 ///
 /// SAFETY:
-/// - `PyBuffer<u8>` pins the exporter according to Python's buffer
+/// - `PyUntypedBuffer` pins the exporter according to Python's buffer
 ///   protocol until release/drop.
-/// - We only construct this for C-contiguous `u8` buffers.
+/// - We only construct this for contiguous buffers, viewed as raw bytes.
 /// - `copy=False` callers are responsible for not mutating the backing
 ///   object until the send completes, matching PyZMQ's zero-copy contract.
 struct PyBufferOwner {
-    _buffer: PyBuffer<u8>,
+    _buffer: PyUntypedBuffer,
     ptr: *const u8,
     len: usize,
 }
@@ -73,7 +73,7 @@ impl AsRef<[u8]> for PyBufferOwner {
 
 /// Build a `Bytes` from a Python bytes-like object. Immutable `bytes`
 /// use zero-copy ownership. Buffer-protocol objects copy by default,
-/// and use zero-copy ownership for C-contiguous `u8` buffers only when
+/// and use zero-copy ownership for contiguous buffers only when
 /// the caller requested `copy=False`.
 pub fn bytes_from_pyany(b: &Bound<'_, PyAny>, copy: bool) -> PyResult<Bytes> {
     if let Ok(frame) = b.cast::<Frame>() {
@@ -82,18 +82,64 @@ pub fn bytes_from_pyany(b: &Bound<'_, PyAny>, copy: bool) -> PyResult<Bytes> {
     if let Ok(pb) = b.cast::<PyBytes>() {
         return Ok(Bytes::from_owner(PyBytesOwner::from_pybytes(pb)));
     }
-    if let Ok(buffer) = PyBuffer::<u8>::get(b) {
-        if !copy && buffer.as_slice(b.py()).is_some() {
-            return Ok(Bytes::from_owner(PyBufferOwner {
-                ptr: buffer.buf_ptr().cast(),
-                len: buffer.len_bytes(),
-                _buffer: buffer,
-            }));
-        }
-        return Ok(Bytes::from(buffer.to_vec(b.py())?));
+    let buffer = PyUntypedBuffer::get(b)?;
+    if !buffer.is_c_contiguous() && !buffer.is_fortran_contiguous() {
+        return Err(pyo3::exceptions::PyBufferError::new_err(
+            "buffer must be contiguous",
+        ));
     }
-    let view: &[u8] = b.extract()?;
+    if buffer.len_bytes() == 0 {
+        return Ok(Bytes::new());
+    }
+    if !copy {
+        return Ok(Bytes::from_owner(PyBufferOwner {
+            ptr: buffer.buf_ptr().cast(),
+            len: buffer.len_bytes(),
+            _buffer: buffer,
+        }));
+    }
+    // SAFETY: the export pins a contiguous allocation; the GIL remains held
+    // for this copy. Interpret raw bytes independently of element format.
+    let view =
+        unsafe { std::slice::from_raw_parts(buffer.buf_ptr().cast::<u8>(), buffer.len_bytes()) };
     Ok(Bytes::copy_from_slice(view))
+}
+
+pub(crate) fn payload_with_tracker(
+    b: &Bound<'_, PyAny>,
+    copy: bool,
+    track: bool,
+) -> PyResult<(Bytes, Option<Py<PyAny>>)> {
+    let (data, source) = payload_with_completion(b, copy, track)?;
+    let tracker = source
+        .map(|source| crate::tracker::from_source(b.py(), source))
+        .transpose()?;
+    Ok((data, tracker))
+}
+
+/// Raw buffers contribute tokens; Frames contribute their existing trackers.
+fn payload_with_completion(
+    b: &Bound<'_, PyAny>,
+    copy: bool,
+    track: bool,
+) -> PyResult<(Bytes, Option<Py<PyAny>>)> {
+    if let Ok(frame) = b.cast::<Frame>() {
+        let frame = frame.borrow();
+        let tracker = frame.tracker_clone(b.py());
+        if track && tracker.is_none() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Not a tracked message",
+            ));
+        }
+        return Ok((frame.bytes_clone(), tracker));
+    }
+    let data = bytes_from_pyany(b, copy)?;
+    if track && !copy {
+        let (data, token) = crate::tracker::track_buffer(b.py(), data)?;
+        Ok((data, Some(token.into_any())))
+    } else {
+        Ok((data, None))
+    }
 }
 
 pub fn routing_id_from_pyany(b: &Bound<'_, PyAny>) -> u32 {
@@ -102,26 +148,47 @@ pub fn routing_id_from_pyany(b: &Bound<'_, PyAny>) -> u32 {
         .unwrap_or(0)
 }
 
+pub fn group_from_pyany(b: &Bound<'_, PyAny>) -> Option<String> {
+    b.cast::<Frame>()
+        .ok()
+        .and_then(|frame| frame.borrow().group_value())
+}
+
 /// Build a multipart `Message` from a Python list/tuple of bytes-like.
-pub fn message_from_pylist(parts: &Bound<'_, PyAny>, copy: bool) -> PyResult<Message> {
+pub fn message_from_pylist(
+    parts: &Bound<'_, PyAny>,
+    copy: bool,
+    track: bool,
+) -> PyResult<(Message, Option<Py<PyAny>>)> {
     let it = parts.try_iter()?;
     let mut collected = Vec::new();
     let mut routing_id = 0;
+    let mut trackers = Vec::new();
     for part in it {
         let part = part?;
         routing_id = routing_id.max(routing_id_from_pyany(&part));
-        collected.push(bytes_from_pyany(&part, copy)?);
+        let (data, tracker) = payload_with_completion(&part, copy, track)?;
+        collected.push(data);
+        if let Some(tracker) = tracker {
+            trackers.push(tracker);
+        }
     }
     let message = match collected.len() {
         0 => Message::new(),
         1 => Message::single(collected.into_iter().next().unwrap()),
         _ => Message::multipart(collected),
     };
-    Ok(if routing_id == 0 {
+    let message = if routing_id == 0 {
         message
     } else {
         message.with_routing_id(routing_id)
-    })
+    };
+    let tracker = if track && !copy && trackers.is_empty() {
+        Some(crate::tracker::finished(parts.py())?)
+    } else {
+        crate::tracker::aggregate(parts.py(), trackers)?
+    };
+    Ok((message, tracker))
 }
 
 /// Return a Python list of bytes - one per message frame.

--- a/bindings/pyomq/src/frame.rs
+++ b/bindings/pyomq/src/frame.rs
@@ -13,6 +13,8 @@ pub struct Frame {
     data: Bytes,
     more: bool,
     routing_id: u32,
+    group: Option<String>,
+    tracker: Option<Py<PyAny>>,
 }
 
 impl Frame {
@@ -21,6 +23,8 @@ impl Frame {
             data,
             more: false,
             routing_id: 0,
+            group: None,
+            tracker: None,
         }
     }
 
@@ -29,6 +33,8 @@ impl Frame {
             data,
             more,
             routing_id: 0,
+            group: None,
+            tracker: None,
         }
     }
 
@@ -37,6 +43,23 @@ impl Frame {
             data,
             more,
             routing_id,
+            group: None,
+            tracker: None,
+        }
+    }
+
+    pub(crate) fn from_bytes_more_routing_group(
+        data: Bytes,
+        more: bool,
+        routing_id: u32,
+        group: String,
+    ) -> Self {
+        Self {
+            data,
+            more,
+            routing_id,
+            group: Some(group),
+            tracker: None,
         }
     }
 
@@ -47,6 +70,14 @@ impl Frame {
     pub(crate) fn routing_id_value(&self) -> u32 {
         self.routing_id
     }
+
+    pub(crate) fn group_value(&self) -> Option<String> {
+        self.group.clone()
+    }
+
+    pub(crate) fn tracker_clone(&self, py: Python<'_>) -> Option<Py<PyAny>> {
+        self.tracker.as_ref().map(|tracker| tracker.clone_ref(py))
+    }
 }
 
 #[pymethods]
@@ -54,19 +85,36 @@ impl Frame {
     #[new]
     #[pyo3(signature = (data=None, track=false, copy=None, copy_threshold=None))]
     fn new(
+        py: Python<'_>,
         data: Option<&Bound<'_, PyAny>>,
         track: bool,
         copy: Option<bool>,
         copy_threshold: Option<usize>,
     ) -> PyResult<Self> {
-        let _ = (track, copy, copy_threshold);
-        match data {
-            Some(data) => Ok(Self::from_bytes(crate::conversions::bytes_from_pyany(
-                data,
-                copy.unwrap_or(true),
-            )?)),
-            None => Ok(Self::from_bytes(Bytes::new())),
+        let mut frame = if let Some(data) = data {
+            let mut bytes = crate::conversions::bytes_from_pyany(data, false)?;
+            let copy = copy.unwrap_or(bytes.len() < copy_threshold.unwrap_or(65_536));
+            if copy {
+                bytes = Bytes::copy_from_slice(&bytes);
+            }
+            let mut frame = Self::from_bytes(bytes);
+            if track {
+                if copy {
+                    frame.tracker = Some(crate::tracker::finished(py)?);
+                } else {
+                    let (data, tracker) = crate::tracker::track(py, frame.data)?;
+                    frame.data = data;
+                    frame.tracker = Some(tracker);
+                }
+            }
+            frame
+        } else {
+            Self::from_bytes(Bytes::new())
+        };
+        if track && frame.tracker.is_none() {
+            frame.tracker = Some(crate::tracker::finished(py)?);
         }
+        Ok(frame)
     }
 
     #[getter]
@@ -95,8 +143,26 @@ impl Frame {
     }
 
     #[getter]
+    fn group(&self) -> Option<String> {
+        self.group.clone()
+    }
+
+    #[setter]
+    fn set_group(&mut self, group: Option<String>) {
+        self.group = group;
+    }
+
+    #[getter]
     fn tracker<'py>(&self, py: Python<'py>) -> Bound<'py, PyAny> {
-        py.None().bind(py).clone()
+        self.tracker.as_ref().map_or_else(
+            || py.None().bind(py).clone(),
+            |tracker| tracker.bind(py).clone(),
+        )
+    }
+
+    fn _track_received(&mut self, py: Python<'_>) -> PyResult<()> {
+        self.tracker = Some(crate::tracker::finished(py)?);
+        Ok(())
     }
 
     fn __bytes__<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {

--- a/bindings/pyomq/src/lib.rs
+++ b/bindings/pyomq/src/lib.rs
@@ -16,6 +16,7 @@ mod peer_info;
 mod runtime;
 mod socket;
 mod socket_async;
+mod tracker;
 
 use std::str::FromStr;
 use std::sync::Arc;
@@ -23,6 +24,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 use omq_proto::endpoint::Endpoint;
 use pyo3::prelude::*;
+#[cfg(feature = "curve")]
+use pyo3::types::PyBytes;
 
 /// Extractor that accepts either a sync `Socket` or an `AsyncSocket`,
 /// yielding the shared `SocketInner`.
@@ -55,6 +58,8 @@ fn _native(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<socket::Monitor>()?;
     m.add_class::<socket::Socket>()?;
     m.add_class::<socket_async::AsyncSocket>()?;
+    m.add_class::<socket_async::PendingSend>()?;
+    m.add_class::<tracker::ReleaseToken>()?;
     m.add_function(wrap_pyfunction!(backend_name, m)?)?;
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(wait_any, m)?)?;
@@ -159,18 +164,18 @@ fn native_proxy(
 
 #[cfg(feature = "curve")]
 #[pyfunction]
-fn curve_keypair(py: Python<'_>) -> PyResult<(Bound<'_, PyAny>, Bound<'_, PyAny>)> {
+fn curve_keypair(py: Python<'_>) -> PyResult<(Bound<'_, PyBytes>, Bound<'_, PyBytes>)> {
     let kp = omq_proto::CurveKeypair::generate();
     let pub_z85 = kp.public.to_z85();
     let sec_z85 = kp.secret.to_z85();
-    let pub_bytes = pyo3::types::PyBytes::new(py, pub_z85.as_bytes());
-    let sec_bytes = pyo3::types::PyBytes::new(py, sec_z85.as_bytes());
-    Ok((pub_bytes.into_any(), sec_bytes.into_any()))
+    let pub_bytes = PyBytes::new(py, pub_z85.as_bytes());
+    let sec_bytes = PyBytes::new(py, sec_z85.as_bytes());
+    Ok((pub_bytes, sec_bytes))
 }
 
 #[cfg(feature = "curve")]
 #[pyfunction]
-fn curve_public<'py>(py: Python<'py>, secret_z85: &[u8]) -> PyResult<Bound<'py, PyAny>> {
+fn curve_public<'py>(py: Python<'py>, secret_z85: &[u8]) -> PyResult<Bound<'py, PyBytes>> {
     let secret_str = std::str::from_utf8(secret_z85).map_err(|_| {
         pyo3::exceptions::PyValueError::new_err("secret key must be valid UTF-8 Z85")
     })?;
@@ -178,7 +183,7 @@ fn curve_public<'py>(py: Python<'py>, secret_z85: &[u8]) -> PyResult<Bound<'py, 
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     let pk = sk.derive_public();
     let pub_z85 = pk.to_z85();
-    Ok(pyo3::types::PyBytes::new(py, pub_z85.as_bytes()).into_any())
+    Ok(PyBytes::new(py, pub_z85.as_bytes()))
 }
 
 #[pyfunction]

--- a/bindings/pyomq/src/socket.rs
+++ b/bindings/pyomq/src/socket.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use omq_proto::TrySendError;
 use omq_proto::error::Error as PError;
 use omq_tokio::MonitorEvent;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyType};
 use tokio::task::JoinHandle;
@@ -41,6 +42,24 @@ static ATFORK_REGISTERED: std::sync::Once = std::sync::Once::new();
 
 fn deadline_after(timeout: Duration) -> Option<Instant> {
     Instant::now().checked_add(timeout)
+}
+
+pub(crate) fn split_dish_message(msg: omq_tokio::Message) -> PyResult<(String, Bytes)> {
+    let mut parts = msg.iter();
+    let group = parts
+        .next()
+        .ok_or_else(|| PyValueError::new_err("DISH received a message without a group"))?;
+    let body = parts
+        .next()
+        .ok_or_else(|| PyValueError::new_err("DISH received a message without a body"))?;
+    if parts.next().is_some() {
+        return Err(PyValueError::new_err(
+            "DISH received a multipart group message",
+        ));
+    }
+    let group = String::from_utf8(group.to_vec())
+        .map_err(|_| PyValueError::new_err("DISH received a non-UTF-8 group"))?;
+    Ok((group, body))
 }
 
 #[cfg(unix)]
@@ -106,6 +125,7 @@ pub(crate) struct SocketInner {
     pub sndbuf: Mutex<SendBuffer>,
     pub rxbuf: Mutex<Vec<Bytes>>,
     pub rxmsgs: Mutex<Vec<omq_tokio::Message>>,
+    pub pending_sends: Mutex<Vec<std::sync::Weak<crate::socket_async::PendingMessage>>>,
     pub materialized: std::sync::RwLock<Option<Materialized>>,
     pub blocking_materialized: std::sync::RwLock<Option<BlockingMaterialized>>,
     closed: AtomicBool,
@@ -129,6 +149,7 @@ impl SocketInner {
             sndbuf: Mutex::new(SendBuffer::default()),
             rxbuf: Mutex::new(Vec::new()),
             rxmsgs: Mutex::new(Vec::new()),
+            pending_sends: Mutex::new(Vec::new()),
             materialized: std::sync::RwLock::new(None),
             blocking_materialized: std::sync::RwLock::new(None),
             closed: AtomicBool::new(false),
@@ -344,6 +365,7 @@ impl SocketInner {
             state.recv_ready.force_wake();
             state.send_ready.force_wake();
         }
+        self.clear_buffers();
         materialized
     }
 
@@ -357,7 +379,24 @@ impl SocketInner {
             std::mem::forget(materialized);
             return None;
         }
+        self.clear_buffers();
         materialized
+    }
+
+    fn clear_buffers(&self) {
+        // Python buffer-release callbacks may reenter the socket. Move owners
+        // out of every lock before dropping them.
+        let parts = std::mem::take(&mut self.sndbuf.lock().unwrap().parts);
+        let received = std::mem::take(&mut *self.rxbuf.lock().unwrap());
+        let messages = std::mem::take(&mut *self.rxmsgs.lock().unwrap());
+        let pending_sends = std::mem::take(&mut *self.pending_sends.lock().unwrap());
+        for pending in pending_sends {
+            if let Some(pending) = pending.upgrade() {
+                let message = pending.lock().unwrap().take();
+                drop(message);
+            }
+        }
+        drop((parts, received, messages));
     }
 
     pub fn close_linger(&self, linger: Option<i64>) -> Option<Duration> {
@@ -468,7 +507,7 @@ impl Monitor {
     }
 }
 
-fn monitor_event_to_dict<'py>(py: Python<'py>, ev: &MonitorEvent) -> PyResult<Bound<'py, PyAny>> {
+fn monitor_event_to_dict<'py>(py: Python<'py>, ev: &MonitorEvent) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
     match ev {
         MonitorEvent::Listening { endpoint } => {
@@ -532,7 +571,7 @@ fn monitor_event_to_dict<'py>(py: Python<'py>, ev: &MonitorEvent) -> PyResult<Bo
             d.set_item("event", "unknown")?;
         }
     }
-    Ok(d.into_any())
+    Ok(d)
 }
 
 #[pymethods]
@@ -543,13 +582,13 @@ impl Monitor {
     /// Returns a dict with at minimum `{"event": "<name>"}` plus
     /// event-specific keys (`endpoint`, `connection_id`, etc.).
     #[pyo3(signature = (timeout_ms = -1))]
-    fn recv<'py>(&self, py: Python<'py>, timeout_ms: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn recv<'py>(&self, py: Python<'py>, timeout_ms: i64) -> PyResult<Bound<'py, PyDict>> {
         let n = self.lagged.swap(0, Ordering::Relaxed);
         if n > 0 {
             let d = PyDict::new(py);
             d.set_item("event", "lagged")?;
             d.set_item("count", n)?;
-            return Ok(d.into_any());
+            return Ok(d);
         }
         let ev = py.detach(|| {
             if timeout_ms < 0 {
@@ -568,13 +607,13 @@ impl Monitor {
 
     /// Try to receive without blocking. Raises `zmq.Again` if no event
     /// is available.
-    fn recv_nowait<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn recv_nowait<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let n = self.lagged.swap(0, Ordering::Relaxed);
         if n > 0 {
             let d = PyDict::new(py);
             d.set_item("event", "lagged")?;
             d.set_item("count", n)?;
-            return Ok(d.into_any());
+            return Ok(d);
         }
         match self.rx.try_recv() {
             Ok(ev) => monitor_event_to_dict(py, &ev),
@@ -665,40 +704,160 @@ impl Socket {
         dispatch::blocking_unit(&self.inner, py, move |s| s.disconnect(ep))
     }
 
-    #[pyo3(signature = (payload, flags = 0, copy = true))]
+    #[pyo3(signature = (payload, flags = 0, copy = true, track = false))]
     fn send(
         &self,
         py: Python<'_>,
         payload: &Bound<'_, PyAny>,
         flags: i32,
         copy: bool,
-    ) -> PyResult<()> {
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            let Some(group) = conversions::group_from_pyany(payload) else {
+                return Err(PyValueError::new_err(
+                    "RADIO requires a group; pass group= or set Frame.group",
+                ));
+            };
+            if flags & crate::constants::SNDMORE != 0 {
+                return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+            }
+            let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+            self.send_message(py, omq_tokio::Message::with_group(group, bytes))?;
+            return Ok(tracker);
+        }
         let routing_id = conversions::routing_id_from_pyany(payload);
-        let bytes = conversions::bytes_from_pyany(payload, copy)?;
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
         let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
-            return Ok(());
+            return Ok(tracker);
         };
         if routing_id != 0 {
             msg = msg.with_routing_id(routing_id);
         }
-        self.send_message(py, msg)
+        self.send_message(py, msg)?;
+        Ok(tracker)
     }
 
-    #[pyo3(signature = (parts, flags = 0, copy = true))]
+    #[pyo3(signature = (payload, group, flags = 0, copy = true, track = false))]
+    fn _send_with_group(
+        &self,
+        py: Python<'_>,
+        payload: &Bound<'_, PyAny>,
+        group: String,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if !matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "group is only valid on RADIO sockets",
+            ));
+        }
+        if flags & crate::constants::SNDMORE != 0 {
+            return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+        }
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+        self.send_message(py, omq_tokio::Message::with_group(group, bytes))?;
+        Ok(tracker)
+    }
+
+    #[pyo3(signature = (payload, routing_id, flags = 0, copy = true, track = false))]
+    fn _send_with_routing(
+        &self,
+        py: Python<'_>,
+        payload: &Bound<'_, PyAny>,
+        routing_id: u32,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+        let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
+            return Ok(tracker);
+        };
+        if routing_id != 0 {
+            msg = msg.with_routing_id(routing_id);
+        }
+        self.send_message(py, msg)?;
+        Ok(tracker)
+    }
+
+    #[pyo3(signature = (parts, flags = 0, copy = true, track = false))]
     fn send_multipart(
         &self,
         py: Python<'_>,
         parts: &Bound<'_, PyAny>,
         flags: i32,
         copy: bool,
-    ) -> PyResult<()> {
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "RADIO requires send(..., group=...) or send_multipart(..., group=...)",
+            ));
+        }
         let _ = flags;
-        let msg = conversions::message_from_pylist(parts, copy)?;
-        self.send_message(py, msg)
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        self.send_message(py, msg)?;
+        Ok(tracker)
+    }
+
+    #[pyo3(signature = (parts, group, flags = 0, copy = true, track = false))]
+    fn _send_multipart_with_group(
+        &self,
+        py: Python<'_>,
+        parts: &Bound<'_, PyAny>,
+        group: String,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if !matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "group is only valid on RADIO sockets",
+            ));
+        }
+        if flags & crate::constants::SNDMORE != 0 {
+            return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+        }
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        if msg.len() != 1 {
+            return Err(PyValueError::new_err(
+                "RADIO group send requires exactly one message part",
+            ));
+        }
+        let body = msg.part_bytes(0).expect("one-part message has a body");
+        self.send_message(py, omq_tokio::Message::with_group(group, body))?;
+        Ok(tracker)
+    }
+
+    #[pyo3(signature = (parts, routing_id, flags = 0, copy = true, track = false))]
+    fn _send_multipart_with_routing(
+        &self,
+        py: Python<'_>,
+        parts: &Bound<'_, PyAny>,
+        routing_id: u32,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        let _ = flags;
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        self.send_message(py, msg.with_routing_id(routing_id))?;
+        Ok(tracker)
     }
 
     #[pyo3(signature = (flags = 0))]
     fn recv<'py>(&self, py: Python<'py>, flags: i32) -> PyResult<Bound<'py, PyBytes>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Dish) {
+            let msg = if flags & crate::constants::NOBLOCK != 0 {
+                self.try_recv_message()?
+            } else {
+                self.recv_message(py)?
+            };
+            let (_, body) = split_dish_message(msg)?;
+            return Ok(PyBytes::new(py, &body));
+        }
         if let Some(head) = self.inner.pop_rxbuf_head() {
             return Ok(PyBytes::new(py, &head));
         }
@@ -721,6 +880,18 @@ impl Socket {
 
     #[pyo3(signature = (flags = 0))]
     fn recv_frame<'py>(&self, py: Python<'py>, flags: i32) -> PyResult<Bound<'py, Frame>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Dish) {
+            let msg = if flags & crate::constants::NOBLOCK != 0 {
+                self.try_recv_message()?
+            } else {
+                self.recv_message(py)?
+            };
+            let (group, body) = split_dish_message(msg)?;
+            return Bound::new(
+                py,
+                Frame::from_bytes_more_routing_group(body, false, 0, group),
+            );
+        }
         if let Some((head, more)) = self.inner.pop_rxbuf_head_with_more() {
             return Bound::new(py, Frame::from_bytes_more(head, more));
         }
@@ -745,6 +916,15 @@ impl Socket {
 
     #[pyo3(signature = (flags = 0))]
     fn recv_multipart<'py>(&self, py: Python<'py>, flags: i32) -> PyResult<Bound<'py, PyList>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Dish) {
+            let msg = if flags & crate::constants::NOBLOCK != 0 {
+                self.try_recv_message()?
+            } else {
+                self.recv_message(py)?
+            };
+            let (_, body) = split_dish_message(msg)?;
+            return PyList::new(py, [PyBytes::new(py, &body)]);
+        }
         let leftover = self.inner.take_rxbuf();
         if !leftover.is_empty() {
             return PyList::new(py, leftover.into_iter().map(|b| PyBytes::new(py, &b)));
@@ -763,6 +943,19 @@ impl Socket {
         py: Python<'py>,
         flags: i32,
     ) -> PyResult<Bound<'py, PyList>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Dish) {
+            let msg = if flags & crate::constants::NOBLOCK != 0 {
+                self.try_recv_message()?
+            } else {
+                self.recv_message(py)?
+            };
+            let (group, body) = split_dish_message(msg)?;
+            let frame = Bound::new(
+                py,
+                Frame::from_bytes_more_routing_group(body, false, 0, group),
+            )?;
+            return PyList::new(py, [frame]);
+        }
         let leftover = self.inner.take_rxbuf();
         if !leftover.is_empty() {
             return conversions::frames_to_pylist(py, leftover);

--- a/bindings/pyomq/src/socket_async.rs
+++ b/bindings/pyomq/src/socket_async.rs
@@ -14,11 +14,13 @@
 //! dispatch helpers (block on a tokio oneshot).
 
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use bytes::Bytes;
 use omq_proto::error::Error as PError;
 
 use crate::error::timeout_err;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyType};
 
@@ -27,11 +29,96 @@ use crate::dispatch;
 use crate::error::map_err;
 use crate::frame::Frame;
 use crate::runtime::ContextInner;
-use crate::socket::SocketInner;
+use crate::socket::{SocketInner, split_dish_message};
 
 #[pyclass(module = "pyomq._native")]
 pub struct AsyncSocket {
     pub(crate) inner: Arc<SocketInner>,
+}
+
+/// Allocated only after queue backpressure. Owns the fully converted message.
+pub(crate) type PendingMessage = Mutex<Option<omq_proto::Message>>;
+
+#[pyclass(module = "pyomq._native")]
+pub(crate) struct PendingSend {
+    inner: Arc<SocketInner>,
+    message: Arc<PendingMessage>,
+    tracker: Option<Py<PyAny>>,
+}
+
+#[pymethods]
+impl PendingSend {
+    fn retry(&mut self) -> PyResult<Option<Py<PyAny>>> {
+        self.inner.materialize()?;
+        let guard = self.inner.materialized.read().unwrap();
+        let materialized = guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
+        let mut pending = self.message.lock().unwrap();
+        let message = pending
+            .take()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("send already completed"))?;
+        match materialized
+            .send_prod
+            .lock()
+            .unwrap()
+            .push_and_flush(message)
+        {
+            Ok(()) => Ok(self.tracker.take()),
+            Err(message) => {
+                *pending = Some(message);
+                Err(timeout_err())
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        let message = self.message.lock().unwrap().take();
+        self.tracker.take();
+        // Releasing a Python exporter can close the socket and revisit this
+        // pending entry, so the message lock must already be released.
+        drop(message);
+    }
+}
+
+fn submit(
+    py: Python<'_>,
+    inner: &Arc<SocketInner>,
+    message: omq_proto::Message,
+    tracker: Option<Py<PyAny>>,
+) -> PyResult<Option<Py<PyAny>>> {
+    inner.materialize()?;
+    let guard = inner.materialized.read().unwrap();
+    let materialized = guard.as_ref().ok_or_else(|| map_err(PError::Closed))?;
+    match materialized
+        .send_prod
+        .lock()
+        .unwrap()
+        .push_and_flush(message)
+    {
+        Ok(()) => Ok(tracker),
+        Err(message) => {
+            let message = Arc::new(Mutex::new(Some(message)));
+            let mut pending_sends = inner.pending_sends.lock().unwrap();
+            if pending_sends.len() == pending_sends.capacity() {
+                pending_sends.retain(|pending| pending.strong_count() != 0);
+                // Leave room for another live set. Sweeping on every insert,
+                // or reclaiming only one slot at a time, makes bursts quadratic.
+                let live = pending_sends.len();
+                pending_sends.reserve(live);
+            }
+            pending_sends.push(Arc::downgrade(&message));
+            let pending = Py::new(
+                py,
+                PendingSend {
+                    inner: inner.clone(),
+                    message,
+                    tracker,
+                },
+            )?;
+            let error = timeout_err();
+            error.value(py).setattr("_pending_send", pending)?;
+            Err(error)
+        }
+    }
 }
 
 impl AsyncSocket {
@@ -76,44 +163,161 @@ impl AsyncSocket {
 
     // ── Send (sync push into yring) ─────────────────────────────────
 
-    #[pyo3(signature = (payload, flags = 0, copy = true))]
-    fn send(&self, payload: &Bound<'_, PyAny>, flags: i32, copy: bool) -> PyResult<()> {
+    #[pyo3(signature = (payload, flags = 0, copy = true, track = false))]
+    fn send(
+        &self,
+        payload: &Bound<'_, PyAny>,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            let Some(group) = conversions::group_from_pyany(payload) else {
+                return Err(PyValueError::new_err(
+                    "RADIO requires a group; pass group= or set Frame.group",
+                ));
+            };
+            if flags & crate::constants::SNDMORE != 0 {
+                return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+            }
+            let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+            return submit(
+                payload.py(),
+                &self.inner,
+                omq_tokio::Message::with_group(group, bytes),
+                tracker,
+            );
+        }
         let routing_id = conversions::routing_id_from_pyany(payload);
-        let bytes = conversions::bytes_from_pyany(payload, copy)?;
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
         let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
-            return Ok(());
+            return Ok(tracker);
         };
         if routing_id != 0 {
             msg = msg.with_routing_id(routing_id);
         }
-        self.inner.materialize()?;
-        let materialized_guard = self.inner.materialized.read().unwrap();
-        let materialized = materialized_guard.as_ref().unwrap();
-        let mut prod = materialized.send_prod.lock().unwrap();
-        match prod.push_and_flush(msg) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(timeout_err()),
-        }
+        submit(payload.py(), &self.inner, msg, tracker)
     }
 
-    #[pyo3(signature = (parts, flags = 0, copy = true))]
-    fn send_multipart(&self, parts: &Bound<'_, PyAny>, flags: i32, copy: bool) -> PyResult<()> {
-        let _ = flags;
-        let msg = conversions::message_from_pylist(parts, copy)?;
-        self.inner.materialize()?;
-        let materialized_guard = self.inner.materialized.read().unwrap();
-        let materialized = materialized_guard.as_ref().unwrap();
-        let mut prod = materialized.send_prod.lock().unwrap();
-        match prod.push_and_flush(msg) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(timeout_err()),
+    #[pyo3(signature = (payload, group, flags = 0, copy = true, track = false))]
+    fn _send_with_group(
+        &self,
+        payload: &Bound<'_, PyAny>,
+        group: String,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if !matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "group is only valid on RADIO sockets",
+            ));
         }
+        if flags & crate::constants::SNDMORE != 0 {
+            return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+        }
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+        submit(
+            payload.py(),
+            &self.inner,
+            omq_tokio::Message::with_group(group, bytes),
+            tracker,
+        )
+    }
+
+    #[pyo3(signature = (payload, routing_id, flags = 0, copy = true, track = false))]
+    fn _send_with_routing(
+        &self,
+        payload: &Bound<'_, PyAny>,
+        routing_id: u32,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        let (bytes, tracker) = conversions::payload_with_tracker(payload, copy, track)?;
+        let Some(mut msg) = self.inner.build_or_buffer(bytes, flags) else {
+            return Ok(tracker);
+        };
+        if routing_id != 0 {
+            msg = msg.with_routing_id(routing_id);
+        }
+        submit(payload.py(), &self.inner, msg, tracker)
+    }
+
+    #[pyo3(signature = (parts, flags = 0, copy = true, track = false))]
+    fn send_multipart(
+        &self,
+        parts: &Bound<'_, PyAny>,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "RADIO requires send(..., group=...) or send_multipart(..., group=...)",
+            ));
+        }
+        let _ = flags;
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        submit(parts.py(), &self.inner, msg, tracker)
+    }
+
+    #[pyo3(signature = (parts, group, flags = 0, copy = true, track = false))]
+    fn _send_multipart_with_group(
+        &self,
+        parts: &Bound<'_, PyAny>,
+        group: String,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if !matches!(self.inner.socket_type, omq_tokio::SocketType::Radio) {
+            return Err(PyValueError::new_err(
+                "group is only valid on RADIO sockets",
+            ));
+        }
+        if flags & crate::constants::SNDMORE != 0 {
+            return Err(PyValueError::new_err("RADIO group send cannot use SNDMORE"));
+        }
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        if msg.len() != 1 {
+            return Err(PyValueError::new_err(
+                "RADIO group send requires exactly one message part",
+            ));
+        }
+        let body = msg.part_bytes(0).expect("one-part message has a body");
+        submit(
+            parts.py(),
+            &self.inner,
+            omq_tokio::Message::with_group(group, body),
+            tracker,
+        )
+    }
+
+    #[pyo3(signature = (parts, routing_id, flags = 0, copy = true, track = false))]
+    fn _send_multipart_with_routing(
+        &self,
+        parts: &Bound<'_, PyAny>,
+        routing_id: u32,
+        flags: i32,
+        copy: bool,
+        track: bool,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        let _ = flags;
+        let (msg, tracker) = conversions::message_from_pylist(parts, copy, track)?;
+        submit(
+            parts.py(),
+            &self.inner,
+            msg.with_routing_id(routing_id),
+            tracker,
+        )
     }
 
     // ── Recv (try-poll + readiness fd for async notification) ────────
 
     #[pyo3(name = "_try_recv")]
     fn try_recv<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let dish = matches!(self.inner.socket_type, omq_tokio::SocketType::Dish);
         if let Some(head) = self.inner.pop_rxbuf_head() {
             return Ok(PyBytes::new(py, &head).into_any());
         }
@@ -125,6 +329,10 @@ impl AsyncSocket {
         let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
             materialized.recv_space.notify_changed();
+            if dish {
+                let (_, body) = split_dish_message(msg)?;
+                return Ok(PyBytes::new(py, &body).into_any());
+            }
             let mut parts: Vec<Bytes> = msg.iter().collect();
             let head = if parts.is_empty() {
                 Bytes::new()
@@ -142,6 +350,7 @@ impl AsyncSocket {
 
     #[pyo3(name = "_try_recv_frame")]
     fn try_recv_frame<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let dish = matches!(self.inner.socket_type, omq_tokio::SocketType::Dish);
         if let Some((head, more)) = self.inner.pop_rxbuf_head_with_more() {
             return Ok(Bound::new(py, Frame::from_bytes_more(head, more))?.into_any());
         }
@@ -153,6 +362,14 @@ impl AsyncSocket {
         let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
             materialized.recv_space.notify_changed();
+            if dish {
+                let (group, body) = split_dish_message(msg)?;
+                return Ok(Bound::new(
+                    py,
+                    Frame::from_bytes_more_routing_group(body, false, 0, group),
+                )?
+                .into_any());
+            }
             let routing_id = msg.routing_id().unwrap_or(0);
             let mut parts: Vec<Bytes> = msg.iter().collect();
             let head = if parts.is_empty() {
@@ -172,6 +389,7 @@ impl AsyncSocket {
 
     #[pyo3(name = "_try_recv_multipart")]
     fn try_recv_multipart<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let dish = matches!(self.inner.socket_type, omq_tokio::SocketType::Dish);
         let leftover = self.inner.take_rxbuf();
         if !leftover.is_empty() {
             return Ok(
@@ -186,6 +404,10 @@ impl AsyncSocket {
         let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
             materialized.recv_space.notify_changed();
+            if dish {
+                let (_, body) = split_dish_message(msg)?;
+                return Ok(PyList::new(py, [PyBytes::new(py, &body)])?.into_any());
+            }
             Ok(conversions::parts_to_pylist(py, msg)?.into_any())
         } else {
             Ok(py.None().bind(py).clone())
@@ -194,6 +416,7 @@ impl AsyncSocket {
 
     #[pyo3(name = "_try_recv_multipart_frames")]
     fn try_recv_multipart_frames<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let dish = matches!(self.inner.socket_type, omq_tokio::SocketType::Dish);
         let leftover = self.inner.take_rxbuf();
         if !leftover.is_empty() {
             return Ok(conversions::frames_to_pylist(py, leftover)?.into_any());
@@ -206,6 +429,14 @@ impl AsyncSocket {
         let mut cons = materialized.recv_cons.lock().unwrap();
         if let Some(msg) = cons.prefetch_and_pop() {
             materialized.recv_space.notify_changed();
+            if dish {
+                let (group, body) = split_dish_message(msg)?;
+                let frame = Bound::new(
+                    py,
+                    Frame::from_bytes_more_routing_group(body, false, 0, group),
+                )?;
+                return Ok(PyList::new(py, [frame])?.into_any());
+            }
             Ok(conversions::message_to_frame_list(py, msg)?.into_any())
         } else {
             Ok(py.None().bind(py).clone())

--- a/bindings/pyomq/src/tracker.rs
+++ b/bindings/pyomq/src/tracker.rs
@@ -1,0 +1,130 @@
+//! Completion follows buffer ownership, never queue admission or peer delivery.
+
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use pyo3::prelude::*;
+
+#[derive(Debug, Default)]
+pub(crate) struct Completion {
+    done: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl Completion {
+    fn finish(&self) {
+        *self.done.lock().unwrap() = true;
+        self.changed.notify_all();
+    }
+}
+
+#[pyclass(frozen, module = "pyomq._native")]
+#[derive(Debug)]
+pub(crate) struct ReleaseToken(Arc<Completion>);
+
+#[pymethods]
+impl ReleaseToken {
+    #[getter]
+    fn done(&self) -> bool {
+        *self.0.done.lock().unwrap()
+    }
+
+    #[pyo3(signature = (timeout=None))]
+    fn wait(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<bool> {
+        let timeout = timeout
+            .map(Duration::try_from_secs_f64)
+            .transpose()
+            .map_err(|_| pyo3::exceptions::PyValueError::new_err("invalid timeout"))?;
+        Ok(py.detach(|| {
+            let guard = self.0.done.lock().unwrap();
+            let guard = if let Some(timeout) = timeout {
+                self.0
+                    .changed
+                    .wait_timeout_while(guard, timeout, |done| !*done)
+                    .unwrap()
+                    .0
+            } else {
+                self.0.changed.wait_while(guard, |done| !*done).unwrap()
+            };
+            *guard
+        }))
+    }
+}
+
+struct FinishOnDrop(Arc<Completion>);
+
+impl Drop for FinishOnDrop {
+    fn drop(&mut self) {
+        self.0.finish();
+    }
+}
+
+// Fields drop in declaration order: release the exporter before notifying waiters.
+struct TrackedBytes {
+    data: Bytes,
+    _finish: FinishOnDrop,
+}
+
+impl AsRef<[u8]> for TrackedBytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+pub(crate) fn track(py: Python<'_>, data: Bytes) -> PyResult<(Bytes, Py<PyAny>)> {
+    let (data, token) = track_buffer(py, data)?;
+    Ok((data, from_source(py, token.into_any())?))
+}
+
+/// Multipart conversion collects tokens before building one Python tracker.
+pub(crate) fn track_buffer(py: Python<'_>, data: Bytes) -> PyResult<(Bytes, Py<ReleaseToken>)> {
+    let state = Arc::new(Completion::default());
+    let token = Py::new(py, ReleaseToken(state.clone()))?;
+    Ok((
+        Bytes::from_owner(TrackedBytes {
+            data,
+            _finish: FinishOnDrop(state),
+        }),
+        token,
+    ))
+}
+
+pub(crate) fn from_source(py: Python<'_>, source: Py<PyAny>) -> PyResult<Py<PyAny>> {
+    if !source.bind(py).is_instance_of::<ReleaseToken>() {
+        // Sending an existing Frame must return its original tracker.
+        return Ok(source);
+    }
+    Ok(py
+        .import("pyomq._tracker")?
+        .getattr("_from_sources")?
+        .call1((source,))?
+        .unbind())
+}
+
+pub(crate) fn finished(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    Ok(py
+        .import("pyomq._tracker")?
+        .getattr("_FINISHED_TRACKER")?
+        .unbind())
+}
+
+pub(crate) fn aggregate(py: Python<'_>, trackers: Vec<Py<PyAny>>) -> PyResult<Option<Py<PyAny>>> {
+    if trackers.is_empty() {
+        return Ok(None);
+    }
+    if trackers.len() == 1 {
+        return trackers
+            .into_iter()
+            .next()
+            .map(|source| from_source(py, source))
+            .transpose();
+    }
+    let args = pyo3::types::PyTuple::new(py, trackers)?;
+    Ok(Some(
+        py.import("pyomq._tracker")?
+            .getattr("_from_sources")?
+            .call1(args)?
+            .unbind(),
+    ))
+}

--- a/bindings/pyomq/tests/soak/conftest.py
+++ b/bindings/pyomq/tests/soak/conftest.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-from typing import List, Tuple
 
 
 def soak_duration() -> float:

--- a/bindings/pyomq/tests/soak/test_context_churn.py
+++ b/bindings/pyomq/tests/soak/test_context_churn.py
@@ -9,7 +9,6 @@ everything. Leaks in the binding layer show up here first.
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration
 
 

--- a/bindings/pyomq/tests/soak/test_fan_out.py
+++ b/bindings/pyomq/tests/soak/test_fan_out.py
@@ -10,7 +10,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 NUM_SUBS = 16
@@ -24,7 +23,8 @@ def test_fan_out():
     ctx = zmq.Context()
     pub = ctx.socket(zmq.PUB)
     pub.setsockopt(zmq.SNDHWM, 500)
-    ep = pub.bind(tcp_ep())
+    pub.bind(tcp_ep())
+    ep = pub.last_endpoint
 
     subs = []
     for _ in range(NUM_SUBS):

--- a/bindings/pyomq/tests/soak/test_inproc_throughput.py
+++ b/bindings/pyomq/tests/soak/test_inproc_throughput.py
@@ -9,7 +9,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, inproc_ep, soak_duration
 
 MSG_SIZE = 64

--- a/bindings/pyomq/tests/soak/test_io_threads.py
+++ b/bindings/pyomq/tests/soak/test_io_threads.py
@@ -33,7 +33,8 @@ ctx = zmq.Context(io_threads=IO_THREADS)
 # --- PUSH/PULL throughput ---
 pull = ctx.socket(zmq.PULL)
 push = ctx.socket(zmq.PUSH)
-ep = pull.bind("tcp://127.0.0.1:0")
+pull.bind("tcp://127.0.0.1:0")
+ep = pull.last_endpoint
 push.connect(ep)
 push.setsockopt(zmq.SNDTIMEO, 5000)
 pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -90,7 +91,8 @@ tput = recvd / elapsed if elapsed > 0 else 0
 # --- REQ/REP latency ---
 rep = ctx.socket(zmq.REP)
 req = ctx.socket(zmq.REQ)
-ep2 = rep.bind("tcp://127.0.0.1:0")
+rep.bind("tcp://127.0.0.1:0")
+ep2 = rep.last_endpoint
 req.connect(ep2)
 rep.setsockopt(zmq.RCVTIMEO, 5000)
 rep.setsockopt(zmq.SNDTIMEO, 5000)
@@ -140,6 +142,7 @@ def test_io_threads_variants():
             text=True,
             timeout=per_variant + 30,
             env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+            check=False,
         )
         print(f"  stdout: {result.stdout.strip()}")
         if result.stderr.strip():

--- a/bindings/pyomq/tests/soak/test_ipc_throughput.py
+++ b/bindings/pyomq/tests/soak/test_ipc_throughput.py
@@ -10,7 +10,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration
 
 MSG_SIZE = 512

--- a/bindings/pyomq/tests/soak/test_large_messages.py
+++ b/bindings/pyomq/tests/soak/test_large_messages.py
@@ -8,7 +8,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 MSG_SIZE = 1024 * 1024
@@ -23,7 +22,8 @@ def test_large_message_throughput():
     push = ctx.socket(zmq.PUSH)
     pull.setsockopt(zmq.RCVHWM, 4)
     push.setsockopt(zmq.SNDHWM, 4)
-    ep = pull.bind(tcp_ep())
+    pull.bind(tcp_ep())
+    ep = pull.last_endpoint
     push.connect(ep)
     push.setsockopt(zmq.SNDTIMEO, 5000)
     pull.setsockopt(zmq.RCVTIMEO, 5000)

--- a/bindings/pyomq/tests/soak/test_multipart.py
+++ b/bindings/pyomq/tests/soak/test_multipart.py
@@ -15,8 +15,6 @@ import threading
 import time
 
 import pyomq as zmq
-from typing import List
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 FRAME_B = 128
@@ -58,7 +56,8 @@ def test_multipart_push_pull():
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
-    ep = pull.bind(tcp_ep())
+    pull.bind(tcp_ep())
+    ep = pull.last_endpoint
     push.connect(ep)
     push.setsockopt(zmq.SNDTIMEO, 5000)
     pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -137,7 +136,8 @@ def test_multipart_dealer_router():
     ctx = zmq.Context()
     router = ctx.socket(zmq.ROUTER)
     dealer = ctx.socket(zmq.DEALER)
-    ep = router.bind(tcp_ep())
+    router.bind(tcp_ep())
+    ep = router.last_endpoint
     dealer.setsockopt(zmq.IDENTITY, b"soak-client")
     dealer.connect(ep)
     dealer.setsockopt(zmq.SNDTIMEO, 5000)

--- a/bindings/pyomq/tests/soak/test_pair.py
+++ b/bindings/pyomq/tests/soak/test_pair.py
@@ -10,7 +10,6 @@ import struct
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 
@@ -25,7 +24,8 @@ def test_pair_bidirectional():
     a.setsockopt(zmq.RCVTIMEO, 1)
     b.setsockopt(zmq.SNDTIMEO, 1000)
     b.setsockopt(zmq.RCVTIMEO, 1)
-    ep = a.bind(tcp_ep())
+    a.bind(tcp_ep())
+    ep = a.last_endpoint
     b.connect(ep)
 
     time.sleep(0.1)

--- a/bindings/pyomq/tests/soak/test_peer_churn.py
+++ b/bindings/pyomq/tests/soak/test_peer_churn.py
@@ -11,12 +11,10 @@ in a realistic range (well under 10/sec on average).
 
 import random
 import time
-from typing import List, Tuple
 
 import pyomq as zmq
-from pyomq import Socket
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
+from pyomq import Socket
 
 NUM_PEERS = 20
 TICK_HZ = 10
@@ -32,7 +30,8 @@ def test_peer_churn():
     push = ctx.socket(zmq.PUSH)
     push.setsockopt(zmq.SNDTIMEO, 1)
     push.setsockopt(zmq.SNDHWM, 1024)
-    ep = push.bind(tcp_ep())
+    push.bind(tcp_ep())
+    ep = push.last_endpoint
 
     peers: list[tuple[Socket, bool]] = []
     for _ in range(NUM_PEERS):

--- a/bindings/pyomq/tests/soak/test_poller.py
+++ b/bindings/pyomq/tests/soak/test_poller.py
@@ -10,7 +10,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 NUM_CHANNELS = 4
@@ -28,7 +27,8 @@ def test_poller_multi_socket():
     for _ in range(NUM_CHANNELS):
         pull = ctx.socket(zmq.PULL)
         push = ctx.socket(zmq.PUSH)
-        ep = pull.bind(tcp_ep())
+        pull.bind(tcp_ep())
+        ep = pull.last_endpoint
         push.connect(ep)
         push.setsockopt(zmq.SNDTIMEO, 2000)
         pulls.append(pull)

--- a/bindings/pyomq/tests/soak/test_pub_sub_churn.py
+++ b/bindings/pyomq/tests/soak/test_pub_sub_churn.py
@@ -8,7 +8,6 @@ import random
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 TOPICS = [b"fast.", b"slow.", b"all.", b"rare."]
@@ -21,7 +20,8 @@ def test_pub_sub_churn():
     ctx = zmq.Context()
     pub = ctx.socket(zmq.PUB)
     pub.setsockopt(zmq.SNDTIMEO, 100)
-    ep = pub.bind(tcp_ep())
+    pub.bind(tcp_ep())
+    ep = pub.last_endpoint
 
     subs: list = []
     pub_count = 0

--- a/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
+++ b/bindings/pyomq/tests/soak/test_pub_sub_throughput.py
@@ -10,7 +10,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 NUM_SUBS = 4
@@ -25,7 +24,8 @@ def test_pub_sub_throughput():
     ctx = zmq.Context()
     pub = ctx.socket(zmq.PUB)
     pub.setsockopt(zmq.SNDHWM, 1000)
-    ep = pub.bind(tcp_ep())
+    pub.bind(tcp_ep())
+    ep = pub.last_endpoint
 
     subs = []
     for i in range(NUM_SUBS):

--- a/bindings/pyomq/tests/soak/test_push_pull_throughput.py
+++ b/bindings/pyomq/tests/soak/test_push_pull_throughput.py
@@ -7,7 +7,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 
@@ -18,7 +17,8 @@ def test_push_pull_sustained():
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
-    ep = pull.bind(tcp_ep())
+    pull.bind(tcp_ep())
+    ep = pull.last_endpoint
     push.connect(ep)
     push.setsockopt(zmq.SNDTIMEO, 2000)
     pull.setsockopt(zmq.RCVTIMEO, 2000)

--- a/bindings/pyomq/tests/soak/test_reconnect_storm.py
+++ b/bindings/pyomq/tests/soak/test_reconnect_storm.py
@@ -9,7 +9,6 @@ import errno
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 
@@ -35,7 +34,8 @@ def test_reconnect_storm():
     push.setsockopt(zmq.RECONNECT_IVL, 10)
 
     pull = _new_pull(ctx)
-    ep = pull.bind(tcp_ep())
+    pull.bind(tcp_ep())
+    ep = pull.last_endpoint
     push.connect(ep)
 
     start = time.monotonic()

--- a/bindings/pyomq/tests/soak/test_req_rep_cycles.py
+++ b/bindings/pyomq/tests/soak/test_req_rep_cycles.py
@@ -8,7 +8,6 @@ import threading
 import time
 
 import pyomq as zmq
-
 from conftest import ResourceMonitor, soak_duration, tcp_ep
 
 
@@ -19,7 +18,8 @@ def test_req_rep_cycles():
     ctx = zmq.Context()
     rep = ctx.socket(zmq.REP)
     req = ctx.socket(zmq.REQ)
-    ep = rep.bind(tcp_ep())
+    rep.bind(tcp_ep())
+    ep = rep.last_endpoint
     req.connect(ep)
     rep.setsockopt(zmq.RCVTIMEO, 100)
     rep.setsockopt(zmq.SNDTIMEO, 5000)

--- a/bindings/pyomq/tests/test_async.py
+++ b/bindings/pyomq/tests/test_async.py
@@ -1,13 +1,13 @@
 """asyncio facade: pyomq.asyncio.Context / Socket roundtrips."""
 
 import asyncio
+import socket as stdsocket
 import sys
 import time
 
-import pytest
-
 import pyomq
 import pyomq.asyncio as zmq_async
+import pytest
 
 pytestmark = pytest.mark.event_loop("selector", "proactor")
 
@@ -33,7 +33,8 @@ async def test_async_push_pull_tcp(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"tcp-hello")
         assert await pull.recv() == b"tcp-hello"
@@ -48,7 +49,8 @@ async def test_async_send_multipart(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"a", b"b", b"c"])
         assert await pull.recv_multipart() == [b"a", b"b", b"c"]
@@ -58,12 +60,42 @@ async def test_async_send_multipart(tcp_endpoint):
 
 
 @pytest.mark.asyncio
+async def test_async_radio_dish_groups():
+    s = stdsocket.socket(stdsocket.AF_INET, stdsocket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    endpoint = f"udp://127.0.0.1:{port}"
+
+    ctx = zmq_async.Context()
+    dish = ctx.socket(pyomq.DISH)
+    radio = ctx.socket(pyomq.RADIO)
+    try:
+        dish.bind(endpoint)
+        dish.join("weather")
+        radio.connect(endpoint)
+        await asyncio.sleep(0.05)
+
+        await radio.send(b"sunny", group="weather")
+        frame = await dish.recv(copy=False)
+        assert bytes(frame) == b"sunny"
+        assert frame.group == "weather"
+
+        await radio.send_multipart([b"cloudy"], group="weather")
+        assert await dish.recv_multipart() == [b"cloudy"]
+    finally:
+        radio.close()
+        dish.close()
+
+
+@pytest.mark.asyncio
 async def test_async_send_accepts_memoryview_copy_false(tcp_endpoint):
     ctx = zmq_async.Context()
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         await push.send(memoryview(b"hello"), copy=False)
         assert await pull.recv() == b"hello"
@@ -78,7 +110,8 @@ async def test_async_send_multipart_accepts_buffers_copy_false(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         await push.send_multipart(
             [bytearray(b"meta"), memoryview(b"payload")], copy=False
@@ -95,7 +128,8 @@ async def test_async_pubsub(tcp_endpoint):
     pub = ctx.socket(pyomq.PUB)
     sub = ctx.socket(pyomq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.setsockopt(pyomq.SUBSCRIBE, b"hot/")
         await asyncio.sleep(0.2)  # let SUBSCRIBE propagate
@@ -115,7 +149,8 @@ async def test_async_concurrent_recvs(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         # Fire off N concurrent recvs. AsyncSocket.recv returns an
@@ -141,7 +176,8 @@ async def test_async_mixed_with_sync(tcp_endpoint):
     pull = ctx_sync.socket(pyomq.PULL)
     push = ctx_async.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"mixed")
         assert pull.recv() == b"mixed"
@@ -176,7 +212,8 @@ async def test_async_sndmore_flag_aggregates(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"a", flags=pyomq.SNDMORE)
         push.send(b"b", flags=pyomq.SNDMORE)
@@ -193,7 +230,8 @@ async def test_async_rcvmore_iterates_frames(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push = ctx.socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"x", b"y", b"z"])
         assert await pull.recv() == b"x"
@@ -211,7 +249,8 @@ async def test_async_rcvmore_iterates_frames(tcp_endpoint):
 async def test_async_context_manager(tcp_endpoint):
     ctx = zmq_async.Context()
     async with ctx.socket(pyomq.PAIR) as a, ctx.socket(pyomq.PAIR) as b:
-        ep = a.bind(tcp_endpoint)
+        a.bind(tcp_endpoint)
+        ep = a.last_endpoint
         b.connect(ep)
         a.send(b"ping")
         assert await b.recv() == b"ping"
@@ -225,7 +264,8 @@ async def test_async_req_rep_roundtrip(tcp_endpoint):
     rep = ctx.socket(pyomq.REP)
     req = ctx.socket(pyomq.REQ)
     try:
-        ep = rep.bind(tcp_endpoint)
+        rep.bind(tcp_endpoint)
+        ep = rep.last_endpoint
         req.connect(ep)
         req.send(b"ping")
         assert await rep.recv() == b"ping"
@@ -242,7 +282,8 @@ async def test_async_unsubscribe_drops_topic(tcp_endpoint):
     pub = ctx.socket(pyomq.PUB)
     sub = ctx.socket(pyomq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.subscribe(b"a")
         sub.subscribe(b"b")
@@ -264,7 +305,8 @@ async def test_async_subscribe_helpers_accept_str_prefixes(tcp_endpoint):
     pub = ctx.socket(pyomq.PUB)
     sub = ctx.socket(pyomq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.subscribe("weather/")
         await asyncio.sleep(0.2)
@@ -287,7 +329,8 @@ async def test_async_dealer_router_identity(tcp_endpoint):
     dealer = ctx.socket(pyomq.DEALER)
     try:
         dealer.setsockopt(pyomq.IDENTITY, b"client-A")
-        ep = router.bind(tcp_endpoint)
+        router.bind(tcp_endpoint)
+        ep = router.last_endpoint
         dealer.connect(ep)
         dealer.send(b"hello")
         parts = await router.recv_multipart()
@@ -310,7 +353,8 @@ async def test_async_push_pull_bulk_tcp(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     push_sync = pyomq.Context().socket(pyomq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push_sync.connect(ep)
 
         def sender():
@@ -343,7 +387,7 @@ async def test_async_close_wakes_pending_recv(tcp_endpoint):
         recv_task = pull.recv()
         await asyncio.sleep(0.05)
         pull.close()
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa B017
             await recv_task
-    except Exception:
+    except Exception:  # noqa S110
         pass

--- a/bindings/pyomq/tests/test_async_auth.py
+++ b/bindings/pyomq/tests/test_async_auth.py
@@ -2,11 +2,9 @@
 
 import asyncio
 
-import pytest
-
 import pyomq
 import pyomq.asyncio as zmq_async
-
+import pytest
 
 # ── CURVE ────────────────────────────────────────────────────────────
 
@@ -30,7 +28,8 @@ async def test_async_curve_auth_allowed_keys(tcp_endpoint):
         push.curve_publickey = client_pub
         push.curve_secretkey = client_sec
 
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"async-curve-ok")
         pull.setsockopt(pyomq.RCVTIMEO, 5000)
@@ -59,7 +58,8 @@ async def test_async_curve_auth_callback(tcp_endpoint):
         push.curve_publickey = client_pub
         push.curve_secretkey = client_sec
 
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"async-curve-cb")
         pull.setsockopt(pyomq.RCVTIMEO, 5000)
@@ -96,7 +96,8 @@ async def test_async_curve_auth_callback_receives_identity(tcp_endpoint):
         dealer.curve_publickey = client_pub
         dealer.curve_secretkey = client_sec
 
-        ep = router.bind(tcp_endpoint)
+        router.bind(tcp_endpoint)
+        ep = router.last_endpoint
         dealer.connect(ep)
         dealer.send(b"async-probe")
         msg = await asyncio.wait_for(router.recv_multipart(), timeout=5.0)

--- a/bindings/pyomq/tests/test_async_compat.py
+++ b/bindings/pyomq/tests/test_async_compat.py
@@ -1,9 +1,8 @@
 """Async wrapper parity tests."""
 
-import pytest
-
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
+import pytest
 
 
 async def test_async_again_exception(tcp_endpoint):
@@ -12,7 +11,8 @@ async def test_async_again_exception(tcp_endpoint):
     ctx = zmq_async.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.close()
         with pytest.raises(zmq.ContextTerminated):
             await pull.recv()
@@ -25,7 +25,8 @@ async def test_async_send_recv_string(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_string("hello")
         assert await pull.recv_string() == "hello"
@@ -39,7 +40,8 @@ async def test_async_send_recv_json(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_json({"k": 1})
         assert await pull.recv_json() == {"k": 1}
@@ -53,7 +55,8 @@ async def test_async_send_recv_pyobj(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_pyobj([1, 2, 3])
         assert await pull.recv_pyobj() == [1, 2, 3]
@@ -134,7 +137,8 @@ async def test_async_send_recv_serialized(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         def ser(msg):

--- a/bindings/pyomq/tests/test_async_interop.py
+++ b/bindings/pyomq/tests/test_async_interop.py
@@ -35,7 +35,8 @@ async def test_async_pyomq_push_to_pyzmq_pull(tcp_endpoint):
 async def test_async_pyzmq_push_to_pyomq_pull(tcp_endpoint):
     ctx = zmq_async.Context()
     pull = ctx.socket(pyomq.PULL)
-    ep = pull.bind(tcp_endpoint)
+    pull.bind(tcp_endpoint)
+    ep = pull.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         push = py_ctx.socket(zmq_pyzmq.PUSH)
@@ -52,7 +53,8 @@ async def test_async_pyzmq_push_to_pyomq_pull(tcp_endpoint):
 async def test_async_pyomq_pub_to_pyzmq_sub(tcp_endpoint):
     ctx = zmq_async.Context()
     pub = ctx.socket(pyomq.PUB)
-    ep = pub.bind(tcp_endpoint)
+    pub.bind(tcp_endpoint)
+    ep = pub.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         sub = py_ctx.socket(zmq_pyzmq.SUB)

--- a/bindings/pyomq/tests/test_basic.py
+++ b/bindings/pyomq/tests/test_basic.py
@@ -8,7 +8,8 @@ def _push_pull(endpoint: str) -> None:
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
     try:
-        ep = pull.bind(endpoint)
+        pull.bind(endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
         assert pull.recv() == b"hello"
@@ -31,7 +32,8 @@ def test_push_pull_multipart(tcp_endpoint):
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"meta", b"trailer"])
         assert pull.recv_multipart() == [b"meta", b"trailer"]
@@ -46,7 +48,8 @@ def test_sndmore_flag_aggregates(tcp_endpoint):
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"a", flags=zmq.SNDMORE)
         push.send(b"b", flags=zmq.SNDMORE)
@@ -63,7 +66,8 @@ def test_rcvmore_iterates_frames(tcp_endpoint):
     pull = ctx.socket(zmq.PULL)
     push = ctx.socket(zmq.PUSH)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"x", b"y", b"z"])
         assert pull.recv() == b"x"
@@ -80,7 +84,8 @@ def test_rcvmore_iterates_frames(tcp_endpoint):
 
 def test_context_manager_protocol(tcp_endpoint):
     with zmq.Context() as ctx, ctx.socket(zmq.PAIR) as a, ctx.socket(zmq.PAIR) as b:
-        ep = a.bind(tcp_endpoint)
+        a.bind(tcp_endpoint)
+        ep = a.last_endpoint
         b.connect(ep)
         a.send(b"ping")
         assert b.recv() == b"ping"

--- a/bindings/pyomq/tests/test_compat.py
+++ b/bindings/pyomq/tests/test_compat.py
@@ -1,10 +1,8 @@
 """pyzmq-compatible API surface tests."""
 
-import pytest
-
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
-
+import pytest
 
 # ── Serialization methods ────────────────────────────────────────────
 
@@ -14,7 +12,8 @@ def test_send_recv_string(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_string("hello")
         assert pull.recv_string() == "hello"
@@ -29,7 +28,8 @@ def test_send_recv_string_encoding(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_string("héllo", encoding="utf-16")
         assert pull.recv_string(encoding="utf-16") == "héllo"
@@ -44,7 +44,8 @@ def test_send_recv_json(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_json({"k": 1, "arr": [2, 3]})
         assert pull.recv_json() == {"k": 1, "arr": [2, 3]}
@@ -59,7 +60,8 @@ def test_send_recv_json_kwargs(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_json({"b": 2, "a": 1}, sort_keys=True)
         raw = pull.recv()
@@ -75,7 +77,8 @@ def test_send_recv_pyobj(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_pyobj([1, 2, 3])
         assert pull.recv_pyobj() == [1, 2, 3]
@@ -92,7 +95,8 @@ def test_send_recv_pyobj_protocol(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_pyobj({"x": 42}, protocol=2)
         raw = pull.recv()
@@ -179,7 +183,8 @@ def test_copy_false_recv_returns_frame():
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind("tcp://127.0.0.1:0")
+        pull.bind("tcp://127.0.0.1:0")
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
         frame = pull.recv(copy=False)
@@ -200,13 +205,14 @@ def test_copy_false_multipart_recv_returns_frames():
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind("tcp://127.0.0.1:0")
+        pull.bind("tcp://127.0.0.1:0")
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"a", b"bb", b"ccc"])
         frames = pull.recv_multipart(copy=False)
         assert [bytes(frame) for frame in frames] == [b"a", b"bb", b"ccc"]
         assert all(isinstance(frame, zmq.Frame) for frame in frames)
-        assert [getattr(frame, "more") for frame in frames] == [True, True, False]
+        assert [frame.more for frame in frames] == [True, True, False]
     finally:
         push.close()
         pull.close()
@@ -220,8 +226,10 @@ def test_copy_false_frames_can_be_rerouted():
     broker_out = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep_in = broker_in.bind("tcp://127.0.0.1:0")
-        ep_out = pull.bind("tcp://127.0.0.1:0")
+        broker_in.bind("tcp://127.0.0.1:0")
+        ep_in = broker_in.last_endpoint
+        pull.bind("tcp://127.0.0.1:0")
+        ep_out = pull.last_endpoint
         push.connect(ep_in)
         broker_out.connect(ep_out)
         push.send_multipart([b"route", b"body"])
@@ -240,7 +248,8 @@ def test_send_accepts_bytearray_buffer(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(bytearray(b"hello"))
         assert pull.recv() == b"hello"
@@ -255,7 +264,8 @@ def test_send_copies_mutable_buffer_by_default(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         data = bytearray(b"hello")
         push.send(data)
@@ -272,7 +282,8 @@ def test_send_accepts_memoryview_buffer_copy_false(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(memoryview(b"hello"), copy=False)
         assert pull.recv() == b"hello"
@@ -292,7 +303,8 @@ def test_send_multipart_accepts_buffer_parts(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([bytearray(b"meta"), memoryview(b"payload")], copy=False)
         assert pull.recv_multipart() == [b"meta", b"payload"]
@@ -302,17 +314,18 @@ def test_send_multipart_accepts_buffer_parts(tcp_endpoint):
         ctx.term()
 
 
-def test_send_accepts_noncontiguous_numpy_array_copy_false(tcp_endpoint):
+def test_send_rejects_noncontiguous_numpy_array_copy_false(tcp_endpoint):
     np = pytest.importorskip("numpy")
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         data = np.arange(16, dtype=np.uint8)[::2]
-        push.send(data, copy=False)
-        assert pull.recv() == data.tobytes()
+        with pytest.raises(BufferError):
+            push.send(data, copy=False)
     finally:
         push.close()
         pull.close()
@@ -325,7 +338,8 @@ def test_send_accepts_numpy_uint8_array_copy_false(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         data = np.arange(12, dtype=np.uint8).reshape((2, 2, 3))
         push.send(data, copy=False)
@@ -341,7 +355,8 @@ def test_copy_false_send_accepted():
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind("tcp://127.0.0.1:0")
+        pull.bind("tcp://127.0.0.1:0")
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello", copy=False)
         assert pull.recv() == b"hello"
@@ -351,15 +366,16 @@ def test_copy_false_send_accepted():
         ctx.term()
 
 
-def test_track_true_send_returns_tracker():
+def test_track_true_copied_send_returns_none():
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind("tcp://127.0.0.1:0")
+        pull.bind("tcp://127.0.0.1:0")
+        ep = pull.last_endpoint
         push.connect(ep)
         tracker = push.send(b"hello", track=True)
-        assert isinstance(tracker, zmq.MessageTracker)
+        assert tracker is None
         assert pull.recv() == b"hello"
     finally:
         push.close()
@@ -470,7 +486,8 @@ def test_send_recv_serialized(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         def my_serialize(msg):
@@ -549,7 +566,8 @@ def test_socket_poll_ready(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"data")
         import time
@@ -681,11 +699,12 @@ def test_select_ready(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"sel")
         time.sleep(0.05)
-        rready, wready, xready = zmq.select([pull], [], [], timeout=1.0)
+        rready, _wready, _xready = zmq.select([pull], [], [], timeout=1.0)
         assert pull in rready
     finally:
         push.close()
@@ -824,8 +843,10 @@ def test_proxy_req_rep(tcp_endpoint):
     client.rcvtimeo = 2000
 
     try:
-        fe_ep = frontend.bind(tcp_endpoint)
-        be_ep = backend.bind(tcp_endpoint)
+        frontend.bind(tcp_endpoint)
+        fe_ep = frontend.last_endpoint
+        backend.bind(tcp_endpoint)
+        be_ep = backend.last_endpoint
         worker.connect(be_ep)
         client.connect(fe_ep)
 
@@ -864,8 +885,10 @@ def test_proxy_req_rep_two_clients_preserves_routes(tcp_endpoint):
     client_b.rcvtimeo = 2000
 
     try:
-        fe_ep = frontend.bind(tcp_endpoint)
-        be_ep = backend.bind(tcp_endpoint)
+        frontend.bind(tcp_endpoint)
+        fe_ep = frontend.last_endpoint
+        backend.bind(tcp_endpoint)
+        be_ep = backend.last_endpoint
         worker.connect(be_ep)
         client_a.connect(fe_ep)
         client_b.connect(fe_ep)
@@ -912,9 +935,12 @@ def test_proxy_with_capture(tcp_endpoint):
     client = ctx.socket(zmq.REQ)
 
     try:
-        fe_ep = frontend.bind(tcp_endpoint)
-        be_ep = backend.bind(tcp_endpoint)
-        cap_ep = capture_recv.bind(tcp_endpoint)
+        frontend.bind(tcp_endpoint)
+        fe_ep = frontend.last_endpoint
+        backend.bind(tcp_endpoint)
+        be_ep = backend.last_endpoint
+        capture_recv.bind(tcp_endpoint)
+        cap_ep = capture_recv.last_endpoint
         capture.connect(cap_ep)
         worker.connect(be_ep)
         client.connect(fe_ep)
@@ -959,9 +985,12 @@ def test_proxy_steerable(tcp_endpoint):
     controller = ctx.socket(zmq.PUSH)
 
     try:
-        fe_ep = frontend.bind(tcp_endpoint)
-        be_ep = backend.bind(tcp_endpoint)
-        ctrl_ep = control.bind(tcp_endpoint)
+        frontend.bind(tcp_endpoint)
+        fe_ep = frontend.last_endpoint
+        backend.bind(tcp_endpoint)
+        be_ep = backend.last_endpoint
+        control.bind(tcp_endpoint)
+        ctrl_ep = control.last_endpoint
         sender.connect(fe_ep)
         receiver.connect(be_ep)
         controller.connect(ctrl_ep)

--- a/bindings/pyomq/tests/test_compression.py
+++ b/bindings/pyomq/tests/test_compression.py
@@ -1,8 +1,7 @@
 """Compression transport smoke tests."""
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 pytestmark = pytest.mark.skipif(not zmq.has("zstd"), reason="zstd feature not compiled")
 
@@ -31,7 +30,8 @@ def test_zstd_push_pull_custom_level(tcp_endpoint):
         pull.rcvtimeo = 2000
         push.compression_level = 1
         assert push.compression_level == 1
-        ep = pull.bind(_zstd(tcp_endpoint))
+        pull.bind(_zstd(tcp_endpoint))
+        ep = pull.last_endpoint
         push.connect(ep)
         msg = _payload(1, 4096)
         push.send(msg)
@@ -51,7 +51,8 @@ def test_zstd_push_pull_static_dict(tcp_endpoint):
         push.compression_level = 1
         push.compression_dict = ZSTD_DICT
         assert push.compression_dict == ZSTD_DICT
-        ep = pull.bind(_zstd(tcp_endpoint))
+        pull.bind(_zstd(tcp_endpoint))
+        ep = pull.last_endpoint
         push.connect(ep)
         msg = _payload(2)
         push.send(msg)
@@ -70,7 +71,8 @@ def test_zstd_push_pull_auto_train(tcp_endpoint):
         pull.rcvtimeo = 2000
         push.compression_auto_train = 1
         assert push.compression_auto_train == 1
-        ep = pull.bind(_zstd(tcp_endpoint))
+        pull.bind(_zstd(tcp_endpoint))
+        ep = pull.last_endpoint
         push.connect(ep)
         messages = [_payload(i) for i in range(130)]
         for msg in messages:

--- a/bindings/pyomq/tests/test_connect_before_bind.py
+++ b/bindings/pyomq/tests/test_connect_before_bind.py
@@ -8,11 +8,9 @@ with PUSH/PULL, REQ/REP, and PAIR.
 import errno
 import time
 
-import pytest
-
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
-
+import pytest
 
 BIND_DELAYS = [0, 0.05, 0.25]
 TCP_BIND_RETRIES = 20

--- a/bindings/pyomq/tests/test_curve.py
+++ b/bindings/pyomq/tests/test_curve.py
@@ -2,9 +2,8 @@
 
 import time
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 @pytest.mark.skipif(not zmq.has("curve"), reason="curve feature not compiled")
@@ -86,7 +85,8 @@ def test_curve_push_pull_tcp(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     try:
         _curve_server_client(pull, push)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello over curve")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -104,7 +104,8 @@ def test_curve_req_rep_tcp(tcp_endpoint):
     req = ctx.socket(zmq.REQ)
     try:
         _curve_server_client(rep, req)
-        ep = rep.bind(tcp_endpoint)
+        rep.bind(tcp_endpoint)
+        ep = rep.last_endpoint
         req.connect(ep)
         req.setsockopt(zmq.SNDTIMEO, 5000)
         rep.setsockopt(zmq.RCVTIMEO, 5000)
@@ -126,7 +127,8 @@ def test_curve_pub_sub_tcp(tcp_endpoint):
     sub = ctx.socket(zmq.SUB)
     try:
         _curve_server_client(pub, sub)
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.setsockopt(zmq.SUBSCRIBE, b"hot/")
         sub.connect(ep)
         sub.setsockopt(zmq.RCVTIMEO, 5000)
@@ -147,7 +149,8 @@ def test_curve_multipart_tcp(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     try:
         _curve_server_client(pull, push)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"a", b"bb", b"ccc"])
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -171,7 +174,8 @@ def test_curve_bad_serverkey_rejects(tcp_endpoint):
         pull.curve_server = 1
         pull.curve_publickey = server_pub
         pull.curve_secretkey = server_sec
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
 
         push.curve_serverkey = wrong_pub
         push.curve_publickey = client_pub

--- a/bindings/pyomq/tests/test_curve_auth.py
+++ b/bindings/pyomq/tests/test_curve_auth.py
@@ -1,9 +1,7 @@
 """CURVE client authentication tests."""
 
-import pytest
-
 import pyomq as zmq
-
+import pytest
 
 pytestmark = pytest.mark.skipif(
     not zmq.has("curve"), reason="curve feature not compiled"
@@ -33,7 +31,8 @@ def test_curve_auth_allowed_keys_accept(tcp_endpoint):
     try:
         client_pub = _setup_curve(pull, push)
         pull.set_curve_auth([client_pub])
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"allowed")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -52,7 +51,8 @@ def test_curve_auth_allowed_keys_reject(tcp_endpoint):
         _setup_curve(pull, push)
         other_pub, _ = zmq.curve_keypair()
         pull.set_curve_auth([other_pub])
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"should not arrive")
         pull.setsockopt(zmq.RCVTIMEO, 1000)
@@ -71,7 +71,8 @@ def test_curve_auth_callback_accept(tcp_endpoint):
     try:
         client_pub = _setup_curve(pull, push)
         pull.set_curve_auth(lambda peer: peer.public_key == client_pub)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"callback ok")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -89,7 +90,8 @@ def test_curve_auth_callback_reject(tcp_endpoint):
     try:
         _setup_curve(pull, push)
         pull.set_curve_auth(lambda peer: False)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"rejected")
         pull.setsockopt(zmq.RCVTIMEO, 1000)
@@ -108,7 +110,8 @@ def test_curve_auth_none_accepts_all(tcp_endpoint):
     try:
         _setup_curve(pull, push)
         pull.set_curve_auth(None)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"open")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -132,7 +135,8 @@ def test_curve_auth_callback_receives_z85_key(tcp_endpoint):
             return True
 
         pull.set_curve_auth(auth)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"probe")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -163,7 +167,8 @@ def test_curve_auth_callback_receives_identity(tcp_endpoint):
             return peer.public_key == client_pub and peer.identity == b"client-one"
 
         router.set_curve_auth(auth)
-        ep = router.bind(tcp_endpoint)
+        router.bind(tcp_endpoint)
+        ep = router.last_endpoint
         dealer.connect(ep)
         dealer.send(b"probe")
         router.setsockopt(zmq.RCVTIMEO, 5000)

--- a/bindings/pyomq/tests/test_device.py
+++ b/bindings/pyomq/tests/test_device.py
@@ -13,8 +13,10 @@ def test_device_forwards_messages(tcp_endpoint):
     sender = ctx.socket(zmq.PUSH)
     receiver = ctx.socket(zmq.PULL)
     try:
-        fe_ep = frontend.bind(tcp_endpoint)
-        be_ep = backend.bind("tcp://127.0.0.1:0")
+        frontend.bind(tcp_endpoint)
+        fe_ep = frontend.last_endpoint
+        backend.bind("tcp://127.0.0.1:0")
+        be_ep = backend.last_endpoint
 
         sender.connect(fe_ep)
         receiver.connect(be_ep)

--- a/bindings/pyomq/tests/test_exceptions.py
+++ b/bindings/pyomq/tests/test_exceptions.py
@@ -2,16 +2,16 @@
 
 import errno
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 def test_again_on_rcvtimeo(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.setsockopt(zmq.RCVTIMEO, 50)
         with pytest.raises(zmq.Again):
             pull.recv()
@@ -32,7 +32,8 @@ def test_again_errno(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.setsockopt(zmq.RCVTIMEO, 50)
         with pytest.raises(zmq.Again) as exc_info:
             pull.recv()
@@ -46,7 +47,8 @@ def test_closed_socket_raises_context_terminated(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.close()
         with pytest.raises(zmq.ContextTerminated):
             pull.recv()
@@ -58,7 +60,8 @@ def test_context_terminated_errno(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.close()
         with pytest.raises(zmq.ContextTerminated) as exc_info:
             pull.recv()
@@ -90,7 +93,8 @@ def test_zmqerror_catches_subclasses(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.setsockopt(zmq.RCVTIMEO, 50)
         with pytest.raises(zmq.ZMQError):
             pull.recv()
@@ -103,7 +107,8 @@ def test_zmqbaseerror_catches_all(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         pull.setsockopt(zmq.RCVTIMEO, 50)
         with pytest.raises(zmq.error.ZMQBaseError):
             pull.recv()

--- a/bindings/pyomq/tests/test_fork.py
+++ b/bindings/pyomq/tests/test_fork.py
@@ -5,9 +5,8 @@ import select
 import sys
 import time
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:This process .* is multi-threaded, use of fork:DeprecationWarning"
@@ -56,7 +55,8 @@ def test_socket_works_after_fork():
     ctx = zmq.Context()
     push = ctx.socket(zmq.PUSH)
     push.setsockopt(zmq.SNDTIMEO, FORK_TIMEOUT_MS)
-    ep = push.bind("tcp://127.0.0.1:0")
+    push.bind("tcp://127.0.0.1:0")
+    ep = push.last_endpoint
 
     r, w = os.pipe()
     pid = os.fork()  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
@@ -88,7 +88,8 @@ def test_pre_materialized_socket_works_after_fork():
     pull = ctx.socket(zmq.PULL)
     push.setsockopt(zmq.SNDTIMEO, FORK_TIMEOUT_MS)
     pull.setsockopt(zmq.RCVTIMEO, FORK_TIMEOUT_MS)
-    ep = pull.bind("tcp://127.0.0.1:0")
+    pull.bind("tcp://127.0.0.1:0")
+    ep = pull.last_endpoint
     push.connect(ep)
 
     # Materialize by sending a message before fork.

--- a/bindings/pyomq/tests/test_inproc_namespace.py
+++ b/bindings/pyomq/tests/test_inproc_namespace.py
@@ -2,8 +2,8 @@
 
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
-from pyomq.testing import rust_thread_send_via_share_key
 import pytest
+from pyomq.testing import rust_thread_send_via_share_key
 
 
 def test_two_contexts_same_inproc_name():

--- a/bindings/pyomq/tests/test_inproc_throughput.py
+++ b/bindings/pyomq/tests/test_inproc_throughput.py
@@ -4,9 +4,8 @@ import os
 import threading
 import time
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 ATTEMPTS = 3
 MIN_RATE = 650_000

--- a/bindings/pyomq/tests/test_interop.py
+++ b/bindings/pyomq/tests/test_interop.py
@@ -69,7 +69,8 @@ def test_pyomq_push_pyzmq_pull(endpoint):
 def test_pyzmq_push_pyomq_pull(endpoint):
     ctx = pyomq.Context()
     pull = ctx.socket(pyomq.PULL)
-    ep = pull.bind(endpoint)
+    pull.bind(endpoint)
+    ep = pull.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         push = py_ctx.socket(zmq_pyzmq.PUSH)
@@ -89,7 +90,8 @@ def test_pyzmq_push_pyomq_pull(endpoint):
 def test_pyomq_pub_pyzmq_sub(endpoint):
     ctx = pyomq.Context()
     pub = ctx.socket(pyomq.PUB)
-    ep = pub.bind(endpoint)
+    pub.bind(endpoint)
+    ep = pub.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         sub = py_ctx.socket(zmq_pyzmq.SUB)
@@ -163,7 +165,8 @@ def test_pyomq_req_pyzmq_rep(endpoint):
 def test_pyzmq_req_pyomq_rep(endpoint):
     ctx = pyomq.Context()
     rep = ctx.socket(pyomq.REP)
-    ep = rep.bind(endpoint)
+    rep.bind(endpoint)
+    ep = rep.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         req = py_ctx.socket(zmq_pyzmq.REQ)
@@ -212,7 +215,8 @@ def test_pyomq_dealer_pyzmq_router(endpoint):
 def test_pyzmq_dealer_pyomq_router(endpoint):
     ctx = pyomq.Context()
     router = ctx.socket(pyomq.ROUTER)
-    ep = router.bind(endpoint)
+    router.bind(endpoint)
+    ep = router.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         dealer = py_ctx.socket(zmq_pyzmq.DEALER)
@@ -267,7 +271,8 @@ def test_pyomq_xpub_pyzmq_xsub(endpoint):
     legacy 3.0 0x01-prefix message form pyzmq XSUB emits."""
     ctx = pyomq.Context()
     xpub = ctx.socket(pyomq.XPUB)
-    ep = xpub.bind(endpoint)
+    xpub.bind(endpoint)
+    ep = xpub.last_endpoint
     try:
         py_ctx = zmq_pyzmq.Context.instance()
         xsub = py_ctx.socket(zmq_pyzmq.XSUB)

--- a/bindings/pyomq/tests/test_interop_curve.py
+++ b/bindings/pyomq/tests/test_interop_curve.py
@@ -17,9 +17,8 @@ zmq_pyzmq = pytest.importorskip("zmq")
 pytestmark = pytest.mark.event_loop("selector")
 
 
-from zmq.auth.thread import ThreadAuthenticator
-
 import pyomq
+from zmq.auth.thread import ThreadAuthenticator
 
 _skip_no_curve = pytest.mark.skipif(
     not pyomq.has("curve"), reason="curve feature not compiled"
@@ -39,7 +38,8 @@ def test_pyomq_curve_server_pyzmq_curve_client_push_pull(tcp_endpoint):
     pull.curve_server = 1
     pull.curve_publickey = server_pub
     pull.curve_secretkey = server_sec
-    ep = pull.bind(tcp_endpoint)
+    pull.bind(tcp_endpoint)
+    ep = pull.last_endpoint
 
     py_ctx = zmq_pyzmq.Context.instance()
     push = py_ctx.socket(zmq_pyzmq.PUSH)
@@ -67,7 +67,8 @@ def test_pyomq_curve_server_pyzmq_curve_client_req_rep(tcp_endpoint):
     rep.curve_server = 1
     rep.curve_publickey = server_pub
     rep.curve_secretkey = server_sec
-    ep = rep.bind(tcp_endpoint)
+    rep.bind(tcp_endpoint)
+    ep = rep.last_endpoint
 
     py_ctx = zmq_pyzmq.Context.instance()
     req = py_ctx.socket(zmq_pyzmq.REQ)

--- a/bindings/pyomq/tests/test_key_errors.py
+++ b/bindings/pyomq/tests/test_key_errors.py
@@ -1,8 +1,7 @@
 """Verify bad key data raises ValueError (not panic) on first I/O."""
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 @pytest.mark.skipif(not zmq.has("curve"), reason="curve not compiled")

--- a/bindings/pyomq/tests/test_message_compat.py
+++ b/bindings/pyomq/tests/test_message_compat.py
@@ -1,5 +1,7 @@
 """Message, Frame, MessageTracker compat classes."""
 
+from threading import Event
+
 import pyomq as zmq
 
 
@@ -58,10 +60,10 @@ def test_message_tracker_done():
 
 
 def test_message_tracker_pending():
-    t = zmq.MessageTracker(_pending=True)
+    t = zmq.MessageTracker(Event())
     assert t.done is False
     try:
-        t.wait()
+        t.wait(0)
         assert False, "should have raised NotDone"
     except zmq.NotDone:
         pass

--- a/bindings/pyomq/tests/test_options.py
+++ b/bindings/pyomq/tests/test_options.py
@@ -3,9 +3,8 @@
 import threading
 import time
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 def _push():

--- a/bindings/pyomq/tests/test_plain.py
+++ b/bindings/pyomq/tests/test_plain.py
@@ -2,9 +2,8 @@
 
 import time
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 def _plain_server_client(server_sock, client_sock):
@@ -21,7 +20,8 @@ def test_plain_push_pull_tcp(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     try:
         _plain_server_client(pull, push)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello over plain")
         pull.setsockopt(zmq.RCVTIMEO, 5000)
@@ -42,7 +42,8 @@ def test_plain_fixed_policy_accepts_each_allowlist_entry(tcp_endpoint):
         pull.set_plain_auth([("alice", "secret"), ("bob", "hunter2")])
         push.plain_username = b"bob"
         push.plain_password = b"hunter2"
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"second credential")
         pull.rcvtimeo = 5000
@@ -86,7 +87,8 @@ def test_plain_fixed_policy_rejects_wrong_password(tcp_endpoint):
         pull.set_plain_auth([("alice", "secret")])
         push.plain_username = b"alice"
         push.plain_password = b"wrong"
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"blocked")
         pull.rcvtimeo = 300
@@ -142,7 +144,8 @@ def test_plain_server_callback_receives_credentials(tcp_endpoint):
         pull.set_plain_auth(authenticate)
         push.plain_username = b"alice"
         push.plain_password = b"secret"
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"authenticated")
         pull.rcvtimeo = 5000
@@ -161,7 +164,8 @@ def test_plain_req_rep_tcp(tcp_endpoint):
     req = ctx.socket(zmq.REQ)
     try:
         _plain_server_client(rep, req)
-        ep = rep.bind(tcp_endpoint)
+        rep.bind(tcp_endpoint)
+        ep = rep.last_endpoint
         req.connect(ep)
         req.setsockopt(zmq.SNDTIMEO, 5000)
         rep.setsockopt(zmq.RCVTIMEO, 5000)
@@ -183,7 +187,8 @@ def test_plain_pub_sub_tcp(tcp_endpoint):
     sub = ctx.socket(zmq.SUB)
     try:
         _plain_server_client(pub, sub)
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.setsockopt(zmq.SUBSCRIBE, b"hot/")
         sub.connect(ep)
         sub.setsockopt(zmq.RCVTIMEO, 5000)
@@ -204,7 +209,8 @@ def test_plain_multipart_tcp(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     try:
         _plain_server_client(pull, push)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"a", b"bb", b"ccc"])
         pull.setsockopt(zmq.RCVTIMEO, 5000)

--- a/bindings/pyomq/tests/test_poller.py
+++ b/bindings/pyomq/tests/test_poller.py
@@ -13,10 +13,12 @@ def test_poll_returns_ready(tcp_endpoint):
     pull2 = ctx.socket(zmq.PULL)
     push2 = ctx.socket(zmq.PUSH)
     try:
-        ep = pull1.bind(tcp_endpoint)
+        pull1.bind(tcp_endpoint)
+        ep = pull1.last_endpoint
         push1.connect(ep)
 
-        ep2 = pull2.bind(tcp_endpoint)
+        pull2.bind(tcp_endpoint)
+        ep2 = pull2.last_endpoint
         push2.connect(ep2)
 
         push1.send(b"only-one")
@@ -43,7 +45,8 @@ def test_poll_timeout_empty(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         poller = zmq.Poller()
         poller.register(pull, zmq.POLLIN)
         events = poller.poll(timeout=50)
@@ -98,10 +101,12 @@ def test_poll_multiple_ready(tcp_endpoint):
     push2 = ctx.socket(zmq.PUSH)
     pull2 = ctx.socket(zmq.PULL)
     try:
-        ep = pull1.bind(tcp_endpoint)
+        pull1.bind(tcp_endpoint)
+        ep = pull1.last_endpoint
         push1.connect(ep)
 
-        ep2 = pull2.bind(tcp_endpoint)
+        pull2.bind(tcp_endpoint)
+        ep2 = pull2.last_endpoint
         push2.connect(ep2)
 
         push1.send(b"msg1")
@@ -136,7 +141,8 @@ def test_register_unregister(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
         time.sleep(0.02)
@@ -158,7 +164,8 @@ def test_modify_flags(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
         time.sleep(0.02)
@@ -186,7 +193,8 @@ def test_poll_no_busywait(tcp_endpoint):
     ctx = zmq.Context()
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         poller = zmq.Poller()
         poller.register(pull, zmq.POLLIN)
 

--- a/bindings/pyomq/tests/test_public_contract.py
+++ b/bindings/pyomq/tests/test_public_contract.py
@@ -1,0 +1,184 @@
+"""Runtime checks for public contracts not exercised by native stubtest."""
+
+import errno
+from typing import Any, cast
+
+import pyomq as zmq
+import pyomq.asyncio as azmq
+import pytest
+
+
+@pytest.mark.parametrize("context", [zmq.Context, azmq.Context])
+def test_bytes_endpoints_and_metadata(context):
+    with context() as ctx, ctx.socket(zmq.PUSH) as socket:
+        scope = socket.bind(b"inproc://bytes-contract")
+        assert scope.addr == "inproc://bytes-contract"
+        assert socket.last_endpoint == b"inproc://bytes-contract"
+        assert socket.getsockopt(zmq.LAST_ENDPOINT) == b"inproc://bytes-contract"
+        socket.unbind(b"inproc://bytes-contract")
+        socket.connect(b"inproc://bytes-contract")
+        socket.disconnect(b"inproc://bytes-contract")
+        assert socket.connection_info(999_999) is None
+
+
+@pytest.mark.parametrize("context", [zmq.Context, azmq.Context])
+def test_auth_accepts_one_shot_iterables(context):
+    with context() as ctx, ctx.socket(zmq.PULL) as socket:
+        socket.set_plain_auth(pair for pair in [("user", "password")])
+        public, _ = zmq.curve_keypair()
+        socket.set_curve_auth(key for key in [public])
+
+
+def test_error_constructor_contract():
+    error = zmq.ZMQError(errno.EAGAIN)
+    assert error.errno == errno.EAGAIN
+    assert error.strerror == zmq.strerror(errno.EAGAIN)
+    assert str(error) == error.strerror
+    error = zmq.ZMQError(errno=errno.EINVAL, msg="invalid")
+    assert error.errno == errno.EINVAL
+    assert str(error) == error.strerror == "invalid"
+    assert zmq.ZMQError("message").strerror == "message"
+    assert zmq.ZMQError(msg="message").strerror == "message"
+    assert zmq.ZMQError().errno is None
+
+
+def test_pyzmq_keyword_and_scope_contracts():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        bind_scope = pull.bind("inproc://scope-contract")
+        assert bind_scope.socket is pull
+        assert bind_scope.kind == "bind"
+        assert bind_scope.addr == "inproc://scope-contract"
+        assert not isinstance(bind_scope, str)
+        assert str(bind_scope) == "<SocketContext(bind='inproc://scope-contract')>"
+        with pytest.raises(TypeError):
+            push.connect(cast(Any, bind_scope))
+        push.connect(pull.last_endpoint)
+        push.send_multipart(msg_parts=[b"one", b"two"])
+        assert pull.recv_multipart() == [b"one", b"two"]
+        bind_scope.__exit__()
+
+        with pull.bind("inproc://scope-contract-with") as bound:
+            assert bound is pull
+            with push.connect("inproc://scope-contract-with") as connected:
+                assert connected is push
+
+        sub = ctx.socket(zmq.SUB)
+        sub.subscribe(topic=b"topic")
+        sub.unsubscribe(topic=b"topic")
+        sub.close()
+
+        dealer = ctx.socket(zmq.DEALER)
+        dealer.setsockopt_string(zmq.IDENTITY, optval="identity")
+        assert dealer.getsockopt(zmq.IDENTITY) == b"identity"
+        dealer.close()
+
+        _, secret_key = zmq.curve_keypair()
+        assert zmq.curve_public(secret_key=secret_key)
+        assert zmq.strerror(errno=zmq.EAGAIN)
+
+
+def test_recv_into_matches_pyzmq_copy_contract():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        endpoint = "inproc://recv-into-contract"
+        pull.bind(endpoint)
+        push.connect(endpoint)
+        target = bytearray(3)
+        push.send(b"hello")
+        assert pull.recv_into(target) == 5
+        assert target == b"hel"
+        target = bytearray(10)
+        push.send(b"hello")
+        assert pull.recv_into(target, nbytes=2) == 5
+        assert target[:2] == b"he"
+
+
+def test_context_shadow_constructor_contract():
+    with zmq.Context() as context:
+        with zmq.Context(shadow=context) as shadow:
+            assert shadow._ctx is context._ctx
+        with zmq.Context(context) as shadow:
+            assert shadow._ctx is context._ctx
+    with azmq.Context() as context, azmq.Context(shadow=context) as shadow:
+        assert shadow._ctx is context._ctx
+
+
+def test_routing_id_keyword_contract():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.SERVER) as server,
+        ctx.socket(zmq.CLIENT) as client,
+    ):
+        endpoint = "inproc://routing-id-contract"
+        server.bind(endpoint)
+        client.connect(endpoint)
+        client.send(b"ping")
+        request = server.recv(copy=False)
+        server.send_multipart(msg_parts=[b"pong"], routing_id=request.routing_id)
+        assert client.recv() == b"pong"
+
+
+@pytest.mark.asyncio
+async def test_async_recv_into_contract():
+    with (
+        azmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        endpoint = "inproc://async-recv-into-contract"
+        pull.bind(endpoint)
+        push.connect(endpoint)
+        target = bytearray(3)
+        await push.send(b"hello")
+        assert await pull.recv_into(target) == 5
+        assert target == b"hel"
+
+
+@pytest.mark.asyncio
+async def test_stream_callbacks_receive_parts_and_tracker():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        pull.bind("inproc://stream-callbacks")
+        push.connect("inproc://stream-callbacks")
+        stream = zmq.ZMQStream(push)
+        called = []
+        stream.on_send(
+            lambda parts, tracker: called.append(("default", parts, tracker))
+        )
+        tracker = stream.send(b"first", copy=False, track=True)
+        assert called == [("default", [b"first"], tracker)]
+        assert pull.recv() == b"first"
+        tracker = stream.send_multipart(
+            (part for part in [b"second", b"third"]),
+            copy=False,
+            track=True,
+            callback=lambda parts, tracker: called.append(("override", parts, tracker)),
+        )
+        assert called[-1] == ("override", [b"second", b"third"], tracker)
+        assert len(called) == 2
+        assert pull.recv_multipart() == [b"second", b"third"]
+
+        class FalseyCallback:
+            def __bool__(self):
+                return False
+
+            def __call__(self, parts, tracker):
+                called.append(("falsey", parts, tracker))
+
+        stream.send(b"fourth", callback=FalseyCallback())
+        assert called[-1] == ("falsey", [b"fourth"], None)
+        assert pull.recv() == b"fourth"
+        stream.send_multipart(iter([b"fifth"]), callback=FalseyCallback())
+        assert called[-1] == ("falsey", [b"fifth"], None)
+        assert pull.recv_multipart() == [b"fifth"]
+        stream.close()

--- a/bindings/pyomq/tests/test_pubsub.py
+++ b/bindings/pyomq/tests/test_pubsub.py
@@ -10,7 +10,8 @@ def test_pub_sub_prefix_filter(tcp_endpoint):
     pub = ctx.socket(zmq.PUB)
     sub = ctx.socket(zmq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.setsockopt(zmq.SUBSCRIBE, b"weather/")
         # PUB/SUB has no built-in handshake; give the SUBSCRIBE a moment
@@ -33,7 +34,8 @@ def test_unsubscribe_drops_topic(tcp_endpoint):
     pub = ctx.socket(zmq.PUB)
     sub = ctx.socket(zmq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.setsockopt(zmq.SUBSCRIBE, b"a")
         sub.setsockopt(zmq.SUBSCRIBE, b"b")
@@ -55,16 +57,17 @@ def test_subscribe_helpers_accept_str_prefixes(tcp_endpoint):
     pub = ctx.socket(zmq.PUB)
     sub = ctx.socket(zmq.SUB)
     try:
-        ep = pub.bind(tcp_endpoint)
+        pub.bind(tcp_endpoint)
+        ep = pub.last_endpoint
         sub.connect(ep)
         sub.subscribe("weather/")
         time.sleep(0.2)
         sub.unsubscribe("weather/")
-        sub.subscribe("sports/")
+        sub.subscribe("")
         time.sleep(0.2)
-        pub.send(b"weather/sunny")
+        # pub.send(b"weather/sunny")
         pub.send(b"sports/score-12")
-        sub.setsockopt(zmq.RCVTIMEO, 500)
+        # sub.setsockopt(zmq.RCVTIMEO, 500)
         assert sub.recv() == b"sports/score-12"
     finally:
         pub.close()

--- a/bindings/pyomq/tests/test_recv_future.py
+++ b/bindings/pyomq/tests/test_recv_future.py
@@ -8,14 +8,47 @@ import threading
 import types
 from typing import Any
 
-import pytest
-
 import pyomq
 import pyomq.asyncio as zmq_async
+import pytest
 
 
 async def _await(value):
     return await value
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix fd readiness path only")
+@pytest.mark.parametrize("fails", [False, True])
+def test_completed_future_releases_fd_while_retained(fails):
+    read_fd, write_fd = os.pipe()
+
+    def receive():
+        if fails:
+            raise RuntimeError("closed")
+        return b"received"
+
+    pending = zmq_async._RecvFuture(receive, read_fd)
+    try:
+        assert pending.done()
+        with pytest.raises(OSError):
+            os.fstat(read_fd)
+        if fails:
+            with pytest.raises(RuntimeError, match="closed"):
+                pending.result()
+        else:
+            assert pending.result() == b"received"
+    finally:
+        os.close(write_fd)
+        if pending._fd >= 0:
+            os.close(pending._fd)
+            pending._fd = -1
+
+
+def test_untracked_receives_do_not_allocate_closure_cells():
+    # Capturing self in a tracked-only closure still allocates a cell on
+    # every ordinary receive. Keep that work off the measured hot path.
+    assert not zmq_async.Socket.recv.__code__.co_cellvars
+    assert not zmq_async.Socket.recv_multipart.__code__.co_cellvars
 
 
 @pytest.mark.asyncio
@@ -24,7 +57,8 @@ async def test_recv_future_await(tcp_endpoint):
     push = ctx.socket(pyomq.PUSH)
     pull = ctx.socket(pyomq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"await-test")
         msg = await pull.recv()
@@ -41,7 +75,8 @@ async def test_recv_future_fast_path(tcp_endpoint):
     push = ctx.socket(pyomq.PUSH)
     pull = ctx.socket(pyomq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"fast")
         await asyncio.sleep(0.1)
@@ -59,7 +94,8 @@ async def test_recv_future_done_transitions(tcp_endpoint):
     push = ctx.socket(pyomq.PUSH)
     pull = ctx.socket(pyomq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         fut = pull.recv()
@@ -67,6 +103,8 @@ async def test_recv_future_done_transitions(tcp_endpoint):
         push.send(b"done-test")
         msg = await fut
         assert msg == b"done-test"
+        assert fut.done()
+        assert fut.result() == b"done-test"
     finally:
         push.close()
         pull.close()
@@ -74,12 +112,13 @@ async def test_recv_future_done_transitions(tcp_endpoint):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix fd readiness path only")
 @pytest.mark.asyncio
-async def test_cancelled_read_does_not_close_reused_fd(tcp_endpoint, monkeypatch):
+async def test_canceled_read_preserves_message_and_reused_fd(tcp_endpoint, monkeypatch):
     ctx = zmq_async.Context()
     push = ctx.socket(pyomq.PUSH)
     pull = ctx.socket(pyomq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         pending: Any = pull.recv_multipart()
@@ -92,6 +131,7 @@ async def test_cancelled_read_does_not_close_reused_fd(tcp_endpoint, monkeypatch
         assert ready
 
         replacement: list[Any] = []
+        recovered = []
         replacement_created = asyncio.Event()
         real_os = zmq_async.os
         os_proxy = types.ModuleType("os")
@@ -100,6 +140,7 @@ async def test_cancelled_read_does_not_close_reused_fd(tcp_endpoint, monkeypatch
         def close_and_reuse(fd: int) -> None:
             os.close(fd)
             if fd == old_fd and not replacement:
+                recovered.append(pull._sock._try_recv_multipart())
                 replacement_waiter: Any = pull.recv_multipart()
                 if replacement_waiter._fd != old_fd:
                     os.dup2(replacement_waiter._fd, old_fd)
@@ -108,11 +149,12 @@ async def test_cancelled_read_does_not_close_reused_fd(tcp_endpoint, monkeypatch
                 replacement.append(replacement_waiter)
                 replacement_created.set()
 
-        setattr(os_proxy, "close", close_and_reuse)
+        os_proxy.__dict__["close"] = close_and_reuse
         monkeypatch.setattr(zmq_async, "os", os_proxy)
 
         asyncio.get_running_loop().call_soon(pending_task.cancel)
         await replacement_created.wait()
+        assert recovered == [[b"raced"]]
         assert replacement[0]._fd == old_fd
 
         replacement_task = asyncio.create_task(_await(replacement[0]))
@@ -135,7 +177,8 @@ async def test_windows_cancelled_recv_does_not_stall_replacement(tcp_endpoint):
     push = ctx.socket(pyomq.PUSH)
     pull = ctx.socket(pyomq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         for index in range(200):

--- a/bindings/pyomq/tests/test_reqrep.py
+++ b/bindings/pyomq/tests/test_reqrep.py
@@ -10,7 +10,8 @@ def test_req_rep_roundtrip(tcp_endpoint):
     rep = ctx.socket(zmq.REP)
     req = ctx.socket(zmq.REQ)
     try:
-        ep = rep.bind(tcp_endpoint)
+        rep.bind(tcp_endpoint)
+        ep = rep.last_endpoint
         req.connect(ep)
         req.send(b"ping")
         assert rep.recv() == b"ping"
@@ -28,14 +29,15 @@ def test_rep_accepts_reply_while_client_closes(tcp_endpoint):
     rep.setsockopt(zmq.RCVTIMEO, 1_000)
     rep.setsockopt(zmq.SNDTIMEO, 1_000)
     rep.setsockopt(zmq.LINGER, 0)
-    endpoint = rep.bind(tcp_endpoint)
+    rep.bind(tcp_endpoint)
+    endpoint = rep.last_endpoint
     failure = []
 
     def serve():
         try:
             for _ in range(21):
                 rep.send(rep.recv())
-        except Exception as error:  # noqa: BLE001 - preserve thread failure
+        except Exception as error:
             failure.append(error)
 
     server = threading.Thread(target=serve)
@@ -65,7 +67,8 @@ def test_dealer_router_identity_routes_back(tcp_endpoint):
     dealer = ctx.socket(zmq.DEALER)
     try:
         dealer.setsockopt(zmq.IDENTITY, b"client-A")
-        ep = router.bind(tcp_endpoint)
+        router.bind(tcp_endpoint)
+        ep = router.last_endpoint
         dealer.connect(ep)
         # DEALER sends; ROUTER recv exposes the identity as the first frame.
         dealer.send(b"hello")

--- a/bindings/pyomq/tests/test_send_backpressure.py
+++ b/bindings/pyomq/tests/test_send_backpressure.py
@@ -2,10 +2,9 @@
 
 import asyncio
 
-import pytest
-
 import pyomq
 import pyomq.asyncio as zmq_async
+import pytest
 
 
 @pytest.mark.asyncio
@@ -16,7 +15,8 @@ async def test_async_send_completes_after_drain(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     try:
         push.setsockopt(pyomq.SNDHWM, 2)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         await asyncio.sleep(0.1)
 
@@ -44,7 +44,8 @@ async def test_async_send_does_not_block_event_loop(tcp_endpoint):
     pull = ctx.socket(pyomq.PULL)
     try:
         push.setsockopt(pyomq.SNDHWM, 1)
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         await asyncio.sleep(0.1)
 

--- a/bindings/pyomq/tests/test_shadow.py
+++ b/bindings/pyomq/tests/test_shadow.py
@@ -2,11 +2,9 @@
 
 import asyncio
 
-import pytest
-
 import pyomq as zmq
 import pyomq.asyncio as zmq_async
-
+import pytest
 
 # ── Context.shadow ──────────────────────────────────────────────────
 
@@ -64,7 +62,8 @@ async def test_context_shadow_async_creates_sync_native_socket(inproc_endpoint):
         assert type(pull._sock) is zmq._native.Socket
 
         pull.setsockopt(zmq.RCVTIMEO, 1000)
-        ep = pull.bind(inproc_endpoint)
+        pull.bind(inproc_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         await push.send(b"hello")
         assert pull.recv() == b"hello"
@@ -88,7 +87,8 @@ async def test_async_context_shadow_sync_creates_async_native_socket(inproc_endp
         assert type(pull) is zmq_async.Socket
         assert type(pull._sock) is zmq._native.AsyncSocket
 
-        ep = pull.bind(inproc_endpoint)
+        pull.bind(inproc_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
         assert await asyncio.wait_for(pull.recv(), timeout=1.0) == b"hello"
@@ -134,7 +134,8 @@ async def test_shadow_recv(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send(b"hello")
 
@@ -153,7 +154,8 @@ async def test_shadow_recv_multipart(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
         push.send_multipart([b"a", b"b"])
 
@@ -172,7 +174,8 @@ async def test_shadow_send(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         shadow = zmq.Socket.shadow(push)

--- a/bindings/pyomq/tests/test_socket_attrs.py
+++ b/bindings/pyomq/tests/test_socket_attrs.py
@@ -1,8 +1,7 @@
 """Socket attribute-style option access (pyzmq compat)."""
 
-import pytest
-
 import pyomq as zmq
+import pytest
 
 
 def test_linger_attr():

--- a/bindings/pyomq/tests/test_socket_types.py
+++ b/bindings/pyomq/tests/test_socket_types.py
@@ -9,9 +9,8 @@ the binding to a working peer.
 import socket as stdsocket
 import time
 
-import pytest
-
 import pyomq
+import pytest
 
 ALL_TYPES = [
     pyomq.PAIR,
@@ -68,7 +67,8 @@ def test_pub_sub():
     ctx = pyomq.Context()
     pub = ctx.socket(pyomq.PUB)
     sub = ctx.socket(pyomq.SUB)
-    ep = pub.bind("tcp://127.0.0.1:0")
+    pub.bind("tcp://127.0.0.1:0")
+    ep = pub.last_endpoint
     sub.connect(ep)
     sub.subscribe(b"")
     time.sleep(0.05)
@@ -92,7 +92,8 @@ def test_xpub_xsub():
     ctx = pyomq.Context()
     xpub = ctx.socket(pyomq.XPUB)
     xsub = ctx.socket(pyomq.XSUB)
-    ep = xpub.bind("tcp://127.0.0.1:0")
+    xpub.bind("tcp://127.0.0.1:0")
+    ep = xpub.last_endpoint
     xsub.connect(ep)
     xsub.subscribe(b"")
     # Drain the subscribe notification at XPUB. RFC says it surfaces as
@@ -261,13 +262,19 @@ def test_radio_dish_udp_with_groups():
     time.sleep(0.05)
 
     # Drop: not in joined groups.
-    radio.send_multipart([b"news", b"ignored"])
+    radio.send(b"ignored", group="news")
     # Deliver.
-    radio.send_multipart([b"weather", b"sunny"])
+    radio.send(b"sunny", group="weather")
 
     dish.setsockopt(pyomq.RCVTIMEO, 500)
-    parts = dish.recv_multipart()
-    assert parts == [b"weather", b"sunny"]
+    assert dish.recv() == b"sunny"
+
+    frame = pyomq.Frame(b"cloudy")
+    frame.group = "weather"
+    radio.send(frame)
+    received = dish.recv(copy=False)
+    assert bytes(received) == b"cloudy"
+    assert received.group == "weather"
 
     dish.leave(b"weather")
     radio.close()
@@ -291,12 +298,16 @@ def test_radio_dish_helpers_accept_str_groups():
         radio.connect(ep)
         time.sleep(0.05)
 
-        radio.send_multipart([b"weather", b"sunny"])
+        radio.send_multipart([b"sunny"], group="weather")
         dish.setsockopt(pyomq.RCVTIMEO, 500)
-        assert dish.recv_multipart() == [b"weather", b"sunny"]
+        assert dish.recv_multipart() == [b"sunny"]
+        with pytest.raises(ValueError, match="RADIO requires a group"):
+            radio.send(b"no-group")
+        with pytest.raises(ValueError, match="RADIO requires"):
+            radio.send_multipart([b"weather", b"raw-group"])
 
         dish.leave("weather")
-        radio.send_multipart([b"weather", b"ignored"])
+        radio.send_multipart([b"ignored"], group="weather")
         try:
             msg = dish.recv_multipart()
         except pyomq.Again:
@@ -313,11 +324,12 @@ def test_stream_raw_tcp():
     """STREAM socket accepts raw TCP and echoes data back."""
     ctx = pyomq.Context()
     stream = ctx.socket(pyomq.STREAM)
-    ep = stream.bind("tcp://127.0.0.1:0")
+    stream.bind("tcp://127.0.0.1:0")
+    ep = stream.last_endpoint
     stream.setsockopt(pyomq.RCVTIMEO, 1000)
 
     raw = stdsocket.socket(stdsocket.AF_INET, stdsocket.SOCK_STREAM)
-    host, port = ep.replace("tcp://", "").split(":")
+    host, port = ep.decode().replace("tcp://", "").split(":")
     raw.connect((host, int(port)))
     raw.sendall(b"hello")
 

--- a/bindings/pyomq/tests/test_tracking.py
+++ b/bindings/pyomq/tests/test_tracking.py
@@ -1,0 +1,530 @@
+"""Buffer ownership and multipart retry regressions."""
+
+import asyncio
+import gc
+import subprocess
+import sys
+import threading
+import time
+from array import array
+from typing import Any, cast
+
+import pyomq as zmq
+import pyomq.asyncio as azmq
+import pytest
+
+
+async def _fill_send_ring(socket):
+    deadline = time.monotonic() + 3
+    full_rounds = 0
+    while time.monotonic() < deadline:
+        sent = 0
+        for _ in range(10_000):
+            try:
+                socket._sock.send(b"fill")
+                sent += 1
+            except zmq._native.ZMQError as exc:
+                assert exc.errno == zmq.EAGAIN
+                break
+        full_rounds = full_rounds + 1 if sent == 0 else 0
+        if full_rounds == 3:
+            return
+        # Let the native pump finish any batch already taken from the ring.
+        await asyncio.sleep(0.01)
+    pytest.fail("native ring did not remain backpressured")
+
+
+def test_frame_tracker_follows_exported_views():
+    data = bytearray(100_000)
+    frame = zmq.Frame(data, copy=False, track=True)
+    tracker = frame.tracker
+    assert tracker is not None and not tracker.done
+    view = frame.buffer
+    del frame
+    with pytest.raises(zmq.NotDone):
+        tracker.wait(0)
+    del view
+    gc.collect()
+    tracker.wait(2)
+    data.extend(b"safe")
+
+
+def test_tracker_aggregation_and_timeout():
+    first, last = threading.Event(), threading.Event()
+    tracker = zmq.MessageTracker(zmq.MessageTracker(first), last)
+    last.set()
+    with pytest.raises(zmq.NotDone):
+        tracker.wait(0.001)
+    first.set()
+    tracker.wait(0)
+    assert tracker.done
+    with pytest.raises(ValueError):
+        zmq.MessageTracker(zmq.Frame(b"untracked"))
+
+
+@pytest.mark.parametrize("timeout", [None, -1, 2])
+def test_single_native_tracker_wait_releases_gil(timeout):
+    frames = [zmq.Frame(bytearray(100_000), copy=False, track=True)]
+    tracker = frames[0].tracker
+    assert type(tracker) is zmq.MessageTracker
+
+    def release():
+        time.sleep(0.02)
+        frames.clear()
+
+    thread = threading.Thread(target=release)
+    thread.start()
+    try:
+        tracker.wait(timeout)
+    finally:
+        thread.join(2)
+    assert tracker.done
+    tracker.wait(0)
+
+
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), -float("inf")])
+@pytest.mark.parametrize("released", [False, True])
+def test_single_native_tracker_rejects_nonfinite_timeout(timeout, released):
+    frame = zmq.Frame(bytearray(100_000), copy=False, track=True)
+    tracker = frame.tracker
+    assert tracker is not None
+    if released:
+        del frame
+    with pytest.raises(ValueError, match="finite"):
+        tracker.wait(timeout)
+
+
+def test_multipart_preserves_existing_frame_tracker_and_raw_buffer_ownership():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        pull.bind("inproc://mixed-completion-sources")
+        push.connect("inproc://mixed-completion-sources")
+        data = bytearray(100_000)
+        frame = zmq.Frame(data, copy=False, track=True)
+        original = frame.tracker
+        assert original is not None
+        assert push.send_multipart([frame], copy=False, track=True) is original
+        assert pull.recv() == data
+        tracker = push.send_multipart(
+            [bytearray(100_000), frame], copy=False, track=True
+        )
+        assert type(tracker) is zmq.MessageTracker
+        received = pull.recv_multipart(copy=False)
+        del frame
+        # Keep only the raw-buffer part. Both kinds of source must be watched.
+        received.pop()
+        original.wait(2)
+        assert not tracker.done
+        received.clear()
+        tracker.wait(2)
+        data.extend(b"released")
+
+
+@pytest.mark.parametrize("multipart", [False, True])
+@pytest.mark.parametrize("size", [128, 1024])
+def test_tcp_tracker_allows_buffer_reuse_across_processes(multipart, size):
+    code = """
+import sys
+import pyomq as zmq
+multipart = sys.argv[2] == "True"
+size = int(sys.argv[3])
+with zmq.Context() as ctx, ctx.socket(zmq.PULL) as pull:
+    pull.rcvtimeo = 3000
+    pull.connect(sys.argv[1])
+    for index in range(16):
+        expected = bytes([index]) * size
+        if multipart:
+            assert pull.recv_multipart() == [expected, expected]
+        else:
+            assert pull.recv() == expected
+"""
+    with zmq.Context() as ctx, ctx.socket(zmq.PUSH) as push:
+        push.linger = 0
+        push.sndtimeo = 3000
+        push.bind("tcp://127.0.0.1:0")
+        endpoint = push.last_endpoint
+        assert endpoint is not None
+        receiver = subprocess.Popen(
+            [sys.executable, "-c", code, endpoint.decode(), str(multipart), str(size)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            data = bytearray(size)
+            for index in range(16):
+                data[:] = bytes([index]) * len(data)
+                tracker = (
+                    push.send_multipart([data, data], copy=False, track=True)
+                    if multipart
+                    else push.send(data, copy=False, track=True)
+                )
+                assert tracker is not None
+                tracker.wait(3)
+                # Completion must release every export, not just allow reads.
+                data.append(0)
+                data.pop()
+            stdout, stderr = receiver.communicate(timeout=5)
+            assert receiver.returncode == 0, stdout + stderr
+        finally:
+            if receiver.poll() is None:
+                receiver.kill()
+                receiver.wait()
+
+
+@pytest.mark.parametrize("copy", [True, False])
+def test_multibyte_buffers(copy):
+    data = array("I", [1, 2, 3])
+    assert bytes(zmq.Frame(data, copy=copy)) == data.tobytes()
+    with pytest.raises(BufferError):
+        zmq.Frame(memoryview(b"abcdef")[::2], copy=copy)
+
+
+@pytest.mark.parametrize("retained_index", [0, 1])
+def test_multipart_tracker_waits_for_every_inproc_part(retained_index):
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        pull.bind("inproc://tracked-multipart")
+        push.connect("inproc://tracked-multipart")
+        tracker = push.send_multipart(
+            (bytearray(100_000) for _ in range(2)), copy=False, track=True
+        )
+        assert tracker is not None
+        frames = pull.recv_multipart(copy=False, track=True)
+        assert all(f.tracker is not None and f.tracker.done for f in frames)
+        retained = frames.pop(retained_index)
+        frames.clear()
+        assert not tracker.done
+        del retained
+        gc.collect()
+        tracker.wait(2)
+
+
+def test_copied_send_and_tracked_frame_contract():
+    with (
+        zmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        pull.bind("inproc://tracker-copy")
+        push.connect("inproc://tracker-copy")
+        assert push.send(bytearray(b"copy"), copy=True, track=True) is None
+        assert pull.recv() == b"copy"
+        with pytest.raises(ValueError):
+            push.send(zmq.Frame(b"untracked"), track=True)
+        frame = zmq.Frame(b"tracked", copy=True, track=True)
+        assert push.send(frame) is frame.tracker
+        assert pull.recv() == b"tracked"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shadow", [False, True])
+async def test_async_and_shadow_send_results(shadow):
+    with (
+        azmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        pull.bind("inproc://tracker-async")
+        push.connect("inproc://tracker-async")
+        if shadow:
+            result = zmq.Socket.shadow(push).send_multipart(
+                (part for part in [b"a", b"b"]), copy=False, track=True
+            )
+        else:
+            result = await push.send_multipart(
+                (part for part in [b"a", b"b"]), copy=False, track=True
+            )
+        assert isinstance(result, zmq.MessageTracker)
+        assert await pull.recv_multipart() == [b"a", b"b"]
+        result.wait(2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sndmore", [False, True])
+async def test_generator_survives_native_backpressure(sndmore):
+    with (
+        azmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        push.sndhwm = 1
+        push.bind("inproc://generator-retry")
+        await _fill_send_ring(push)
+        iterations = []
+
+        def parts():
+            for value in (b"first", b"last"):
+                iterations.append(value)
+                yield value
+
+        if sndmore:
+            await push.send(b"first", zmq.SNDMORE)
+            sent = asyncio.ensure_future(push.send(b"last"))
+        else:
+            sent = asyncio.ensure_future(push.send_multipart(parts()))
+        pull.connect("inproc://generator-retry")
+        while True:
+            received = await asyncio.wait_for(pull.recv_multipart(), 3)
+            if received != [b"fill"]:
+                break
+        assert received == [b"first", b"last"]
+        assert await asyncio.wait_for(sent, 3) is None
+        assert iterations == ([] if sndmore else [b"first", b"last"])
+
+
+@pytest.mark.parametrize("async_socket", [False, True])
+def test_close_releases_incomplete_multipart(async_socket):
+    context = azmq.Context if async_socket else zmq.Context
+    with context() as ctx:
+        socket = ctx.socket(zmq.PUSH)
+        data = bytearray(100_000)
+        result: Any = socket.send(data, zmq.SNDMORE, copy=False, track=True)
+        tracker = result.result() if async_socket else result
+        assert isinstance(tracker, zmq.MessageTracker)
+        assert not tracker.done
+        socket.close(0)
+        tracker.wait(2)
+        data.extend(b"released")
+
+
+def test_close_releases_unreceived_multipart_tail():
+    with zmq.Context() as ctx, ctx.socket(zmq.PUSH) as push:
+        pull = ctx.socket(zmq.PULL)
+        pull.bind("inproc://tracked-tail")
+        push.connect("inproc://tracked-tail")
+        data = bytearray(100_000)
+        tracker = push.send_multipart([b"header", data], copy=False, track=True)
+        assert tracker is not None
+        assert pull.recv() == b"header"
+        assert not tracker.done
+        pull.close(0)
+        tracker.wait(2)
+        data.extend(b"released")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_pending_send_releases_export_on_cancel_or_close(cancel):
+    with azmq.Context() as ctx, ctx.socket(zmq.PUSH) as push:
+        push.sndhwm = 1
+        push.bind("inproc://pending-release")
+        await _fill_send_ring(push)
+        data = bytearray(100_000)
+        pending = push.send_multipart((part for part in [data]), copy=False, track=True)
+        task = asyncio.ensure_future(pending)
+        await asyncio.sleep(0)
+        assert not task.done()
+        with pytest.raises(BufferError):
+            data.extend(b"still borrowed")
+        if cancel:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            push.close(0)
+            with pytest.raises(zmq.ZMQError):
+                await asyncio.wait_for(task, 2)
+        # Keep the awaitable/task alive: cancellation and close must release
+        # the exporter without relying on their garbage collection.
+        data.extend(b"released")
+        assert pending.done()
+
+
+def test_wait_releases_gil_and_uses_one_deadline():
+    data = bytearray(100_000)
+    frames = [zmq.Frame(data, copy=False, track=True)]
+    tracker = zmq.MessageTracker(frames[0])
+
+    def release():
+        time.sleep(0.02)
+        frames.clear()
+
+    thread = threading.Thread(target=release)
+    thread.start()
+    try:
+        tracker.wait(2)
+    finally:
+        thread.join(2)
+    data.extend(b"released")
+    first, last = threading.Event(), threading.Event()
+    timer = threading.Timer(0.03, first.set)
+    timer.start()
+    try:
+        start = time.monotonic()
+        with pytest.raises(zmq.NotDone):
+            zmq.MessageTracker(first, last).wait(0.05)
+        # Broad upper bound tolerates scheduler noise; tests never assert an
+        # exact wall-clock interval.
+        assert time.monotonic() - start >= 0.045
+    finally:
+        timer.join()
+
+
+@pytest.mark.asyncio
+async def test_close_releases_all_pending_exports_after_registry_growth():
+    with azmq.Context() as ctx, ctx.socket(zmq.PUSH) as socket:
+        socket.sndhwm = 1
+        socket.bind("inproc://pending-registry")
+        await _fill_send_ring(socket)
+        buffers = [bytearray(100_000) for _ in range(64)]
+        pending = [socket.send(data, copy=False, track=True) for data in buffers]
+        assert all(not future.done() for future in pending)
+        socket.close(0)
+        # Keep every awaitable alive: closing must visit all registry entries.
+        for data in buffers:
+            data.extend(b"released")
+        assert all(future.done() for future in pending)
+
+
+def test_failed_multipart_conversion_releases_previous_exports():
+    with zmq.Context() as ctx, ctx.socket(zmq.PUSH) as push:
+        data = bytearray(100_000)
+        with pytest.raises(TypeError):
+            push.send_multipart(cast(Any, [data, "invalid"]), copy=False, track=True)
+        data.extend(b"released")
+
+
+class BytesOnly:
+    def __bytes__(self):
+        return b"not a buffer"
+
+
+@pytest.mark.parametrize("value", ["text", BytesOnly()])
+@pytest.mark.parametrize("kind", ["sync", "async", "shadow"])
+def test_send_rejects_non_buffers(value, kind):
+    context = zmq.Context if kind == "sync" else azmq.Context
+    with context() as ctx, ctx.socket(zmq.PUSH) as original:
+        socket = zmq.Socket.shadow(original) if kind == "shadow" else original
+        with pytest.raises(TypeError):
+            socket.send(value)
+        with pytest.raises(TypeError):
+            socket.send_multipart([value])
+
+
+def test_close_allows_reentrant_python_buffer_release():
+    # A Python 3.12 buffer exporter can execute user code on release. Keep a
+    # deadlock regression isolated so pytest can terminate it deterministically.
+    code = """
+import pyomq as zmq
+released = []
+with zmq.Context() as ctx:
+    socket = ctx.socket(zmq.PUSH)
+    class Exporter:
+        def __buffer__(self, flags):
+            return memoryview(bytearray(100_000))
+        def __release_buffer__(self, view):
+            try:
+                socket.send(b"closed")
+            except zmq.ZMQError:
+                released.append(True)
+    tracker = socket.send(Exporter(), zmq.SNDMORE, copy=False, track=True)
+    socket.close(0)
+    tracker.wait(2)
+    assert released == [True]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_shadow_retry_keeps_one_shot_parts():
+    with (
+        azmq.Context() as ctx,
+        ctx.socket(zmq.PUSH) as push,
+        ctx.socket(zmq.PULL) as pull,
+    ):
+        push.sndhwm = 1
+        push.bind("inproc://shadow-retry")
+        await _fill_send_ring(push)
+        shadow = zmq.Socket.shadow(push)
+        parts = iter([b"first", bytearray(100_000)])
+        blocked = threading.Event()
+
+        def submit():
+            try:
+                return push._sock.send_multipart(parts, copy=False, track=True)
+            except zmq._native.ZMQError as exc:
+                assert exc.errno == zmq.EAGAIN
+                blocked.set()
+                raise
+
+        # Exercise the actual blocking retry path; observe its first native
+        # EAGAIN before allowing a receiver to drain the backpressured socket.
+        task = asyncio.create_task(asyncio.to_thread(shadow._blocking_send, submit))
+        try:
+            assert await asyncio.to_thread(blocked.wait, 3)
+            pull.connect("inproc://shadow-retry")
+            while True:
+                received = await asyncio.wait_for(pull.recv_multipart(), 3)
+                if received != [b"fill"]:
+                    break
+            assert received == [b"first", bytes(100_000)]
+            tracker = await asyncio.wait_for(task, 3)
+            assert tracker is not None
+            tracker.wait(2)
+        finally:
+            push.close(0)
+            await asyncio.gather(task, return_exceptions=True)
+
+
+def test_cancellation_allows_reentrant_python_buffer_release():
+    code = """
+import asyncio
+import runpy
+import sys
+import pyomq as zmq
+import pyomq.asyncio as azmq
+fill = runpy.run_path(sys.argv[1])["_fill_send_ring"]
+async def run():
+    with azmq.Context() as ctx, ctx.socket(zmq.PUSH) as socket:
+        socket.sndhwm = 1
+        socket.bind("inproc://release-cancel")
+        await fill(socket)
+        released = []
+        class Exporter:
+            def __buffer__(self, flags):
+                return memoryview(bytearray(100_000))
+            def __release_buffer__(self, view):
+                socket.close(0)
+                released.append(True)
+        pending = socket.send(Exporter(), copy=False, track=True)
+        task = asyncio.ensure_future(pending)
+        await asyncio.sleep(0)
+        assert not task.done()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert released == [True]
+        assert socket.closed
+asyncio.run(run())
+"""
+    subprocess.run([sys.executable, "-c", code, __file__], check=True, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_future_marks_cancelled_before_cleanup():
+    states = []
+    future = None
+    waiter = None
+
+    def cleanup():
+        assert future is not None
+        assert waiter is not None
+        states.append(future.cancelled())
+        waiter.fail(RuntimeError("reentrant close"))
+
+    future = azmq._CleanupFuture(
+        loop=asyncio.get_running_loop(),
+        cleanup=cleanup,
+    )
+    waiter = azmq._WindowsWaiter(future, lambda: None, cleanup)
+    future.set_cleanup(waiter.release)
+    assert future.cancel()
+    assert states == [True]

--- a/bindings/pyomq/tests/test_typing_contract.py
+++ b/bindings/pyomq/tests/test_typing_contract.py
@@ -1,0 +1,83 @@
+"""Check public types as a consumer, including deliberately invalid calls."""
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "typing"
+INVALID = """\
+import pyomq as zmq
+import pyomq.asyncio as azmq
+
+class BytesOnly:
+    def __bytes__(self) -> bytes:
+        return b"x"
+
+def invalid(sync: zmq.Socket, async_: azmq.Socket) -> None:
+    sync.send("text")  # reject
+    sync.send(BytesOnly())  # reject
+    async_.send("text")  # reject
+    sync.send_multipart(["text"])  # reject
+    async_.send_multipart([BytesOnly()])  # reject
+    sync.identity = 42  # reject
+    sync.linger = b"bytes"  # reject
+    sync.set_plain_auth([("user", 1)])  # reject
+    sync.set_curve_auth(["not bytes"])  # reject
+    zmq.Frame("text")  # reject
+    zmq.Socket.shadow(async_).send("text")  # reject
+    sync.recv_serialized(lambda parts: len(parts), copy="no")  # reject
+"""
+
+
+def run_checker(checker, paths):
+    if importlib.util.find_spec(checker) is None:
+        pytest.skip(f"install the type-check dependency group for {checker}")
+    arguments = {
+        "ty": ["check", "--output-format", "concise"],
+        "mypy": ["--show-column-numbers"],
+        "pyright": ["--pythonpath", sys.executable],
+    }
+    return subprocess.run(
+        [sys.executable, "-m", checker, *arguments[checker], *map(str, paths)],
+        capture_output=True,
+        text=True,
+        timeout=40,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("checker", ["ty", "mypy", "pyright"])
+def test_consumer_contract(checker):
+    paths = [FIXTURES / "consumer.py"]
+    if checker != "ty":
+        paths.append(FIXTURES / "narrowing.py")
+    result = run_checker(checker, paths)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("checker", ["ty", "mypy", "pyright"])
+def test_invalid_calls_are_rejected(checker, tmp_path):
+    path = tmp_path / "invalid.py"
+    path.write_text(INVALID)
+    result = run_checker(checker, [path])
+    assert result.returncode != 0, "invalid calls unexpectedly accepted"
+    diagnostics = result.stdout + result.stderr
+    for number, line in enumerate(INVALID.splitlines(), 1):
+        if "# reject" in line:
+            assert re.search(rf"invalid\.py:{number}:\d+", diagnostics), diagnostics
+
+
+def test_native_stub_matches_runtime():
+    pytest.importorskip("mypy.stubtest")
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy.stubtest", "pyomq._native"],
+        capture_output=True,
+        text=True,
+        timeout=40,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/bindings/pyomq/tests/test_wheel_contract.py
+++ b/bindings/pyomq/tests/test_wheel_contract.py
@@ -1,0 +1,18 @@
+"""Installed package must carry the native stubs and Python 3.12 ABI contract."""
+
+from importlib.metadata import distribution
+from pathlib import Path
+
+import pyomq
+
+
+def test_installed_typing_files_and_python_floor():
+    package = Path(pyomq.__file__).parent
+    assert (package / "py.typed").is_file()
+    assert (package / "_native.pyi").is_file()
+    metadata = distribution("pyomq")
+    assert metadata.requires is None
+    assert metadata.metadata["Requires-Python"] == ">=3.12"
+    wheel = metadata.read_text("WHEEL")
+    assert wheel is not None
+    assert "Tag: cp312-abi3-" in wheel

--- a/bindings/pyomq/tests/test_zmqstream.py
+++ b/bindings/pyomq/tests/test_zmqstream.py
@@ -16,7 +16,8 @@ def test_zmqstream_on_recv_callback(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         stream = ZMQStream(pull)
@@ -41,7 +42,8 @@ def test_zmqstream_stop_on_recv(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         stream = ZMQStream(pull)
@@ -66,7 +68,8 @@ def test_zmqstream_send_forwards(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         stream = ZMQStream(push)
@@ -86,7 +89,8 @@ def test_zmqstream_send_multipart_forwards(tcp_endpoint):
     push = ctx.socket(zmq.PUSH)
     pull = ctx.socket(zmq.PULL)
     try:
-        ep = pull.bind(tcp_endpoint)
+        pull.bind(tcp_endpoint)
+        ep = pull.last_endpoint
         push.connect(ep)
 
         stream = ZMQStream(push)

--- a/bindings/pyomq/tests/typing/consumer.py
+++ b/bindings/pyomq/tests/typing/consumer.py
@@ -1,0 +1,181 @@
+"""Consumer contracts, checked against the installed package by three checkers."""
+
+import asyncio
+from array import array
+from collections.abc import Buffer, Iterable
+from typing import assert_type
+
+import pyomq as zmq
+import pyomq.asyncio as azmq
+from pyomq import FutureResult
+
+
+class SyncSocket(zmq.Socket):
+    pass
+
+
+class AsyncSocket(azmq.Socket):
+    pass
+
+
+class SyncContext(zmq.Context):
+    pass
+
+
+class AsyncContext(azmq.Context):
+    pass
+
+
+def decode(parts: list[bytes]) -> int:
+    return len(parts)
+
+
+def decode_frames(parts: list[zmq.Frame]) -> str:
+    return str(len(parts))
+
+
+def decode_dynamic(parts: list[bytes] | list[zmq.Frame]) -> float:
+    return float(len(parts))
+
+
+def encode(value: int) -> Iterable[zmq.Sendable]:
+    yield str(value).encode()
+
+
+def sync_api(copy: bool, option: int, buffer: Buffer) -> None:
+    ctx = zmq.Context()
+    sock = ctx.socket(zmq.PAIR)
+    assert_type(sock, zmq.Socket)
+    assert_type(ctx.socket(zmq.PAIR, SyncSocket), SyncSocket)
+    assert_type(zmq.Context(shadow=ctx), zmq.Context)
+    assert_type(SyncContext.instance(), SyncContext)
+    assert_type(SyncContext.from_share_key(1), SyncContext)
+    with SyncContext() as subclass:
+        assert_type(subclass, SyncContext)
+    with ctx.socket(zmq.PAIR, SyncSocket) as sub_socket:
+        assert_type(sub_socket, SyncSocket)
+        assert_type(sub_socket.underlying, SyncSocket)
+        assert_type(zmq.Socket.shadow(sub_socket), SyncSocket)
+    assert_type(sock.context, zmq.Context)
+    with sock.bind(b"inproc://typed") as bound:
+        assert_type(bound, zmq.Socket)
+    with sock.connect(b"inproc://typed") as connected:
+        assert_type(connected, zmq.Socket)
+    assert_type(sock.last_endpoint, bytes)
+    assert_type(sock.recv(), bytes)
+    assert_type(sock.recv(copy=False), zmq.Frame)
+    assert_type(sock.recv(0, False), zmq.Frame)
+    assert_type(sock.recv(copy=copy), bytes | zmq.Frame)
+    assert_type(sock.recv_multipart(), list[bytes])
+    assert_type(sock.recv_multipart(copy=False), list[zmq.Frame])
+    assert_type(sock.recv_multipart(0, False), list[zmq.Frame])
+    assert_type(sock.recv_multipart(copy=copy), list[bytes] | list[zmq.Frame])
+    assert_type(sock.recv_serialized(decode), int)
+    assert_type(sock.recv_serialized(decode_frames, copy=False), str)
+    assert_type(sock.recv_serialized(decode_frames, 0, False), str)
+    assert_type(sock.recv_serialized(decode_dynamic, copy=copy), float)
+    assert_type(sock.send_serialized(42, encode), zmq.MessageTracker | None)
+    for data in [
+        buffer,
+        b"bytes",
+        bytearray(),
+        memoryview(b""),
+        array("I"),
+        zmq.Frame(),
+    ]:
+        assert_type(sock.send(data), zmq.MessageTracker | None)
+    parts: list[zmq.Sendable] = [b"one", memoryview(b"two")]
+    sock.send_multipart(part for part in parts)
+    frame = zmq.Frame(buffer, copy=False, track=True)
+    memoryview(frame)
+    bytes(frame)
+    assert_type(frame.tracker, zmq.MessageTracker | None)
+    if frame.tracker is not None:
+        assert_type(frame.tracker.done, bool)
+        assert_type(frame.tracker.wait(0.1), None)
+    assert_type(sock.linger, int)
+    assert_type(sock.identity, bytes)
+    sock.linger = 0
+    sock.identity = b"id"
+    assert_type(sock.getsockopt(zmq.LINGER), int)
+    assert_type(sock.getsockopt(zmq.IDENTITY), bytes)
+    assert_type(sock.getsockopt(zmq.LAST_ENDPOINT), bytes)
+    assert_type(sock.getsockopt(option), int | bytes | None)
+    assert_type(sock.get(zmq.TYPE), int)
+    assert_type(sock.getsockopt_string(zmq.IDENTITY), str)
+    sock.set_plain_auth(pair for pair in [("user", "password")])
+    sock.set_curve_auth(key for key in [b"key"])
+    sock.set_curve_auth(lambda peer: peer.public_key == b"key")
+    sock.set_plain_auth(lambda peer: peer.username == "user")
+    assert_type(sock.connections(), list[zmq.ConnectionInfo])
+    assert_type(sock.connection_info(1), zmq.ConnectionInfo | None)
+    event = sock.monitor().recv()
+    assert_type(event, zmq.MonitorEvent)
+    poller = zmq.Poller()
+    poller.register(sock)
+    assert_type(poller.poll(), list[tuple[zmq.Socket, int]])
+    assert_type(
+        zmq.select([sock], [], []),
+        tuple[list[zmq.Socket], list[zmq.Socket], list[zmq.Socket]],
+    )
+    assert_type(zmq.ZMQError(zmq.EAGAIN).errno, int | None)
+    assert_type(zmq.ZMQError("message").strerror, str)
+    assert_type(zmq.Again().errno, int | None)
+
+
+async def async_api(copy: bool) -> None:
+    ctx = azmq.Context()
+    sock = ctx.socket(zmq.PAIR)
+    assert_type(sock, azmq.Socket)
+    assert_type(sock.context, azmq.Context)
+    assert_type(ctx.socket(zmq.PAIR, AsyncSocket), AsyncSocket)
+    assert_type(azmq.Context(shadow=ctx), azmq.Context)
+    assert_type(AsyncContext.instance(), AsyncContext)
+    assert_type(AsyncContext.shadow(ctx), AsyncContext)
+    assert_type(AsyncContext.from_share_key(1), AsyncContext)
+    async with ctx.socket(zmq.PAIR, AsyncSocket) as sub_socket:
+        assert_type(sub_socket, AsyncSocket)
+        assert_type(sub_socket.underlying, AsyncSocket)
+    sent = sock.send(b"x")
+    assert_type(sent, FutureResult[zmq.MessageTracker | None])
+    assert_type(await sent, zmq.MessageTracker | None)
+    assert_type(sent.result(), zmq.MessageTracker | None)
+    assert_type(sent.done(), bool)
+    assert_type(sock.recv().result(), bytes)
+    assert_type(await sock.recv(), bytes)
+    assert_type(await sock.recv(copy=False), zmq.Frame)
+    assert_type(await sock.recv(0, False), zmq.Frame)
+    assert_type(await sock.recv(copy=copy), bytes | zmq.Frame)
+    assert_type(await sock.recv_multipart(), list[bytes])
+    assert_type(await sock.recv_multipart(copy=False), list[zmq.Frame])
+    assert_type(await sock.recv_multipart(0, False), list[zmq.Frame])
+    assert_type(await sock.recv_multipart(copy=copy), list[bytes] | list[zmq.Frame])
+    assert_type(await sock.recv_serialized(decode), int)
+    assert_type(asyncio.create_task(sock.recv_serialized(decode)), asyncio.Task[int])
+    assert_type(await sock.recv_serialized(decode_frames, copy=False), str)
+    assert_type(await sock.recv_serialized(decode_frames, 0, False), str)
+    assert_type(await sock.recv_serialized(decode_dynamic, copy=copy), float)
+    assert_type(await sock.send_serialized(42, encode), zmq.MessageTracker | None)
+    shadow = zmq.Socket.shadow(sock)
+    assert_type(shadow.recv(), bytes)
+    assert_type(shadow.recv(copy=False), zmq.Frame)
+    assert_type(shadow.recv_multipart(copy=copy), list[bytes] | list[zmq.Frame])
+    assert_type(shadow.send(b"x"), zmq.MessageTracker | None)
+    assert_type(shadow.getsockopt(zmq.LINGER), int)
+    assert_type(shadow.identity, bytes)
+    poller = azmq.Poller()
+    poller.register(sock)
+    assert_type(await poller.poll(), list[tuple[azmq.Socket, int]])
+
+
+def stream_api(sock: zmq.Socket, copy: bool) -> None:
+    stream = zmq.ZMQStream(sock)
+    stream.on_recv(decode)
+    stream.on_recv(decode_frames, copy=False)
+    stream.on_recv(decode_dynamic, copy=copy)
+    assert_type(stream.send(b"x"), zmq.MessageTracker | None)
+    stream.send_multipart((part for part in [b"x"]), callback=sent)
+
+
+def sent(parts: list[zmq.Sendable], tracker: zmq.MessageTracker | None) -> None:
+    pass

--- a/bindings/pyomq/tests/typing/narrowing.py
+++ b/bindings/pyomq/tests/typing/narrowing.py
@@ -1,0 +1,12 @@
+"""Tagged monitor unions. ty 0.0.63 does not narrow TypedDict tags yet."""
+
+from typing import assert_type
+
+from pyomq import MonitorEvent
+
+
+def narrow_event(event: MonitorEvent) -> None:
+    if event["event"] == "handshake_failed":
+        assert_type(event["reason"], str)
+    if event["event"] == "lagged":
+        assert_type(event["count"], int)


### PR DESCRIPTION
- Raise the pyomq minimum Python version to 3.12 and align public socket signatures, scopes, routing IDs, tracking, shadow sockets, and type stubs with pyzmq.
- Add `recv_into`, pyzmq-compatible bind/connect scope managers, and current endpoint access through `last_endpoint`.
- Expose RADIO/DISH groups as `group=` and `Frame.group` across sync, asyncio, and shadow sockets; remove the raw `[group, body]` Python API.
- Expand sync and asyncio compatibility coverage, including all bundled zguide examples.